### PR TITLE
feat: add elx-button component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "claw-ui",
+  "name": "elementix",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claw-ui",
+      "name": "elementix",
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
@@ -13,10 +13,63 @@
         "@storybook/addon-links": "^8.0.0",
         "@storybook/web-components": "^8.0.0",
         "@storybook/web-components-vite": "^8.0.0",
+        "jsdom": "^29.0.2",
+        "lit": "^3.3.2",
         "typescript": "^5.4.0",
         "vite": "^5.2.0",
         "vitest": "^1.5.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
@@ -26,6 +79,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -496,6 +702,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -521,8 +745,7 @@
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
@@ -530,7 +753,6 @@
       "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
@@ -1452,8 +1674,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -1630,6 +1851,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/browser-assert": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
@@ -1753,6 +1984,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1760,6 +2005,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1778,6 +2037,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -1856,6 +2122,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -2191,6 +2470,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2278,6 +2570,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -2368,13 +2667,53 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lit": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
       "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -2387,7 +2726,6 @@
       "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
@@ -2400,7 +2738,6 @@
       "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -2432,6 +2769,16 @@
         "get-func-name": "^2.0.1"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2459,6 +2806,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memoizerific": {
       "version": "1.11.3",
@@ -2616,6 +2970,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2748,6 +3115,16 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -2794,6 +3171,16 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -2858,6 +3245,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3032,6 +3432,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -3064,6 +3471,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-dedent": {
@@ -3114,6 +3567,16 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/unplugin": {
       "version": "1.16.1",
@@ -3737,12 +4200,60 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -3822,6 +4333,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
-  "keywords": ["web-components", "design-system", "ui"],
+  "keywords": [
+    "web-components",
+    "design-system",
+    "ui"
+  ],
   "author": "clawdiab",
   "license": "MIT",
   "devDependencies": {
@@ -23,6 +27,8 @@
     "@storybook/addon-links": "^8.0.0",
     "@storybook/web-components": "^8.0.0",
     "@storybook/web-components-vite": "^8.0.0",
+    "jsdom": "^29.0.2",
+    "lit": "^3.3.2",
     "typescript": "^5.4.0",
     "vite": "^5.2.0",
     "vitest": "^1.5.0"

--- a/src/components/button/button.stories.ts
+++ b/src/components/button/button.stories.ts
@@ -1,0 +1,48 @@
+import { html } from 'lit';
+import './button';
+
+export default {
+  title: 'Components/Button',
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'danger', 'ghost']
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg']
+    },
+    disabled: { control: 'boolean' },
+    label: { control: 'text' }
+  }
+};
+
+const Template = ({ variant, size, disabled, label }: any) => html`
+  <elx-button
+    variant=${variant}
+    size=${size}
+    ?disabled=${disabled}
+  >${label}</elx-button>
+`;
+
+export const Primary = Template.bind({});
+(Primary as any).args = { variant: 'primary', size: 'md', disabled: false, label: 'Button' };
+
+export const Secondary = Template.bind({});
+(Secondary as any).args = { variant: 'secondary', size: 'md', disabled: false, label: 'Button' };
+
+export const Danger = Template.bind({});
+(Danger as any).args = { variant: 'danger', size: 'md', disabled: false, label: 'Delete' };
+
+export const Ghost = Template.bind({});
+(Ghost as any).args = { variant: 'ghost', size: 'md', disabled: false, label: 'Cancel' };
+
+export const Small = Template.bind({});
+(Small as any).args = { variant: 'primary', size: 'sm', disabled: false, label: 'Small' };
+
+export const Large = Template.bind({});
+(Large as any).args = { variant: 'primary', size: 'lg', disabled: false, label: 'Large' };
+
+export const Disabled = Template.bind({});
+(Disabled as any).args = { variant: 'primary', size: 'md', disabled: true, label: 'Disabled' };

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import './button';
+
+describe('elx-button', () => {
+  beforeAll(() => {
+    // Ensure custom element is registered
+    expect(customElements.get('elx-button')).toBeDefined();
+  });
+
+  it('renders with default props', async () => {
+    const el = document.createElement('elx-button');
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot!.querySelector('button');
+    expect(button).toBeTruthy();
+    expect(button!.classList.contains('primary')).toBe(true);
+    expect(button!.classList.contains('md')).toBe(true);
+
+    el.remove();
+  });
+
+  it('renders slot content', async () => {
+    const el = document.createElement('elx-button');
+    el.textContent = 'Click me';
+    document.body.appendChild(el);
+
+    const slot = el.shadowRoot!.querySelector('slot');
+    expect(slot).toBeTruthy();
+
+    el.remove();
+  });
+
+  it('applies variant attribute', async () => {
+    const el = document.createElement('elx-button');
+    el.setAttribute('variant', 'danger');
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot!.querySelector('button');
+    expect(button!.classList.contains('danger')).toBe(true);
+
+    el.remove();
+  });
+
+  it('applies size attribute', async () => {
+    const el = document.createElement('elx-button');
+    el.setAttribute('size', 'lg');
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot!.querySelector('button');
+    expect(button!.classList.contains('lg')).toBe(true);
+
+    el.remove();
+  });
+
+  it('handles disabled state', async () => {
+    const el = document.createElement('elx-button');
+    el.setAttribute('disabled', '');
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot!.querySelector('button');
+    expect(button!.disabled).toBe(true);
+    expect(button!.getAttribute('aria-disabled')).toBe('true');
+
+    el.remove();
+  });
+
+  it('updates when attributes change', async () => {
+    const el = document.createElement('elx-button');
+    document.body.appendChild(el);
+
+    let button = el.shadowRoot!.querySelector('button');
+    expect(button!.classList.contains('primary')).toBe(true);
+
+    el.setAttribute('variant', 'secondary');
+    button = el.shadowRoot!.querySelector('button');
+    expect(button!.classList.contains('secondary')).toBe(true);
+
+    el.remove();
+  });
+});

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import './button';
 
 describe('elx-button', () => {
   beforeAll(() => {
-    // Ensure custom element is registered
     expect(customElements.get('elx-button')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 
   it('renders with default props', async () => {
@@ -15,8 +18,6 @@ describe('elx-button', () => {
     expect(button).toBeTruthy();
     expect(button!.classList.contains('primary')).toBe(true);
     expect(button!.classList.contains('md')).toBe(true);
-
-    el.remove();
   });
 
   it('renders slot content', async () => {
@@ -26,8 +27,6 @@ describe('elx-button', () => {
 
     const slot = el.shadowRoot!.querySelector('slot');
     expect(slot).toBeTruthy();
-
-    el.remove();
   });
 
   it('applies variant attribute', async () => {
@@ -37,8 +36,6 @@ describe('elx-button', () => {
 
     const button = el.shadowRoot!.querySelector('button');
     expect(button!.classList.contains('danger')).toBe(true);
-
-    el.remove();
   });
 
   it('applies size attribute', async () => {
@@ -48,8 +45,6 @@ describe('elx-button', () => {
 
     const button = el.shadowRoot!.querySelector('button');
     expect(button!.classList.contains('lg')).toBe(true);
-
-    el.remove();
   });
 
   it('handles disabled state', async () => {
@@ -60,8 +55,6 @@ describe('elx-button', () => {
     const button = el.shadowRoot!.querySelector('button');
     expect(button!.disabled).toBe(true);
     expect(button!.getAttribute('aria-disabled')).toBe('true');
-
-    el.remove();
   });
 
   it('updates when attributes change', async () => {
@@ -74,7 +67,58 @@ describe('elx-button', () => {
     el.setAttribute('variant', 'secondary');
     button = el.shadowRoot!.querySelector('button');
     expect(button!.classList.contains('secondary')).toBe(true);
+  });
 
-    el.remove();
+  // Security tests
+  it('ignores invalid variant values (XSS protection)', async () => {
+    const el = document.createElement('elx-button');
+    el.setAttribute('variant', '<script>alert(1)</script>');
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot!.querySelector('button');
+    // Should fall back to default 'primary' since value is invalid
+    expect(button!.classList.contains('primary')).toBe(true);
+    expect(button!.classList.contains('<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('ignores invalid size values', async () => {
+    const el = document.createElement('elx-button');
+    el.setAttribute('size', 'malicious-class');
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot!.querySelector('button');
+    expect(button!.classList.contains('md')).toBe(true);
+    expect(button!.classList.contains('malicious-class')).toBe(false);
+  });
+
+  // Form behavior test
+  it('has type="button" by default to prevent form submission', async () => {
+    const el = document.createElement('elx-button');
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot!.querySelector('button');
+    expect(button!.type).toBe('button');
+  });
+
+  // Focus-visible test
+  it('has focus-visible styles defined', async () => {
+    const el = document.createElement('elx-button');
+    document.body.appendChild(el);
+
+    const style = el.shadowRoot!.querySelector('style');
+    expect(style!.textContent).toContain(':focus-visible');
+  });
+
+  // DOM stability test
+  it('preserves button element across attribute changes', async () => {
+    const el = document.createElement('elx-button');
+    document.body.appendChild(el);
+
+    const button1 = el.shadowRoot!.querySelector('button');
+    el.setAttribute('variant', 'danger');
+    el.setAttribute('size', 'lg');
+
+    const button2 = el.shadowRoot!.querySelector('button');
+    expect(button1).toBe(button2); // Same reference, not recreated
   });
 });

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -1,8 +1,14 @@
+const VALID_VARIANTS = ['primary', 'secondary', 'danger', 'ghost'] as const;
+const VALID_SIZES = ['sm', 'md', 'lg'] as const;
+
+type Variant = typeof VALID_VARIANTS[number];
+type Size = typeof VALID_SIZES[number];
+
 export class ElxButton extends HTMLElement {
   static observedAttributes = ['variant', 'size', 'disabled'];
 
-  private _variant: string = 'primary';
-  private _size: string = 'md';
+  private _button: HTMLButtonElement | null = null;
+  private _slot: HTMLSlotElement | null = null;
 
   constructor() {
     super();
@@ -10,116 +16,100 @@ export class ElxButton extends HTMLElement {
   }
 
   connectedCallback() {
-    this.render();
+    this._buildDom();
+    this._update();
   }
 
   attributeChangedCallback() {
-    this.render();
+    this._update();
   }
 
-  get variant() {
-    return this.getAttribute('variant') || 'primary';
+  get variant(): Variant {
+    const val = this.getAttribute('variant');
+    return VALID_VARIANTS.includes(val as Variant) ? (val as Variant) : 'primary';
   }
 
   set variant(val: string) {
     this.setAttribute('variant', val);
   }
 
-  get size() {
-    return this.getAttribute('size') || 'md';
+  get size(): Size {
+    const val = this.getAttribute('size');
+    return VALID_SIZES.includes(val as Size) ? (val as Size) : 'md';
   }
 
   set size(val: string) {
     this.setAttribute('size', val);
   }
 
-  private render() {
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: inline-block;
+      }
+
+      button {
+        font-family: inherit;
+        cursor: pointer;
+        border: none;
+        border-radius: 6px;
+        font-weight: 500;
+        transition: background-color 0.15s ease, opacity 0.15s ease;
+        line-height: 1;
+      }
+
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      button:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
+
+      /* Sizes */
+      button.sm { padding: 6px 12px; font-size: 13px; }
+      button.md { padding: 8px 16px; font-size: 14px; }
+      button.lg { padding: 12px 24px; font-size: 16px; }
+
+      /* Variants */
+      button.primary { background: #2563eb; color: #fff; }
+      button.primary:hover:not(:disabled) { background: #1d4ed8; }
+
+      button.secondary { background: #e5e7eb; color: #1f2937; }
+      button.secondary:hover:not(:disabled) { background: #d1d5db; }
+
+      button.danger { background: #dc2626; color: #fff; }
+      button.danger:hover:not(:disabled) { background: #b91c1c; }
+
+      button.ghost { background: transparent; color: #2563eb; }
+      button.ghost:hover:not(:disabled) { background: #eff6ff; }
+    `;
+
+    this._button = document.createElement('button');
+    this._button.type = 'button';
+
+    this._slot = document.createElement('slot');
+    this._button.appendChild(this._slot);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(this._button);
+  }
+
+  private _update() {
+    if (!this._button) return;
+
     const disabled = this.hasAttribute('disabled');
 
-    this.shadowRoot!.innerHTML = `
-      <style>
-        :host {
-          display: inline-block;
-        }
-
-        button {
-          font-family: inherit;
-          cursor: pointer;
-          border: none;
-          border-radius: 6px;
-          font-weight: 500;
-          transition: background-color 0.15s ease, opacity 0.15s ease;
-          line-height: 1;
-        }
-
-        button:disabled {
-          opacity: 0.5;
-          cursor: not-allowed;
-        }
-
-        /* Sizes */
-        button.sm {
-          padding: 6px 12px;
-          font-size: 13px;
-        }
-
-        button.md {
-          padding: 8px 16px;
-          font-size: 14px;
-        }
-
-        button.lg {
-          padding: 12px 24px;
-          font-size: 16px;
-        }
-
-        /* Variants */
-        button.primary {
-          background: #2563eb;
-          color: #fff;
-        }
-
-        button.primary:hover:not(:disabled) {
-          background: #1d4ed8;
-        }
-
-        button.secondary {
-          background: #e5e7eb;
-          color: #1f2937;
-        }
-
-        button.secondary:hover:not(:disabled) {
-          background: #d1d5db;
-        }
-
-        button.danger {
-          background: #dc2626;
-          color: #fff;
-        }
-
-        button.danger:hover:not(:disabled) {
-          background: #b91c1c;
-        }
-
-        button.ghost {
-          background: transparent;
-          color: #2563eb;
-        }
-
-        button.ghost:hover:not(:disabled) {
-          background: #eff6ff;
-        }
-      </style>
-      <button
-        class="${this.variant} ${this.size}"
-        ${disabled ? 'disabled' : ''}
-        role="button"
-        aria-disabled="${disabled}"
-      >
-        <slot></slot>
-      </button>
-    `;
+    // Safe class update — only whitelisted values
+    this._button.className = `${this.variant} ${this.size}`;
+    this._button.disabled = disabled;
+    this._button.setAttribute('aria-disabled', String(disabled));
   }
 }
 
-customElements.define('elx-button', ElxButton);
+if (!customElements.get('elx-button')) {
+  customElements.define('elx-button', ElxButton);
+}

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -1,0 +1,125 @@
+export class ElxButton extends HTMLElement {
+  static observedAttributes = ['variant', 'size', 'disabled'];
+
+  private _variant: string = 'primary';
+  private _size: string = 'md';
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  attributeChangedCallback() {
+    this.render();
+  }
+
+  get variant() {
+    return this.getAttribute('variant') || 'primary';
+  }
+
+  set variant(val: string) {
+    this.setAttribute('variant', val);
+  }
+
+  get size() {
+    return this.getAttribute('size') || 'md';
+  }
+
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
+
+  private render() {
+    const disabled = this.hasAttribute('disabled');
+
+    this.shadowRoot!.innerHTML = `
+      <style>
+        :host {
+          display: inline-block;
+        }
+
+        button {
+          font-family: inherit;
+          cursor: pointer;
+          border: none;
+          border-radius: 6px;
+          font-weight: 500;
+          transition: background-color 0.15s ease, opacity 0.15s ease;
+          line-height: 1;
+        }
+
+        button:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+
+        /* Sizes */
+        button.sm {
+          padding: 6px 12px;
+          font-size: 13px;
+        }
+
+        button.md {
+          padding: 8px 16px;
+          font-size: 14px;
+        }
+
+        button.lg {
+          padding: 12px 24px;
+          font-size: 16px;
+        }
+
+        /* Variants */
+        button.primary {
+          background: #2563eb;
+          color: #fff;
+        }
+
+        button.primary:hover:not(:disabled) {
+          background: #1d4ed8;
+        }
+
+        button.secondary {
+          background: #e5e7eb;
+          color: #1f2937;
+        }
+
+        button.secondary:hover:not(:disabled) {
+          background: #d1d5db;
+        }
+
+        button.danger {
+          background: #dc2626;
+          color: #fff;
+        }
+
+        button.danger:hover:not(:disabled) {
+          background: #b91c1c;
+        }
+
+        button.ghost {
+          background: transparent;
+          color: #2563eb;
+        }
+
+        button.ghost:hover:not(:disabled) {
+          background: #eff6ff;
+        }
+      </style>
+      <button
+        class="${this.variant} ${this.size}"
+        ${disabled ? 'disabled' : ''}
+        role="button"
+        aria-disabled="${disabled}"
+      >
+        <slot></slot>
+      </button>
+    `;
+  }
+}
+
+customElements.define('elx-button', ElxButton);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 // Elementix - Web Components Design System
-// Components will be exported here as they are built
+export * from './components/button/button';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,10 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    browser: {
-      enabled: true,
-      name: 'chromium',
-      provider: 'playwright'
-    }
+    environment: 'jsdom',
+    globals: true
   }
 });


### PR DESCRIPTION
## Summary
- Adds `<elx-button>` web component
- 4 variants: primary, secondary, danger, ghost
- 3 sizes: sm, md, lg
- Disabled state with proper aria-disabled
- Shadow DOM with scoped styles
- Storybook stories with controls
- 6 passing tests

## Test Plan
- [x] Unit tests pass (`npm test`)
- [x] Renders with default props
- [x] Applies variant and size attributes
- [x] Handles disabled state
- [x] Updates on attribute changes