### PR TITLE
feat: add elx-avatar component

### DIFF
--- a/src/components/avatar/avatar.stories.ts
+++ b/src/components/avatar/avatar.stories.ts
@@ -1,0 +1,41 @@
+import { html } from 'lit';
+import './avatar';
+
+export default {
+  title: 'Components/Avatar',
+  tags: ['autodocs'],
+  argTypes: {
+    src: { control: 'text' },
+    alt: { control: 'text' },
+    fallback: { control: 'text' },
+    size: { control: { type: 'select' }, options: ['xs', 'sm', 'md', 'lg', 'xl'] },
+    shape: { control: { type: 'select' }, options: ['circle', 'square'] }
+  }
+};
+
+const Template = ({ src, alt, fallback, size, shape }: any) => html`
+  <elx-avatar src=${src} alt=${alt} fallback=${fallback} size=${size} shape=${shape}></elx-avatar>
+`;
+
+export const Default = Template.bind({});
+(Default as any).args = { src: 'https://i.pravatar.cc/150?img=1', alt: 'User', fallback: 'JD', size: 'md', shape: 'circle' };
+
+export const Fallback = Template.bind({});
+(Fallback as any).args = { src: '', alt: '', fallback: 'AB', size: 'md', shape: 'circle' };
+
+export const Sizes = () => html`
+  <div style="display:flex;gap:12px;align-items:center">
+    <elx-avatar size="xs" fallback="XS"></elx-avatar>
+    <elx-avatar size="sm" fallback="SM"></elx-avatar>
+    <elx-avatar size="md" fallback="MD"></elx-avatar>
+    <elx-avatar size="lg" fallback="LG"></elx-avatar>
+    <elx-avatar size="xl" fallback="XL"></elx-avatar>
+  </div>
+`;
+
+export const Square = () => html`
+  <div style="display:flex;gap:12px;align-items:center">
+    <elx-avatar shape="square" size="md" fallback="SQ"></elx-avatar>
+    <elx-avatar shape="square" size="lg" src="https://i.pravatar.cc/150?img=3" alt="Square avatar"></elx-avatar>
+  </div>
+`;

--- a/src/components/avatar/avatar.test.ts
+++ b/src/components/avatar/avatar.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './avatar';
+
+describe('elx-avatar', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-avatar')).toBeDefined();
+  });
+
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('renders with default props', () => {
+    const el = document.createElement('elx-avatar');
+    document.body.appendChild(el);
+    const wrapper = el.shadowRoot!.querySelector('.avatar');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper!.classList.contains('md')).toBe(true);
+    expect(wrapper!.classList.contains('circle')).toBe(true);
+  });
+
+  it('shows fallback when no src', () => {
+    const el = document.createElement('elx-avatar');
+    el.setAttribute('fallback', 'JD');
+    document.body.appendChild(el);
+    const fb = el.shadowRoot!.querySelector('.fallback') as HTMLElement;
+    expect(fb.textContent).toBe('JD');
+    expect(fb.style.display).toBe('flex');
+    expect((el.shadowRoot!.querySelector('img') as HTMLElement).style.display).toBe('none');
+  });
+
+  it('shows image when src is set', () => {
+    const el = document.createElement('elx-avatar');
+    el.setAttribute('src', 'https://example.com/photo.jpg');
+    el.setAttribute('alt', 'User photo');
+    document.body.appendChild(el);
+    const img = el.shadowRoot!.querySelector('img') as HTMLImageElement;
+    expect(img.src).toBe('https://example.com/photo.jpg');
+    expect(img.alt).toBe('User photo');
+    expect(img.style.display).toBe('block');
+  });
+
+  it('truncates fallback to 2 characters', () => {
+    const el = document.createElement('elx-avatar');
+    el.setAttribute('fallback', 'ABCDEF');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.fallback')!.textContent).toBe('AB');
+  });
+
+  it('applies xs size', () => {
+    const el = document.createElement('elx-avatar');
+    el.setAttribute('size', 'xs');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.avatar')!.classList.contains('xs')).toBe(true);
+  });
+
+  it('applies xl size', () => {
+    const el = document.createElement('elx-avatar');
+    el.setAttribute('size', 'xl');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.avatar')!.classList.contains('xl')).toBe(true);
+  });
+
+  it('ignores invalid size, defaults to md', () => {
+    const el = document.createElement('elx-avatar');
+    el.setAttribute('size', 'huge');
+    document.body.appendChild(el);
+    expect(el.size).toBe('md');
+  });
+
+  it('applies square shape', () => {
+    const el = document.createElement('elx-avatar');
+    el.setAttribute('shape', 'square');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.avatar')!.classList.contains('square')).toBe(true);
+  });
+
+  it('ignores invalid shape, defaults to circle', () => {
+    const el = document.createElement('elx-avatar');
+    el.setAttribute('shape', 'triangle');
+    document.body.appendChild(el);
+    expect(el.shape).toBe('circle');
+  });
+
+  it('preserves DOM reference across attribute updates', () => {
+    const el = document.createElement('elx-avatar');
+    document.body.appendChild(el);
+    const img1 = el.shadowRoot!.querySelector('img');
+    el.setAttribute('size', 'lg');
+    el.setAttribute('shape', 'square');
+    const img2 = el.shadowRoot!.querySelector('img');
+    expect(img1).toBe(img2);
+  });
+
+  it('shows fallback on image error', () => {
+    const el = document.createElement('elx-avatar');
+    el.setAttribute('src', 'bad.jpg');
+    el.setAttribute('fallback', 'FB');
+    document.body.appendChild(el);
+    const img = el.shadowRoot!.querySelector('img') as HTMLImageElement;
+    img.dispatchEvent(new Event('error'));
+    const fb = el.shadowRoot!.querySelector('.fallback') as HTMLElement;
+    expect(fb.style.display).toBe('flex');
+    expect(img.style.display).toBe('none');
+  });
+});

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -4,8 +4,6 @@ const VALID_SHAPES = ['circle', 'square'] as const;
 type Size = typeof VALID_SIZES[number];
 type Shape = typeof VALID_SHAPES[number];
 
-const SIZE_MAP: Record<Size, number> = { xs: 24, sm: 32, md: 40, lg: 48, xl: 64 };
-
 export class ElxAvatar extends HTMLElement {
   static observedAttributes = ['src', 'alt', 'fallback', 'size', 'shape'];
 

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -1,0 +1,146 @@
+const VALID_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+const VALID_SHAPES = ['circle', 'square'] as const;
+
+type Size = typeof VALID_SIZES[number];
+type Shape = typeof VALID_SHAPES[number];
+
+const SIZE_MAP: Record<Size, number> = { xs: 24, sm: 32, md: 40, lg: 48, xl: 64 };
+
+export class ElxAvatar extends HTMLElement {
+  static observedAttributes = ['src', 'alt', 'fallback', 'size', 'shape'];
+
+  private _img: HTMLImageElement | null = null;
+  private _fallback: HTMLSpanElement | null = null;
+  private _hasError = false;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() { this._buildDom(); this._update(); }
+  attributeChangedCallback() { this._update(); }
+
+  get src(): string { return this.getAttribute('src') ?? ''; }
+  set src(val: string) { this.setAttribute('src', val); }
+
+  get alt(): string { return this.getAttribute('alt') ?? ''; }
+  set alt(val: string) { this.setAttribute('alt', val); }
+
+  get fallback(): string { return this.getAttribute('fallback') ?? ''; }
+  set fallback(val: string) { this.setAttribute('fallback', val); }
+
+  get size(): Size {
+    const val = this.getAttribute('size');
+    return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
+  }
+  set size(val: string) { this.setAttribute('size', val); }
+
+  get shape(): Shape {
+    const val = this.getAttribute('shape');
+    return (VALID_SHAPES as readonly string[]).indexOf(val as string) !== -1 ? (val as Shape) : 'circle';
+  }
+  set shape(val: string) { this.setAttribute('shape', val); }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: inline-block; }
+
+      .avatar {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        background: #e5e7eb;
+        flex-shrink: 0;
+      }
+
+      .avatar.circle { border-radius: 50%; }
+      .avatar.square { border-radius: 4px; }
+
+      .avatar.xs { width: 24px; height: 24px; }
+      .avatar.sm { width: 32px; height: 32px; }
+      .avatar.md { width: 40px; height: 40px; }
+      .avatar.lg { width: 48px; height: 48px; }
+      .avatar.xl { width: 64px; height: 64px; }
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .fallback {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        color: #6b7280;
+        font-family: inherit;
+        font-weight: 500;
+        text-transform: uppercase;
+      }
+
+      .fallback.xs { font-size: 10px; }
+      .fallback.sm { font-size: 12px; }
+      .fallback.md { font-size: 14px; }
+      .fallback.lg { font-size: 16px; }
+      .fallback.xl { font-size: 20px; }
+    `;
+
+    const wrapper = document.createElement('span');
+    wrapper.className = 'avatar';
+
+    this._img = document.createElement('img');
+    this._img.addEventListener('error', () => this._handleError());
+
+    this._fallback = document.createElement('span');
+    this._fallback.className = 'fallback';
+
+    wrapper.appendChild(this._img);
+    wrapper.appendChild(this._fallback);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(wrapper);
+  }
+
+  private _update() {
+    if (!this._img) return;
+
+    const size = this.size;
+    const shape = this.shape;
+    const src = this.src;
+    const alt = this.alt;
+    const fb = this.fallback;
+
+    const wrapper = this.shadowRoot!.querySelector('.avatar') as HTMLElement;
+    wrapper.className = `avatar ${size} ${shape}`;
+
+    this._img.src = src;
+    this._img.alt = alt;
+
+    this._fallback!.className = `fallback ${size}`;
+    this._fallback!.textContent = fb.slice(0, 2);
+
+    if (!src || this._hasError) {
+      this._img.style.display = 'none';
+      this._fallback!.style.display = 'flex';
+    } else {
+      this._img.style.display = 'block';
+      this._fallback!.style.display = 'none';
+    }
+  }
+
+  private _handleError() {
+    this._hasError = true;
+    this._update();
+  }
+}
+
+if (!customElements.get('elx-avatar')) {
+  customElements.define('elx-avatar', ElxAvatar);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from './components/checkbox/checkbox';
 export * from './components/switch/switch';
 export * from './components/radio/radio';
 export * from './components/badge/badge';
+export * from './components/avatar/avatar';


### PR DESCRIPTION
## Summary
Adds `<elx-avatar>` component.

### Features
- 5 sizes: xs, sm, md, lg, xl
- 2 shapes: circle, square
- Image with graceful error fallback to initials
- Initials fallback (max 2 chars)

### Security
- Whitelist validation on size, shape
- DOM APIs only, guarded registration

### Tests
- 11 passing tests