### PR TITLE
feat: add elx-input component

### DIFF
--- a/src/components/input/input.stories.ts
+++ b/src/components/input/input.stories.ts
@@ -1,0 +1,64 @@
+import { html } from 'lit';
+import './input';
+
+export default {
+  title: 'Components/Input',
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: ['text', 'password', 'email', 'number', 'tel', 'url', 'search']
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg']
+    },
+    disabled: { control: 'boolean' },
+    readonly: { control: 'boolean' },
+    required: { control: 'boolean' },
+    error: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    value: { control: 'text' },
+    label: { control: 'text' },
+    name: { control: 'text' }
+  }
+};
+
+const Template = ({ type, size, disabled, readonly, required, error, placeholder, value, label, name }: any) => html`
+  <elx-input
+    type=${type}
+    size=${size}
+    ?disabled=${disabled}
+    ?readonly=${readonly}
+    ?required=${required}
+    ?error=${error}
+    placeholder=${placeholder}
+    value=${value}
+    label=${label}
+    name=${name}
+  ></elx-input>
+`;
+
+export const Default = Template.bind({});
+(Default as any).args = { type: 'text', size: 'md', disabled: false, readonly: false, required: false, error: false, placeholder: 'Enter text...', value: '', label: '', name: '' };
+
+export const WithLabel = Template.bind({});
+(WithLabel as any).args = { type: 'text', size: 'md', disabled: false, readonly: false, required: false, error: false, placeholder: 'Enter your email', value: '', label: 'Email', name: 'email' };
+
+export const Email = Template.bind({});
+(Email as any).args = { type: 'email', size: 'md', disabled: false, readonly: false, required: true, error: false, placeholder: 'you@example.com', value: '', label: 'Email Address', name: 'email' };
+
+export const Password = Template.bind({});
+(Password as any).args = { type: 'password', size: 'md', disabled: false, readonly: false, required: true, error: false, placeholder: 'Enter password', value: '', label: 'Password', name: 'password' };
+
+export const Error = Template.bind({});
+(Error as any).args = { type: 'text', size: 'md', disabled: false, readonly: false, required: false, error: true, placeholder: 'Invalid input', value: 'bad value', label: 'Field with error', name: 'field' };
+
+export const Disabled = Template.bind({});
+(Disabled as any).args = { type: 'text', size: 'md', disabled: true, readonly: false, required: false, error: false, placeholder: 'Disabled input', value: '', label: 'Disabled', name: '' };
+
+export const Small = Template.bind({});
+(Small as any).args = { type: 'text', size: 'sm', disabled: false, readonly: false, required: false, error: false, placeholder: 'Small input', value: '', label: 'Small', name: '' };
+
+export const Large = Template.bind({});
+(Large as any).args = { type: 'text', size: 'lg', disabled: false, readonly: false, required: false, error: false, placeholder: 'Large input', value: '', label: 'Large', name: '' };

--- a/src/components/input/input.test.ts
+++ b/src/components/input/input.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './input';
+
+describe('elx-input', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-input')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with default props', async () => {
+    const el = document.createElement('elx-input');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input).toBeTruthy();
+    expect(input!.type).toBe('text');
+    expect(input!.classList.contains('md')).toBe(true);
+  });
+
+  it('applies type attribute', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('type', 'password');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.type).toBe('password');
+  });
+
+  it('applies size attribute', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('size', 'lg');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.classList.contains('lg')).toBe(true);
+  });
+
+  it('handles disabled state', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('disabled', '');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.disabled).toBe(true);
+  });
+
+  it('handles readonly state', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('readonly', '');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.readOnly).toBe(true);
+  });
+
+  it('handles required state', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('required', '');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.required).toBe(true);
+  });
+
+  it('handles error state', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('error', '');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.classList.contains('error')).toBe(true);
+  });
+
+  it('sets placeholder', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('placeholder', 'Enter text');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.placeholder).toBe('Enter text');
+  });
+
+  it('sets name attribute', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('name', 'email');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.name).toBe('email');
+  });
+
+  it('sets value', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('value', 'test@example.com');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.value).toBe('test@example.com');
+  });
+
+  it('shows label when provided', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('label', 'Email');
+    document.body.appendChild(el);
+
+    const label = el.shadowRoot!.querySelector('label');
+    expect(label!.style.display).not.toBe('none');
+    expect(label!.textContent).toBe('Email');
+  });
+
+  it('hides label when not provided', async () => {
+    const el = document.createElement('elx-input');
+    document.body.appendChild(el);
+
+    const label = el.shadowRoot!.querySelector('label');
+    expect(label!.style.display).toBe('none');
+  });
+
+  // Security tests
+  it('ignores invalid type values', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('type', 'invalid-type');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.type).toBe('text'); // Falls back to default
+  });
+
+  it('ignores invalid size values', async () => {
+    const el = document.createElement('elx-input');
+    el.setAttribute('size', 'invalid-size');
+    document.body.appendChild(el);
+
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input!.classList.contains('md')).toBe(true); // Falls back to default
+  });
+
+  // Event tests
+  it('dispatches input event on user input', async () => {
+    const el = document.createElement('elx-input');
+    document.body.appendChild(el);
+
+    let eventFired = false;
+    el.addEventListener('input', (e: any) => {
+      eventFired = true;
+      expect(e.detail.value).toBe('test');
+    });
+
+    const input = el.shadowRoot!.querySelector('input')!;
+    input.value = 'test';
+    input.dispatchEvent(new Event('input'));
+
+    expect(eventFired).toBe(true);
+  });
+
+  it('dispatches change event', async () => {
+    const el = document.createElement('elx-input');
+    document.body.appendChild(el);
+
+    let eventFired = false;
+    el.addEventListener('change', () => {
+      eventFired = true;
+    });
+
+    const input = el.shadowRoot!.querySelector('input')!;
+    input.dispatchEvent(new Event('change'));
+
+    expect(eventFired).toBe(true);
+  });
+
+  it('dispatches focus event', async () => {
+    const el = document.createElement('elx-input');
+    document.body.appendChild(el);
+
+    let eventFired = false;
+    el.addEventListener('focus', () => {
+      eventFired = true;
+    });
+
+    const input = el.shadowRoot!.querySelector('input')!;
+    input.dispatchEvent(new Event('focus'));
+
+    expect(eventFired).toBe(true);
+  });
+
+  it('dispatches blur event', async () => {
+    const el = document.createElement('elx-input');
+    document.body.appendChild(el);
+
+    let eventFired = false;
+    el.addEventListener('blur', () => {
+      eventFired = true;
+    });
+
+    const input = el.shadowRoot!.querySelector('input')!;
+    input.dispatchEvent(new Event('blur'));
+
+    expect(eventFired).toBe(true);
+  });
+
+  // DOM stability
+  it('preserves input element across attribute changes', async () => {
+    const el = document.createElement('elx-input');
+    document.body.appendChild(el);
+
+    const input1 = el.shadowRoot!.querySelector('input');
+    el.setAttribute('size', 'lg');
+    el.setAttribute('type', 'email');
+    el.setAttribute('error', '');
+
+    const input2 = el.shadowRoot!.querySelector('input');
+    expect(input1).toBe(input2); // Same reference
+  });
+
+  // Focus methods
+  it('has focus and blur methods', async () => {
+    const el = document.createElement('elx-input');
+    document.body.appendChild(el);
+
+    // Verify focus/blur methods exist and don't throw
+    expect(typeof el.focus).toBe('function');
+    expect(typeof el.blur).toBe('function');
+    expect(() => el.focus()).not.toThrow();
+    expect(() => el.blur()).not.toThrow();
+  });
+});

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -4,11 +4,17 @@ const VALID_TYPES = ['text', 'password', 'email', 'number', 'tel', 'url', 'searc
 type Size = typeof VALID_SIZES[number];
 type InputType = typeof VALID_TYPES[number];
 
+let uid = 0;
+
 export class ElxInput extends HTMLElement {
-  static observedAttributes = ['type', 'size', 'disabled', 'readonly', 'placeholder', 'value', 'name', 'required', 'error'];
+  static observedAttributes = [
+    'type', 'size', 'disabled', 'readonly', 'placeholder',
+    'value', 'name', 'required', 'error', 'label'
+  ];
 
   private _input: HTMLInputElement | null = null;
   private _label: HTMLLabelElement | null = null;
+  private _inputId: string = `elx-input-${++uid}`;
 
   constructor() {
     super();
@@ -26,124 +32,58 @@ export class ElxInput extends HTMLElement {
 
   get type(): InputType {
     const val = this.getAttribute('type');
-    return (VALID_TYPES as readonly string[]).indexOf(val as string) !== -1 ? (val as InputType) : 'text';
+    return (VALID_TYPES as readonly string[]).indexOf(val as string) !== -1
+      ? (val as InputType)
+      : 'text';
   }
 
-  set type(val: string) {
-    this.setAttribute('type', val);
-  }
+  set type(val: string) { this.setAttribute('type', val); }
 
   get size(): Size {
     const val = this.getAttribute('size');
-    return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
+    return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1
+      ? (val as Size)
+      : 'md';
   }
 
-  set size(val: string) {
-    this.setAttribute('size', val);
-  }
+  set size(val: string) { this.setAttribute('size', val); }
 
   get value(): string {
     return this._input?.value ?? this.getAttribute('value') ?? '';
   }
 
   set value(val: string) {
-    if (this._input) {
-      this._input.value = val;
-    }
+    if (this._input) this._input.value = val;
     this.setAttribute('value', val);
   }
 
-  get name(): string {
-    return this.getAttribute('name') ?? '';
-  }
+  get name(): string { return this.getAttribute('name') ?? ''; }
+  set name(val: string) { this.setAttribute('name', val); }
 
-  set name(val: string) {
-    this.setAttribute('name', val);
-  }
+  get placeholder(): string { return this.getAttribute('placeholder') ?? ''; }
+  set placeholder(val: string) { this.setAttribute('placeholder', val); }
 
-  get placeholder(): string {
-    return this.getAttribute('placeholder') ?? '';
-  }
+  get disabled(): boolean { return this.hasAttribute('disabled'); }
+  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
 
-  set placeholder(val: string) {
-    this.setAttribute('placeholder', val);
-  }
+  get readonly(): boolean { return this.hasAttribute('readonly'); }
+  set readonly(val: boolean) { val ? this.setAttribute('readonly', '') : this.removeAttribute('readonly'); }
 
-  get disabled(): boolean {
-    return this.hasAttribute('disabled');
-  }
+  get required(): boolean { return this.hasAttribute('required'); }
+  set required(val: boolean) { val ? this.setAttribute('required', '') : this.removeAttribute('required'); }
 
-  set disabled(val: boolean) {
-    if (val) {
-      this.setAttribute('disabled', '');
-    } else {
-      this.removeAttribute('disabled');
-    }
-  }
+  get error(): boolean { return this.hasAttribute('error'); }
+  set error(val: boolean) { val ? this.setAttribute('error', '') : this.removeAttribute('error'); }
 
-  get readonly(): boolean {
-    return this.hasAttribute('readonly');
-  }
-
-  set readonly(val: boolean) {
-    if (val) {
-      this.setAttribute('readonly', '');
-    } else {
-      this.removeAttribute('readonly');
-    }
-  }
-
-  get required(): boolean {
-    return this.hasAttribute('required');
-  }
-
-  set required(val: boolean) {
-    if (val) {
-      this.setAttribute('required', '');
-    } else {
-      this.removeAttribute('required');
-    }
-  }
-
-  get error(): boolean {
-    return this.hasAttribute('error');
-  }
-
-  set error(val: boolean) {
-    if (val) {
-      this.setAttribute('error', '');
-    } else {
-      this.removeAttribute('error');
-    }
-  }
-
-  focus() {
-    this._input?.focus();
-  }
-
-  blur() {
-    this._input?.blur();
-  }
+  focus() { this._input?.focus(); }
+  blur() { this._input?.blur(); }
 
   private _buildDom() {
     const style = document.createElement('style');
     style.textContent = `
-      :host {
-        display: block;
-      }
-
-      .input-wrapper {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-      }
-
-      label {
-        font-size: 14px;
-        font-weight: 500;
-        color: #374151;
-      }
-
+      :host { display: block; }
+      .input-wrapper { display: flex; flex-direction: column; gap: 4px; }
+      label { font-size: 14px; font-weight: 500; color: #374151; }
       input {
         font-family: inherit;
         border: 1px solid #d1d5db;
@@ -152,47 +92,21 @@ export class ElxInput extends HTMLElement {
         color: #1f2937;
         transition: border-color 0.15s ease, box-shadow 0.15s ease;
         width: 100%;
+        box-sizing: border-box;
       }
-
-      input:focus {
+      input:focus, input:focus-visible {
         outline: none;
         border-color: #2563eb;
         box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
       }
-
-      input:focus-visible {
-        outline: none;
-        border-color: #2563eb;
-        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-      }
-
-      input:disabled {
-        background: #f3f4f6;
-        color: #9ca3af;
-        cursor: not-allowed;
-      }
-
-      input:read-only {
-        background: #f9fafb;
-      }
-
-      input.error {
-        border-color: #dc2626;
-      }
-
-      input.error:focus {
-        border-color: #dc2626;
-        box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
-      }
-
-      /* Sizes */
+      input:disabled { background: #f3f4f6; color: #9ca3af; cursor: not-allowed; }
+      input:read-only { background: #f9fafb; }
+      input.error { border-color: #dc2626; }
+      input.error:focus { border-color: #dc2626; box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1); }
       input.sm { padding: 6px 10px; font-size: 13px; }
       input.md { padding: 8px 12px; font-size: 14px; }
       input.lg { padding: 12px 16px; font-size: 16px; }
-
-      input::placeholder {
-        color: #9ca3af;
-      }
+      input::placeholder { color: #9ca3af; }
     `;
 
     const wrapper = document.createElement('div');
@@ -200,46 +114,41 @@ export class ElxInput extends HTMLElement {
 
     this._label = document.createElement('label');
     this._label.style.display = 'none';
+    this._label.htmlFor = this._inputId;
 
     this._input = document.createElement('input');
+    this._input.id = this._inputId;
 
     wrapper.appendChild(this._label);
     wrapper.appendChild(this._input);
-
     this.shadowRoot!.appendChild(style);
     this.shadowRoot!.appendChild(wrapper);
 
-    // Event forwarding
-    this._input.addEventListener('input', (e) => {
-      this.dispatchEvent(new CustomEvent('input', { 
+    this._input.addEventListener('input', () => {
+      this.dispatchEvent(new CustomEvent('input', {
         detail: { value: this._input!.value },
-        bubbles: true,
-        composed: true
+        bubbles: true, composed: true
       }));
     });
 
-    this._input.addEventListener('change', (e) => {
-      this.dispatchEvent(new CustomEvent('change', { 
+    this._input.addEventListener('change', () => {
+      this.dispatchEvent(new CustomEvent('change', {
         detail: { value: this._input!.value },
-        bubbles: true,
-        composed: true
+        bubbles: true, composed: true
       }));
     });
 
-    this._input.addEventListener('focus', (e) => {
+    this._input.addEventListener('focus', () => {
       this.dispatchEvent(new CustomEvent('focus', { bubbles: true, composed: true }));
     });
 
-    this._input.addEventListener('blur', (e) => {
+    this._input.addEventListener('blur', () => {
       this.dispatchEvent(new CustomEvent('blur', { bubbles: true, composed: true }));
     });
   }
 
   private _update() {
     if (!this._input) return;
-
-    const size = this.size;
-    const hasError = this.error;
 
     this._input.type = this.type;
     this._input.name = this.name;
@@ -248,20 +157,34 @@ export class ElxInput extends HTMLElement {
     this._input.readOnly = this.readonly;
     this._input.required = this.required;
 
-    // Update value only if different (prevents cursor jump)
-    if (this._input.value !== (this.getAttribute('value') ?? '')) {
-      this._input.value = this.getAttribute('value') ?? '';
+    // aria-invalid for error state
+    if (this.error) {
+      this._input.setAttribute('aria-invalid', 'true');
+    } else {
+      this._input.removeAttribute('aria-invalid');
+    }
+
+    // aria-required
+    if (this.required) {
+      this._input.setAttribute('aria-required', 'true');
+    } else {
+      this._input.removeAttribute('aria-required');
+    }
+
+    // Only sync value if attribute changed (prevents cursor jump)
+    const attrVal = this.getAttribute('value') ?? '';
+    if (this._input.value !== attrVal) {
+      this._input.value = attrVal;
     }
 
     // Safe class update
-    this._input.className = `${size}${hasError ? ' error' : ''}`;
+    this._input.className = `${this.size}${this.error ? ' error' : ''}`;
 
-    // Update label visibility
+    // Label
     const labelText = this.getAttribute('label');
     if (labelText) {
       this._label!.style.display = 'block';
       this._label!.textContent = labelText;
-      this._label!.htmlFor = this._input.id || '';
     } else {
       this._label!.style.display = 'none';
     }

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -1,0 +1,273 @@
+const VALID_SIZES = ['sm', 'md', 'lg'] as const;
+const VALID_TYPES = ['text', 'password', 'email', 'number', 'tel', 'url', 'search'] as const;
+
+type Size = typeof VALID_SIZES[number];
+type InputType = typeof VALID_TYPES[number];
+
+export class ElxInput extends HTMLElement {
+  static observedAttributes = ['type', 'size', 'disabled', 'readonly', 'placeholder', 'value', 'name', 'required', 'error'];
+
+  private _input: HTMLInputElement | null = null;
+  private _label: HTMLLabelElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+
+  attributeChangedCallback() {
+    this._update();
+  }
+
+  get type(): InputType {
+    const val = this.getAttribute('type');
+    return (VALID_TYPES as readonly string[]).indexOf(val as string) !== -1 ? (val as InputType) : 'text';
+  }
+
+  set type(val: string) {
+    this.setAttribute('type', val);
+  }
+
+  get size(): Size {
+    const val = this.getAttribute('size');
+    return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
+  }
+
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
+
+  get value(): string {
+    return this._input?.value ?? this.getAttribute('value') ?? '';
+  }
+
+  set value(val: string) {
+    if (this._input) {
+      this._input.value = val;
+    }
+    this.setAttribute('value', val);
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  set name(val: string) {
+    this.setAttribute('name', val);
+  }
+
+  get placeholder(): string {
+    return this.getAttribute('placeholder') ?? '';
+  }
+
+  set placeholder(val: string) {
+    this.setAttribute('placeholder', val);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(val: boolean) {
+    if (val) {
+      this.setAttribute('disabled', '');
+    } else {
+      this.removeAttribute('disabled');
+    }
+  }
+
+  get readonly(): boolean {
+    return this.hasAttribute('readonly');
+  }
+
+  set readonly(val: boolean) {
+    if (val) {
+      this.setAttribute('readonly', '');
+    } else {
+      this.removeAttribute('readonly');
+    }
+  }
+
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+
+  set required(val: boolean) {
+    if (val) {
+      this.setAttribute('required', '');
+    } else {
+      this.removeAttribute('required');
+    }
+  }
+
+  get error(): boolean {
+    return this.hasAttribute('error');
+  }
+
+  set error(val: boolean) {
+    if (val) {
+      this.setAttribute('error', '');
+    } else {
+      this.removeAttribute('error');
+    }
+  }
+
+  focus() {
+    this._input?.focus();
+  }
+
+  blur() {
+    this._input?.blur();
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: block;
+      }
+
+      .input-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      label {
+        font-size: 14px;
+        font-weight: 500;
+        color: #374151;
+      }
+
+      input {
+        font-family: inherit;
+        border: 1px solid #d1d5db;
+        border-radius: 6px;
+        background: #fff;
+        color: #1f2937;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+        width: 100%;
+      }
+
+      input:focus {
+        outline: none;
+        border-color: #2563eb;
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+      }
+
+      input:focus-visible {
+        outline: none;
+        border-color: #2563eb;
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+      }
+
+      input:disabled {
+        background: #f3f4f6;
+        color: #9ca3af;
+        cursor: not-allowed;
+      }
+
+      input:read-only {
+        background: #f9fafb;
+      }
+
+      input.error {
+        border-color: #dc2626;
+      }
+
+      input.error:focus {
+        border-color: #dc2626;
+        box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
+      }
+
+      /* Sizes */
+      input.sm { padding: 6px 10px; font-size: 13px; }
+      input.md { padding: 8px 12px; font-size: 14px; }
+      input.lg { padding: 12px 16px; font-size: 16px; }
+
+      input::placeholder {
+        color: #9ca3af;
+      }
+    `;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'input-wrapper';
+
+    this._label = document.createElement('label');
+    this._label.style.display = 'none';
+
+    this._input = document.createElement('input');
+
+    wrapper.appendChild(this._label);
+    wrapper.appendChild(this._input);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(wrapper);
+
+    // Event forwarding
+    this._input.addEventListener('input', (e) => {
+      this.dispatchEvent(new CustomEvent('input', { 
+        detail: { value: this._input!.value },
+        bubbles: true,
+        composed: true
+      }));
+    });
+
+    this._input.addEventListener('change', (e) => {
+      this.dispatchEvent(new CustomEvent('change', { 
+        detail: { value: this._input!.value },
+        bubbles: true,
+        composed: true
+      }));
+    });
+
+    this._input.addEventListener('focus', (e) => {
+      this.dispatchEvent(new CustomEvent('focus', { bubbles: true, composed: true }));
+    });
+
+    this._input.addEventListener('blur', (e) => {
+      this.dispatchEvent(new CustomEvent('blur', { bubbles: true, composed: true }));
+    });
+  }
+
+  private _update() {
+    if (!this._input) return;
+
+    const size = this.size;
+    const hasError = this.error;
+
+    this._input.type = this.type;
+    this._input.name = this.name;
+    this._input.placeholder = this.placeholder;
+    this._input.disabled = this.disabled;
+    this._input.readOnly = this.readonly;
+    this._input.required = this.required;
+
+    // Update value only if different (prevents cursor jump)
+    if (this._input.value !== (this.getAttribute('value') ?? '')) {
+      this._input.value = this.getAttribute('value') ?? '';
+    }
+
+    // Safe class update
+    this._input.className = `${size}${hasError ? ' error' : ''}`;
+
+    // Update label visibility
+    const labelText = this.getAttribute('label');
+    if (labelText) {
+      this._label!.style.display = 'block';
+      this._label!.textContent = labelText;
+      this._label!.htmlFor = this._input.id || '';
+    } else {
+      this._label!.style.display = 'none';
+    }
+  }
+}
+
+if (!customElements.get('elx-input')) {
+  customElements.define('elx-input', ElxInput);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 // Elementix - Web Components Design System
 export * from './components/button/button';
+export * from './components/input/input';


### PR DESCRIPTION
## Summary
Adds `<elx-input>` web component with full form support.

### Features
- 7 input types: text, password, email, number, tel, url, search
- 3 sizes: sm, md, lg
- States: disabled, readonly, required, error
- Optional label with auto-hide
- Event forwarding (input, change, focus, blur)
- Focus/blur delegation

### Security
- Whitelist validation for type/size attributes
- DOM APIs only (no innerHTML)
- Guarded customElements.define

### Tests
- 20 passing tests covering all features