### PR TITLE
feat: add elx-radio and elx-radio-group components

### DIFF
--- a/src/components/radio/radio.stories.ts
+++ b/src/components/radio/radio.stories.ts
@@ -1,0 +1,38 @@
+import { html } from 'lit';
+import './radio';
+
+export default {
+  title: 'Components/Radio',
+  tags: ['autodocs'],
+};
+
+export const SingleRadio = () => html`
+  <div style="display:flex;flex-direction:column;gap:8px">
+    <elx-radio name="fruit" value="apple" label="Apple" checked></elx-radio>
+    <elx-radio name="fruit" value="banana" label="Banana"></elx-radio>
+    <elx-radio name="fruit" value="cherry" label="Cherry" disabled></elx-radio>
+  </div>
+`;
+
+export const Sizes = () => html`
+  <div style="display:flex;flex-direction:column;gap:12px">
+    <elx-radio size="sm" label="Small" name="size" value="sm"></elx-radio>
+    <elx-radio size="md" label="Medium" name="size" value="md" checked></elx-radio>
+    <elx-radio size="lg" label="Large" name="size" value="lg"></elx-radio>
+  </div>
+`;
+
+export const WithGroup = () => html`
+  <elx-radio-group name="plan" value="pro">
+    <elx-radio value="free" label="Free"></elx-radio>
+    <elx-radio value="pro" label="Pro"></elx-radio>
+    <elx-radio value="enterprise" label="Enterprise"></elx-radio>
+  </elx-radio-group>
+`;
+
+export const GroupDisabled = () => html`
+  <elx-radio-group name="plan" value="free" disabled>
+    <elx-radio value="free" label="Free"></elx-radio>
+    <elx-radio value="pro" label="Pro"></elx-radio>
+  </elx-radio-group>
+`;

--- a/src/components/radio/radio.test.ts
+++ b/src/components/radio/radio.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './radio';
+
+describe('elx-radio', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-radio')).toBeDefined();
+    expect(customElements.get('elx-radio-group')).toBeDefined();
+  });
+
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('renders with default props', () => {
+    const el = document.createElement('elx-radio');
+    document.body.appendChild(el);
+    const input = el.shadowRoot!.querySelector('input');
+    expect(input).toBeTruthy();
+    expect(input!.type).toBe('radio');
+    expect(input!.checked).toBe(false);
+  });
+
+  it('reflects checked attribute', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('checked', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('input')!.checked).toBe(true);
+  });
+
+  it('reflects disabled attribute', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('disabled', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('input')!.disabled).toBe(true);
+  });
+
+  it('applies sm size class', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('size', 'sm');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.radio-circle')!.classList.contains('sm')).toBe(true);
+  });
+
+  it('applies lg size class', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('size', 'lg');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.radio-circle')!.classList.contains('lg')).toBe(true);
+  });
+
+  it('ignores invalid size, defaults to md', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('size', 'xlarge');
+    document.body.appendChild(el);
+    expect(el.size).toBe('md');
+  });
+
+  it('dot is visible when checked', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('checked', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.dot')!.classList.contains('visible')).toBe(true);
+  });
+
+  it('dot is hidden when not checked', () => {
+    const el = document.createElement('elx-radio');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.dot')!.classList.contains('visible')).toBe(false);
+  });
+
+  it('checked class on radio-circle when checked', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('checked', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.radio-circle')!.classList.contains('checked')).toBe(true);
+  });
+
+  it('disabled class on radio-circle when disabled', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('disabled', '');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.radio-circle')!.classList.contains('disabled')).toBe(true);
+  });
+
+  it('sets name and value on input', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('name', 'fruit');
+    el.setAttribute('value', 'apple');
+    document.body.appendChild(el);
+    const input = el.shadowRoot!.querySelector('input')!;
+    expect(input.name).toBe('fruit');
+    expect(input.value).toBe('apple');
+  });
+
+  it('shows label text', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('label', 'Option A');
+    document.body.appendChild(el);
+    const span = el.shadowRoot!.querySelector('.label-text')!;
+    expect(span.textContent).toBe('Option A');
+    expect((span as HTMLElement).style.display).not.toBe('none');
+  });
+
+  it('hides label when not provided', () => {
+    const el = document.createElement('elx-radio');
+    document.body.appendChild(el);
+    const span = el.shadowRoot!.querySelector('.label-text') as HTMLElement;
+    expect(span.style.display).toBe('none');
+  });
+
+  it('label htmlFor matches input id', () => {
+    const el = document.createElement('elx-radio');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('label')!.htmlFor).toBe(el.shadowRoot!.querySelector('input')!.id);
+  });
+
+  it('dispatches change event on selection', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('value', 'apple');
+    el.setAttribute('name', 'fruit');
+    document.body.appendChild(el);
+    let detail: any = null;
+    el.addEventListener('change', (e: any) => { detail = e.detail; });
+    el.shadowRoot!.querySelector('input')!.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(detail).toBeTruthy();
+    expect(detail.value).toBe('apple');
+    expect(detail.name).toBe('fruit');
+  });
+
+  it('does not dispatch change when disabled', () => {
+    const el = document.createElement('elx-radio');
+    el.setAttribute('disabled', '');
+    document.body.appendChild(el);
+    let fired = false;
+    el.addEventListener('change', () => { fired = true; });
+    el.shadowRoot!.querySelector('input')!.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(fired).toBe(false);
+  });
+
+  it('preserves DOM reference across attribute updates', () => {
+    const el = document.createElement('elx-radio');
+    document.body.appendChild(el);
+    const input1 = el.shadowRoot!.querySelector('input');
+    el.setAttribute('size', 'lg');
+    el.setAttribute('label', 'Updated');
+    expect(el.shadowRoot!.querySelector('input')).toBe(input1);
+  });
+
+  it('has focus and blur methods', () => {
+    const el = document.createElement('elx-radio');
+    document.body.appendChild(el);
+    expect(() => el.focus()).not.toThrow();
+    expect(() => el.blur()).not.toThrow();
+  });
+});
+
+describe('elx-radio-group', () => {
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('renders with slot', () => {
+    const group = document.createElement('elx-radio-group');
+    document.body.appendChild(group);
+    expect(group.shadowRoot!.querySelector('slot')).toBeTruthy();
+  });
+
+  it('propagates name to children', () => {
+    const group = document.createElement('elx-radio-group');
+    group.setAttribute('name', 'color');
+    const r1 = document.createElement('elx-radio');
+    r1.setAttribute('value', 'red');
+    const r2 = document.createElement('elx-radio');
+    r2.setAttribute('value', 'blue');
+    group.appendChild(r1);
+    group.appendChild(r2);
+    document.body.appendChild(group);
+    expect(r1.getAttribute('name')).toBe('color');
+    expect(r2.getAttribute('name')).toBe('color');
+  });
+
+  it('syncs checked state via value attribute', () => {
+    const group = document.createElement('elx-radio-group');
+    group.setAttribute('name', 'color');
+    group.setAttribute('value', 'blue');
+    const r1 = document.createElement('elx-radio');
+    r1.setAttribute('value', 'red');
+    const r2 = document.createElement('elx-radio');
+    r2.setAttribute('value', 'blue');
+    group.appendChild(r1);
+    group.appendChild(r2);
+    document.body.appendChild(group);
+    expect(r2.hasAttribute('checked')).toBe(true);
+    expect(r1.hasAttribute('checked')).toBe(false);
+  });
+
+  it('propagates disabled to children', () => {
+    const group = document.createElement('elx-radio-group');
+    group.setAttribute('name', 'color');
+    group.setAttribute('disabled', '');
+    const r1 = document.createElement('elx-radio');
+    r1.setAttribute('value', 'red');
+    group.appendChild(r1);
+    document.body.appendChild(group);
+    expect(r1.hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -1,0 +1,262 @@
+const VALID_SIZES = ['sm', 'md', 'lg'] as const;
+type Size = typeof VALID_SIZES[number];
+
+let uid = 0;
+
+export class ElxRadio extends HTMLElement {
+  static observedAttributes = ['checked', 'disabled', 'size', 'label', 'name', 'value'];
+
+  private _input: HTMLInputElement | null = null;
+  private _labelEl: HTMLLabelElement | null = null;
+  private _dot: HTMLSpanElement | null = null;
+  private _id: string = `elx-radio-${++uid}`;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() { this._buildDom(); this._update(); }
+  attributeChangedCallback() { this._update(); }
+
+  get checked(): boolean { return this.hasAttribute('checked'); }
+  set checked(val: boolean) { val ? this.setAttribute('checked', '') : this.removeAttribute('checked'); }
+
+  get disabled(): boolean { return this.hasAttribute('disabled'); }
+  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+
+  get size(): Size {
+    const val = this.getAttribute('size');
+    return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
+  }
+  set size(val: string) { this.setAttribute('size', val); }
+
+  get name(): string { return this.getAttribute('name') ?? ''; }
+  set name(val: string) { this.setAttribute('name', val); }
+
+  get value(): string { return this.getAttribute('value') ?? ''; }
+  set value(val: string) { this.setAttribute('value', val); }
+
+  get label(): string { return this.getAttribute('label') ?? ''; }
+  set label(val: string) { this.setAttribute('label', val); }
+
+  focus() { this._input?.focus(); }
+  blur() { this._input?.blur(); }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: inline-block; }
+
+      label {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        cursor: pointer;
+        user-select: none;
+        font-family: inherit;
+        color: #1f2937;
+      }
+      label.disabled { cursor: not-allowed; color: #9ca3af; }
+
+      input {
+        position: absolute;
+        width: 1px; height: 1px;
+        padding: 0; margin: -1px;
+        overflow: hidden;
+        clip: rect(0,0,0,0);
+        white-space: nowrap; border: 0;
+      }
+
+      .radio-circle {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 2px solid #d1d5db;
+        border-radius: 50%;
+        background: #fff;
+        transition: all 0.15s ease;
+        flex-shrink: 0;
+      }
+      .radio-circle.sm { width: 14px; height: 14px; }
+      .radio-circle.md { width: 18px; height: 18px; }
+      .radio-circle.lg { width: 22px; height: 22px; }
+
+      .radio-circle.checked { border-color: #2563eb; }
+      .radio-circle.disabled { background: #f3f4f6; border-color: #e5e7eb; }
+      .radio-circle.checked.disabled { border-color: #93c5fd; }
+
+      .dot {
+        border-radius: 50%;
+        background: #2563eb;
+        display: none;
+      }
+      .dot.visible { display: block; }
+      .dot.sm { width: 6px; height: 6px; }
+      .dot.md { width: 8px; height: 8px; }
+      .dot.lg { width: 10px; height: 10px; }
+      .dot.disabled { background: #93c5fd; }
+
+      input:focus-visible + .radio-circle {
+        box-shadow: 0 0 0 3px rgba(37,99,235,0.3);
+        border-color: #2563eb;
+      }
+
+      .label-text.sm { font-size: 13px; }
+      .label-text.md { font-size: 14px; }
+      .label-text.lg { font-size: 16px; }
+    `;
+
+    this._labelEl = document.createElement('label');
+    this._labelEl.htmlFor = this._id;
+
+    this._input = document.createElement('input');
+    this._input.type = 'radio';
+    this._input.id = this._id;
+
+    const circle = document.createElement('span');
+    circle.className = 'radio-circle';
+
+    this._dot = document.createElement('span');
+    this._dot.className = 'dot';
+    circle.appendChild(this._dot);
+
+    const labelText = document.createElement('span');
+    labelText.className = 'label-text';
+
+    this._labelEl.appendChild(this._input);
+    this._labelEl.appendChild(circle);
+    this._labelEl.appendChild(labelText);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(this._labelEl);
+
+    this._input.addEventListener('change', () => {
+      if (this.disabled) return;
+      this.setAttribute('checked', '');
+      // Uncheck siblings in same group
+      this._uncheckSiblings();
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: { value: this.value, name: this.name },
+        bubbles: true, composed: true
+      }));
+    });
+  }
+
+  private _uncheckSiblings() {
+    const parent = this.parentElement;
+    if (!parent) return;
+    const siblings = parent.querySelectorAll(`elx-radio[name="${this.name}"]`);
+    siblings.forEach(sib => {
+      if (sib !== this && sib.hasAttribute('checked')) {
+        sib.removeAttribute('checked');
+      }
+    });
+  }
+
+  private _update() {
+    if (!this._input) return;
+
+    const size = this.size;
+    const isChecked = this.checked;
+    const isDisabled = this.disabled;
+
+    this._input.checked = isChecked;
+    this._input.disabled = isDisabled;
+    this._input.name = this.name;
+    this._input.value = this.value;
+
+    const circle = this.shadowRoot!.querySelector('.radio-circle') as HTMLSpanElement;
+    if (circle) {
+      circle.className = `radio-circle ${size}${isChecked ? ' checked' : ''}${isDisabled ? ' disabled' : ''}`;
+    }
+
+    if (this._dot) {
+      this._dot.className = `dot ${size}${isChecked ? ' visible' : ''}${isDisabled ? ' disabled' : ''}`;
+    }
+
+    this._labelEl!.className = isDisabled ? 'disabled' : '';
+
+    const labelSpan = this.shadowRoot!.querySelector('.label-text') as HTMLElement;
+    if (labelSpan) {
+      labelSpan.className = `label-text ${size}`;
+      labelSpan.textContent = this.label;
+      labelSpan.style.display = this.label ? 'inline' : 'none';
+    }
+  }
+}
+
+export class ElxRadioGroup extends HTMLElement {
+  static observedAttributes = ['name', 'value', 'disabled', 'orientation'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._propagateAttrs();
+    this.addEventListener('change', this._handleChange.bind(this) as EventListener);
+  }
+
+  attributeChangedCallback() { this._propagateAttrs(); }
+
+  get name(): string { return this.getAttribute('name') ?? ''; }
+  set name(val: string) { this.setAttribute('name', val); }
+
+  get value(): string { return this.getAttribute('value') ?? ''; }
+  set value(val: string) { this.setAttribute('value', val); this._syncChecked(); }
+
+  get disabled(): boolean { return this.hasAttribute('disabled'); }
+  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+
+  get orientation(): string { return this.getAttribute('orientation') ?? 'vertical'; }
+  set orientation(val: string) { this.setAttribute('orientation', val); }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: block; }
+      ::slotted(*) { display: block; }
+      :host([orientation="horizontal"]) ::slotted(*) { display: inline-block; margin-right: 16px; }
+    `;
+    const slot = document.createElement('slot');
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(slot);
+  }
+
+  private _propagateAttrs() {
+    const radios = this.querySelectorAll('elx-radio');
+    radios.forEach(radio => {
+      if (this.name) radio.setAttribute('name', this.name);
+      if (this.disabled) radio.setAttribute('disabled', '');
+    });
+    this._syncChecked();
+  }
+
+  private _syncChecked() {
+    const radios = this.querySelectorAll('elx-radio');
+    radios.forEach(radio => {
+      if (radio.getAttribute('value') === this.value) {
+        radio.setAttribute('checked', '');
+      } else {
+        radio.removeAttribute('checked');
+      }
+    });
+  }
+
+  private _handleChange(e: CustomEvent) {
+    if (e.detail?.value) {
+      this.setAttribute('value', e.detail.value);
+    }
+  }
+}
+
+if (!customElements.get('elx-radio')) {
+  customElements.define('elx-radio', ElxRadio);
+}
+if (!customElements.get('elx-radio-group')) {
+  customElements.define('elx-radio-group', ElxRadioGroup);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './components/button/button';
 export * from './components/input/input';
 export * from './components/checkbox/checkbox';
 export * from './components/switch/switch';
+export * from './components/radio/radio';


### PR DESCRIPTION
## Summary
Adds `<elx-radio>` and `<elx-radio-group>` components.

### Features
- ElxRadio: checked, disabled, 3 sizes (sm/md/lg)
- ElxRadioGroup: manages selection, propagates name/disabled
- Circular dot indicator with animated states
- Label with htmlFor association
- Change event with value/name detail
- Mutual exclusion (unchecks siblings)

### Accessibility
- Native radio input for screen reader support
- focus-visible outline on keyboard nav

### Security
- Whitelist size validation
- DOM APIs only, guarded registration

### Tests
- 22 passing tests (18 radio + 4 group)