### PR TITLE
feat: add elx-badge component

### DIFF
--- a/src/components/badge/badge.stories.ts
+++ b/src/components/badge/badge.stories.ts
@@ -1,0 +1,61 @@
+import { html } from 'lit';
+import './badge';
+
+export default {
+  title: 'Components/Badge',
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: { type: 'select' }, options: ['solid', 'soft', 'outline'] },
+    color: { control: { type: 'select' }, options: ['gray', 'red', 'green', 'blue', 'yellow', 'purple'] },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    text: { control: 'text' }
+  }
+};
+
+const Template = ({ variant, color, size, text }: any) => html`
+  <elx-badge variant=${variant} color=${color} size=${size}>${text}</elx-badge>
+`;
+
+export const Default = Template.bind({});
+(Default as any).args = { variant: 'solid', color: 'gray', size: 'md', text: 'Badge' };
+
+export const Colors = () => html`
+  <div style="display:flex;gap:8px;flex-wrap:wrap">
+    <elx-badge color="gray">Gray</elx-badge>
+    <elx-badge color="red">Red</elx-badge>
+    <elx-badge color="green">Green</elx-badge>
+    <elx-badge color="blue">Blue</elx-badge>
+    <elx-badge color="yellow">Yellow</elx-badge>
+    <elx-badge color="purple">Purple</elx-badge>
+  </div>
+`;
+
+export const Soft = () => html`
+  <div style="display:flex;gap:8px;flex-wrap:wrap">
+    <elx-badge variant="soft" color="gray">Gray</elx-badge>
+    <elx-badge variant="soft" color="red">Red</elx-badge>
+    <elx-badge variant="soft" color="green">Green</elx-badge>
+    <elx-badge variant="soft" color="blue">Blue</elx-badge>
+    <elx-badge variant="soft" color="yellow">Yellow</elx-badge>
+    <elx-badge variant="soft" color="purple">Purple</elx-badge>
+  </div>
+`;
+
+export const Outline = () => html`
+  <div style="display:flex;gap:8px;flex-wrap:wrap">
+    <elx-badge variant="outline" color="gray">Gray</elx-badge>
+    <elx-badge variant="outline" color="red">Red</elx-badge>
+    <elx-badge variant="outline" color="green">Green</elx-badge>
+    <elx-badge variant="outline" color="blue">Blue</elx-badge>
+    <elx-badge variant="outline" color="yellow">Yellow</elx-badge>
+    <elx-badge variant="outline" color="purple">Purple</elx-badge>
+  </div>
+`;
+
+export const Sizes = () => html`
+  <div style="display:flex;gap:8px;align-items:center">
+    <elx-badge size="sm" color="blue">Small</elx-badge>
+    <elx-badge size="md" color="blue">Medium</elx-badge>
+    <elx-badge size="lg" color="blue">Large</elx-badge>
+  </div>
+`;

--- a/src/components/badge/badge.test.ts
+++ b/src/components/badge/badge.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './badge';
+
+describe('elx-badge', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-badge')).toBeDefined();
+  });
+
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('renders with default props', () => {
+    const el = document.createElement('elx-badge');
+    document.body.appendChild(el);
+    const span = el.shadowRoot!.querySelector('.badge');
+    expect(span).toBeTruthy();
+    expect(span!.classList.contains('solid')).toBe(true);
+    expect(span!.classList.contains('gray')).toBe(true);
+    expect(span!.classList.contains('md')).toBe(true);
+  });
+
+  it('uses slot for content', () => {
+    const el = document.createElement('elx-badge');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('slot')).toBeTruthy();
+  });
+
+  it('applies solid variant', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('variant', 'solid');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.badge')!.classList.contains('solid')).toBe(true);
+  });
+
+  it('applies soft variant', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('variant', 'soft');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.badge')!.classList.contains('soft')).toBe(true);
+  });
+
+  it('applies outline variant', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('variant', 'outline');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.badge')!.classList.contains('outline')).toBe(true);
+  });
+
+  it('ignores invalid variant, defaults to solid', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('variant', 'fancy');
+    document.body.appendChild(el);
+    expect(el.variant).toBe('solid');
+  });
+
+  it('applies red color', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('color', 'red');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.badge')!.classList.contains('red')).toBe(true);
+  });
+
+  it('applies green color', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('color', 'green');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.badge')!.classList.contains('green')).toBe(true);
+  });
+
+  it('applies blue color', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('color', 'blue');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.badge')!.classList.contains('blue')).toBe(true);
+  });
+
+  it('ignores invalid color, defaults to gray', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('color', 'neon');
+    document.body.appendChild(el);
+    expect(el.color).toBe('gray');
+  });
+
+  it('applies sm size', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('size', 'sm');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.badge')!.classList.contains('sm')).toBe(true);
+  });
+
+  it('applies lg size', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('size', 'lg');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.badge')!.classList.contains('lg')).toBe(true);
+  });
+
+  it('ignores invalid size, defaults to md', () => {
+    const el = document.createElement('elx-badge');
+    el.setAttribute('size', 'xxl');
+    document.body.appendChild(el);
+    expect(el.size).toBe('md');
+  });
+
+  it('updates class when attributes change', () => {
+    const el = document.createElement('elx-badge');
+    document.body.appendChild(el);
+    el.setAttribute('variant', 'outline');
+    el.setAttribute('color', 'purple');
+    el.setAttribute('size', 'lg');
+    const span = el.shadowRoot!.querySelector('.badge')!;
+    expect(span.classList.contains('outline')).toBe(true);
+    expect(span.classList.contains('purple')).toBe(true);
+    expect(span.classList.contains('lg')).toBe(true);
+  });
+
+  it('preserves DOM reference across attribute updates', () => {
+    const el = document.createElement('elx-badge');
+    document.body.appendChild(el);
+    const span1 = el.shadowRoot!.querySelector('.badge');
+    el.setAttribute('color', 'blue');
+    el.setAttribute('size', 'sm');
+    const span2 = el.shadowRoot!.querySelector('.badge');
+    expect(span1).toBe(span2);
+  });
+});

--- a/src/components/badge/badge.ts
+++ b/src/components/badge/badge.ts
@@ -1,0 +1,109 @@
+const VALID_VARIANTS = ['solid', 'soft', 'outline'] as const;
+const VALID_COLORS = ['gray', 'red', 'green', 'blue', 'yellow', 'purple'] as const;
+const VALID_SIZES = ['sm', 'md', 'lg'] as const;
+
+type Variant = typeof VALID_VARIANTS[number];
+type Color = typeof VALID_COLORS[number];
+type Size = typeof VALID_SIZES[number];
+
+export class ElxBadge extends HTMLElement {
+  static observedAttributes = ['variant', 'color', 'size'];
+
+  private _span: HTMLSpanElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+
+  attributeChangedCallback() {
+    this._update();
+  }
+
+  get variant(): Variant {
+    const val = this.getAttribute('variant');
+    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1 ? (val as Variant) : 'solid';
+  }
+  set variant(val: string) { this.setAttribute('variant', val); }
+
+  get color(): Color {
+    const val = this.getAttribute('color');
+    return (VALID_COLORS as readonly string[]).indexOf(val as string) !== -1 ? (val as Color) : 'gray';
+  }
+  set color(val: string) { this.setAttribute('color', val); }
+
+  get size(): Size {
+    const val = this.getAttribute('size');
+    return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
+  }
+  set size(val: string) { this.setAttribute('size', val); }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: inline-block; }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: inherit;
+        font-weight: 500;
+        border-radius: 9999px;
+        white-space: nowrap;
+        line-height: 1;
+      }
+
+      .badge.sm { font-size: 11px; padding: 2px 6px; }
+      .badge.md { font-size: 12px; padding: 2px 8px; }
+      .badge.lg { font-size: 13px; padding: 4px 10px; }
+
+      /* Solid variants */
+      .badge.solid.gray { background: #4b5563; color: #fff; }
+      .badge.solid.red { background: #ef4444; color: #fff; }
+      .badge.solid.green { background: #22c55e; color: #fff; }
+      .badge.solid.blue { background: #3b82f6; color: #fff; }
+      .badge.solid.yellow { background: #eab308; color: #fff; }
+      .badge.solid.purple { background: #a855f7; color: #fff; }
+
+      /* Soft variants */
+      .badge.soft.gray { background: #f3f4f6; color: #4b5563; }
+      .badge.soft.red { background: #fef2f2; color: #dc2626; }
+      .badge.soft.green { background: #f0fdf4; color: #16a34a; }
+      .badge.soft.blue { background: #eff6ff; color: #2563eb; }
+      .badge.soft.yellow { background: #fefce8; color: #ca8a04; }
+      .badge.soft.purple { background: #faf5ff; color: #9333ea; }
+
+      /* Outline variants */
+      .badge.outline.gray { background: transparent; color: #4b5563; border: 1px solid #d1d5db; }
+      .badge.outline.red { background: transparent; color: #dc2626; border: 1px solid #fca5a5; }
+      .badge.outline.green { background: transparent; color: #16a34a; border: 1px solid #86efac; }
+      .badge.outline.blue { background: transparent; color: #2563eb; border: 1px solid #93c5fd; }
+      .badge.outline.yellow { background: transparent; color: #ca8a04; border: 1px solid #fde047; }
+      .badge.outline.purple { background: transparent; color: #9333ea; border: 1px solid #d8b4fe; }
+    `;
+
+    this._span = document.createElement('span');
+    this._span.className = 'badge';
+
+    const slot = document.createElement('slot');
+
+    this._span.appendChild(slot);
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(this._span);
+  }
+
+  private _update() {
+    if (!this._span) return;
+    this._span.className = `badge ${this.size} ${this.variant} ${this.color}`;
+  }
+}
+
+if (!customElements.get('elx-badge')) {
+  customElements.define('elx-badge', ElxBadge);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from './components/input/input';
 export * from './components/checkbox/checkbox';
 export * from './components/switch/switch';
 export * from './components/radio/radio';
+export * from './components/badge/badge';


### PR DESCRIPTION
## Summary
Adds `<elx-badge>` component.

### Features
- 3 variants: solid, soft, outline
- 6 colors: gray, red, green, blue, yellow, purple  
- 3 sizes: sm, md, lg
- Slot-based content

### Security
- Whitelist validation on variant, color, size
- DOM APIs only, guarded registration

### Tests
- 15 passing tests