### PR TITLE
feat: add elx-switch component

### DIFF
--- a/src/components/switch/switch.stories.ts
+++ b/src/components/switch/switch.stories.ts
@@ -1,0 +1,41 @@
+import { html } from 'lit';
+import './switch';
+
+export default {
+  title: 'Components/Switch',
+  tags: ['autodocs'],
+  argTypes: {
+    checked: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    label: { control: 'text' },
+    name: { control: 'text' },
+    value: { control: 'text' }
+  }
+};
+
+const Template = ({ checked, disabled, size, label, name, value }: any) => html`
+  <elx-switch
+    ?checked=${checked}
+    ?disabled=${disabled}
+    size=${size}
+    label=${label}
+    name=${name}
+    value=${value}
+  ></elx-switch>
+`;
+
+export const Default = Template.bind({});
+(Default as any).args = { checked: false, disabled: false, size: 'md', label: 'Dark mode', name: 'darkmode', value: 'on' };
+
+export const Checked = Template.bind({});
+(Checked as any).args = { checked: true, disabled: false, size: 'md', label: 'Enabled', name: '', value: 'on' };
+
+export const Disabled = Template.bind({});
+(Disabled as any).args = { checked: false, disabled: true, size: 'md', label: 'Disabled', name: '', value: 'on' };
+
+export const Small = Template.bind({});
+(Small as any).args = { checked: true, disabled: false, size: 'sm', label: 'Small', name: '', value: 'on' };
+
+export const Large = Template.bind({});
+(Large as any).args = { checked: true, disabled: false, size: 'lg', label: 'Large', name: '', value: 'on' };

--- a/src/components/switch/switch.test.ts
+++ b/src/components/switch/switch.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './switch';
+
+describe('elx-switch', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-switch')).toBeDefined();
+  });
+
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('renders with default props', () => {
+    const el = document.createElement('elx-switch');
+    document.body.appendChild(el);
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input).toBeTruthy();
+    expect(input!.getAttribute('role')).toBe('switch');
+    expect(input!.checked).toBe(false);
+  });
+
+  it('reflects checked attribute', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('checked', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('input')!.checked).toBe(true);
+  });
+
+  it('reflects disabled attribute', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('disabled', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('input')!.disabled).toBe(true);
+  });
+
+  it('has role=switch on input', () => {
+    const el = document.createElement('elx-switch');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('input')!.getAttribute('role')).toBe('switch');
+  });
+
+  it('sets aria-checked to match checked state', () => {
+    const el = document.createElement('elx-switch');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('input')!.getAttribute('aria-checked')).toBe('false');
+    el.setAttribute('checked', '');
+    expect(el.shadowRoot!.querySelector('input')!.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('applies sm size class on track and thumb', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('size', 'sm');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.track')!.classList.contains('sm')).toBe(true);
+    expect(el.shadowRoot!.querySelector('.thumb')!.classList.contains('sm')).toBe(true);
+  });
+
+  it('applies lg size class on track and thumb', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('size', 'lg');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.track')!.classList.contains('lg')).toBe(true);
+    expect(el.shadowRoot!.querySelector('.thumb')!.classList.contains('lg')).toBe(true);
+  });
+
+  it('ignores invalid size, defaults to md', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('size', 'xxl');
+    document.body.appendChild(el);
+    expect(el.size).toBe('md');
+  });
+
+  it('sets name and value on input', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('name', 'darkmode');
+    el.setAttribute('value', 'yes');
+    document.body.appendChild(el);
+    const input = el.shadowRoot!.querySelector('input')!;
+    expect(input.name).toBe('darkmode');
+    expect(input.value).toBe('yes');
+  });
+
+  it('shows label text', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('label', 'Dark mode');
+    document.body.appendChild(el);
+    const span = el.shadowRoot!.querySelector('.label-text')!;
+    expect(span.textContent).toBe('Dark mode');
+    expect((span as HTMLElement).style.display).not.toBe('none');
+  });
+
+  it('hides label when not provided', () => {
+    const el = document.createElement('elx-switch');
+    document.body.appendChild(el);
+    const span = el.shadowRoot!.querySelector('.label-text') as HTMLElement;
+    expect(span.style.display).toBe('none');
+  });
+
+  it('label htmlFor matches input id', () => {
+    const el = document.createElement('elx-switch');
+    document.body.appendChild(el);
+    const label = el.shadowRoot!.querySelector('label')!;
+    const input = el.shadowRoot!.querySelector('input')!;
+    expect(label.htmlFor).toBe(input.id);
+  });
+
+  it('dispatches change event with detail on toggle', () => {
+    const el = document.createElement('elx-switch');
+    document.body.appendChild(el);
+    let detail: any = null;
+    el.addEventListener('change', (e: any) => { detail = e.detail; });
+    const input = el.shadowRoot!.querySelector('input')!;
+    input.checked = true;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(detail).toBeTruthy();
+    expect(detail.checked).toBe(true);
+  });
+
+  it('does not dispatch change when disabled', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('disabled', '');
+    document.body.appendChild(el);
+    let fired = false;
+    el.addEventListener('change', () => { fired = true; });
+    const input = el.shadowRoot!.querySelector('input')!;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(fired).toBe(false);
+  });
+
+  it('track gets checked class when checked', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('checked', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.track')!.classList.contains('checked')).toBe(true);
+  });
+
+  it('thumb gets checked class when checked', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('checked', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.thumb')!.classList.contains('checked')).toBe(true);
+  });
+
+  it('track gets disabled class when disabled', () => {
+    const el = document.createElement('elx-switch');
+    el.setAttribute('disabled', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.track')!.classList.contains('disabled')).toBe(true);
+  });
+
+  it('preserves DOM reference across attribute updates', () => {
+    const el = document.createElement('elx-switch');
+    document.body.appendChild(el);
+    const input1 = el.shadowRoot!.querySelector('input');
+    el.setAttribute('size', 'lg');
+    el.setAttribute('label', 'Updated');
+    const input2 = el.shadowRoot!.querySelector('input');
+    expect(input1).toBe(input2);
+  });
+
+  it('has focus and blur methods', () => {
+    const el = document.createElement('elx-switch');
+    document.body.appendChild(el);
+    expect(() => el.focus()).not.toThrow();
+    expect(() => el.blur()).not.toThrow();
+  });
+});

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -1,0 +1,180 @@
+const VALID_SIZES = ['sm', 'md', 'lg'] as const;
+type Size = typeof VALID_SIZES[number];
+
+let uid = 0;
+
+export class ElxSwitch extends HTMLElement {
+  static observedAttributes = ['checked', 'disabled', 'size', 'label', 'name', 'value'];
+
+  private _input: HTMLInputElement | null = null;
+  private _track: HTMLSpanElement | null = null;
+  private _thumb: HTMLSpanElement | null = null;
+  private _labelEl: HTMLLabelElement | null = null;
+  private _id: string = `elx-switch-${++uid}`;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() { this._buildDom(); this._update(); }
+  attributeChangedCallback() { this._update(); }
+
+  get checked(): boolean { return this.hasAttribute('checked'); }
+  set checked(val: boolean) { val ? this.setAttribute('checked', '') : this.removeAttribute('checked'); }
+
+  get disabled(): boolean { return this.hasAttribute('disabled'); }
+  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+
+  get size(): Size {
+    const val = this.getAttribute('size');
+    return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
+  }
+  set size(val: string) { this.setAttribute('size', val); }
+
+  get name(): string { return this.getAttribute('name') ?? ''; }
+  set name(val: string) { this.setAttribute('name', val); }
+
+  get value(): string { return this.getAttribute('value') ?? 'on'; }
+  set value(val: string) { this.setAttribute('value', val); }
+
+  get label(): string { return this.getAttribute('label') ?? ''; }
+  set label(val: string) { this.setAttribute('label', val); }
+
+  focus() { this._input?.focus(); }
+  blur() { this._input?.blur(); }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: inline-block; }
+
+      label {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        cursor: pointer;
+        user-select: none;
+        font-family: inherit;
+        color: #1f2937;
+      }
+      label.disabled { cursor: not-allowed; color: #9ca3af; }
+
+      input {
+        position: absolute;
+        width: 1px; height: 1px;
+        padding: 0; margin: -1px;
+        overflow: hidden;
+        clip: rect(0,0,0,0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      .track {
+        position: relative;
+        border-radius: 9999px;
+        background: #d1d5db;
+        transition: background 0.2s ease;
+        flex-shrink: 0;
+      }
+      .track.sm { width: 32px; height: 18px; }
+      .track.md { width: 44px; height: 24px; }
+      .track.lg { width: 56px; height: 30px; }
+
+      .track.checked { background: #2563eb; }
+      .track.disabled { opacity: 0.5; }
+
+      .thumb {
+        position: absolute;
+        top: 2px; left: 2px;
+        border-radius: 50%;
+        background: #fff;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+        transition: transform 0.2s ease;
+      }
+      .thumb.sm { width: 14px; height: 14px; }
+      .thumb.md { width: 20px; height: 20px; }
+      .thumb.lg { width: 26px; height: 26px; }
+
+      .thumb.sm.checked { transform: translateX(14px); }
+      .thumb.md.checked { transform: translateX(20px); }
+      .thumb.lg.checked { transform: translateX(26px); }
+
+      input:focus-visible ~ .track {
+        box-shadow: 0 0 0 3px rgba(37,99,235,0.3);
+      }
+
+      .label-text.sm { font-size: 13px; }
+      .label-text.md { font-size: 14px; }
+      .label-text.lg { font-size: 16px; }
+    `;
+
+    this._labelEl = document.createElement('label');
+    this._labelEl.htmlFor = this._id;
+
+    this._input = document.createElement('input');
+    this._input.type = 'checkbox';
+    this._input.id = this._id;
+    this._input.setAttribute('role', 'switch');
+
+    this._track = document.createElement('span');
+    this._track.className = 'track';
+
+    this._thumb = document.createElement('span');
+    this._thumb.className = 'thumb';
+    this._track.appendChild(this._thumb);
+
+    const labelText = document.createElement('span');
+    labelText.className = 'label-text';
+
+    this._labelEl.appendChild(this._input);
+    this._labelEl.appendChild(this._track);
+    this._labelEl.appendChild(labelText);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(this._labelEl);
+
+    this._input.addEventListener('change', () => {
+      if (this.disabled) return;
+      if (this._input!.checked) {
+        this.setAttribute('checked', '');
+      } else {
+        this.removeAttribute('checked');
+      }
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: { checked: this.checked, value: this.value },
+        bubbles: true, composed: true
+      }));
+    });
+  }
+
+  private _update() {
+    if (!this._input) return;
+
+    const size = this.size;
+    const isChecked = this.checked;
+    const isDisabled = this.disabled;
+
+    this._input.checked = isChecked;
+    this._input.disabled = isDisabled;
+    this._input.name = this.name;
+    this._input.value = this.value;
+    this._input.setAttribute('aria-checked', String(isChecked));
+
+    this._track!.className = `track ${size}${isChecked ? ' checked' : ''}${isDisabled ? ' disabled' : ''}`;
+    this._thumb!.className = `thumb ${size}${isChecked ? ' checked' : ''}`;
+
+    this._labelEl!.className = isDisabled ? 'disabled' : '';
+
+    const labelSpan = this.shadowRoot!.querySelector('.label-text') as HTMLElement;
+    if (labelSpan) {
+      labelSpan.className = `label-text ${size}`;
+      labelSpan.textContent = this.label;
+      labelSpan.style.display = this.label ? 'inline' : 'none';
+    }
+  }
+}
+
+if (!customElements.get('elx-switch')) {
+  customElements.define('elx-switch', ElxSwitch);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@
 export * from './components/button/button';
 export * from './components/input/input';
 export * from './components/checkbox/checkbox';
+export * from './components/switch/switch';


### PR DESCRIPTION
## Summary
Adds `<elx-switch>` toggle switch component.

### Features
- Checked, disabled states
- 3 sizes: sm, md, lg with animated sliding thumb
- Label with htmlFor association
- Change event with checked/value detail

### Accessibility
- role=switch on native input
- aria-checked reflects state
- focus-visible outline on keyboard nav

### Security
- Whitelist size validation
- DOM APIs only, guarded registration

### Tests
- 19 passing tests