### PR TITLE
feat: add elx-card component

### DIFF
--- a/src/components/card/card.stories.ts
+++ b/src/components/card/card.stories.ts
@@ -1,0 +1,49 @@
+import { html } from 'lit';
+import './card';
+
+export default {
+  title: 'Components/Card',
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: { type: 'select' }, options: ['elevated', 'outlined', 'filled'] },
+    padding: { control: { type: 'select' }, options: ['none', 'sm', 'md', 'lg'] },
+    interactive: { control: 'boolean' }
+  }
+};
+
+const Template = ({ variant, padding, interactive }: any) => html`
+  <elx-card variant=${variant} padding=${padding} ?interactive=${interactive}>
+    <h3 slot="header">Card Title</h3>
+    <p>This is the card content. It can contain any elements.</p>
+    <div slot="footer">Footer content</div>
+  </elx-card>
+`;
+
+export const Default = Template.bind({});
+(Default as any).args = { variant: 'elevated', padding: 'md', interactive: false };
+
+export const Outlined = Template.bind({});
+(Outlined as any).args = { variant: 'outlined', padding: 'md', interactive: false };
+
+export const Filled = Template.bind({});
+(Filled as any).args = { variant: 'filled', padding: 'md', interactive: false };
+
+export const Interactive = Template.bind({});
+(Interactive as any).args = { variant: 'elevated', padding: 'md', interactive: true };
+
+export const AllVariants = () => html`
+  <div style="display:flex;gap:16px;flex-direction:column;max-width:400px">
+    <elx-card variant="elevated">
+      <strong>Elevated</strong>
+      <p>Default shadow style</p>
+    </elx-card>
+    <elx-card variant="outlined">
+      <strong>Outlined</strong>
+      <p>Border only, no shadow</p>
+    </elx-card>
+    <elx-card variant="filled">
+      <strong>Filled</strong>
+      <p>Background color, no border</p>
+    </elx-card>
+  </div>
+`;

--- a/src/components/card/card.test.ts
+++ b/src/components/card/card.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './card';
+
+describe('elx-card', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-card')).toBeDefined();
+  });
+
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('renders with default props', () => {
+    const el = document.createElement('elx-card');
+    document.body.appendChild(el);
+    const card = el.shadowRoot!.querySelector('.card');
+    expect(card).toBeTruthy();
+    expect(card!.classList.contains('elevated')).toBe(true);
+    expect(card!.classList.contains('pad-md')).toBe(true);
+  });
+
+  it('applies outlined variant', () => {
+    const el = document.createElement('elx-card');
+    el.setAttribute('variant', 'outlined');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.card')!.classList.contains('outlined')).toBe(true);
+  });
+
+  it('applies filled variant', () => {
+    const el = document.createElement('elx-card');
+    el.setAttribute('variant', 'filled');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.card')!.classList.contains('filled')).toBe(true);
+  });
+
+  it('ignores invalid variant, defaults to elevated', () => {
+    const el = document.createElement('elx-card');
+    el.setAttribute('variant', 'fancy');
+    document.body.appendChild(el);
+    expect(el.variant).toBe('elevated');
+  });
+
+  it('applies padding sizes', () => {
+    const sizes = ['none', 'sm', 'md', 'lg'] as const;
+    sizes.forEach(size => {
+      const el = document.createElement('elx-card');
+      el.setAttribute('padding', size);
+      document.body.appendChild(el);
+      expect(el.shadowRoot!.querySelector('.card')!.classList.contains(`pad-${size}`)).toBe(true);
+    });
+  });
+
+  it('ignores invalid padding, defaults to md', () => {
+    const el = document.createElement('elx-card');
+    el.setAttribute('padding', 'xl');
+    document.body.appendChild(el);
+    expect(el.padding).toBe('md');
+  });
+
+  it('sets interactive attributes', () => {
+    const el = document.createElement('elx-card');
+    el.setAttribute('interactive', '');
+    document.body.appendChild(el);
+    expect(el.getAttribute('role')).toBe('button');
+    expect(el.getAttribute('tabindex')).toBe('0');
+    expect(el.shadowRoot!.querySelector('.card')!.classList.contains('interactive')).toBe(true);
+  });
+
+  it('removes interactive attributes when false', () => {
+    const el = document.createElement('elx-card');
+    el.setAttribute('interactive', '');
+    document.body.appendChild(el);
+    el.removeAttribute('interactive');
+    expect(el.getAttribute('role')).toBeNull();
+    expect(el.getAttribute('tabindex')).toBeNull();
+  });
+
+  it('renders slots for header, default, footer', () => {
+    const el = document.createElement('elx-card');
+    document.body.appendChild(el);
+    const slots = el.shadowRoot!.querySelectorAll('slot');
+    expect(slots.length).toBe(3);
+    expect(slots[0].name).toBe('header');
+    expect(slots[1].name).toBe('');
+    expect(slots[2].name).toBe('footer');
+  });
+
+  it('preserves DOM across attribute updates', () => {
+    const el = document.createElement('elx-card');
+    document.body.appendChild(el);
+    const card1 = el.shadowRoot!.querySelector('.card');
+    el.setAttribute('variant', 'outlined');
+    el.setAttribute('padding', 'lg');
+    const card2 = el.shadowRoot!.querySelector('.card');
+    expect(card1).toBe(card2);
+  });
+});

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -1,0 +1,120 @@
+const VALID_VARIANTS = ['elevated', 'outlined', 'filled'] as const;
+const VALID_PADDINGS = ['none', 'sm', 'md', 'lg'] as const;
+
+type Variant = typeof VALID_VARIANTS[number];
+type Padding = typeof VALID_PADDINGS[number];
+
+export class ElxCard extends HTMLElement {
+  static observedAttributes = ['variant', 'padding', 'interactive'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() { this._buildDom(); this._update(); }
+  attributeChangedCallback() { this._update(); }
+
+  get variant(): Variant {
+    const val = this.getAttribute('variant');
+    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1 ? (val as Variant) : 'elevated';
+  }
+  set variant(val: string) { this.setAttribute('variant', val); }
+
+  get padding(): Padding {
+    const val = this.getAttribute('padding');
+    return (VALID_PADDINGS as readonly string[]).indexOf(val as string) !== -1 ? (val as Padding) : 'md';
+  }
+  set padding(val: string) { this.setAttribute('padding', val); }
+
+  get interactive(): boolean { return this.hasAttribute('interactive'); }
+  set interactive(val: boolean) { val ? this.setAttribute('interactive', '') : this.removeAttribute('interactive'); }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: block; }
+
+      .card {
+        border-radius: 8px;
+        font-family: inherit;
+        transition: box-shadow 0.15s ease, transform 0.15s ease;
+      }
+
+      .card.elevated {
+        background: #fff;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08);
+      }
+      .card.outlined {
+        background: #fff;
+        border: 1px solid #e5e7eb;
+      }
+      .card.filled {
+        background: #f3f4f6;
+      }
+
+      .card.pad-none { padding: 0; }
+      .card.pad-sm { padding: 8px; }
+      .card.pad-md { padding: 16px; }
+      .card.pad-lg { padding: 24px; }
+
+      .card.interactive { cursor: pointer; }
+      .card.interactive:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        transform: translateY(-1px);
+      }
+      .card.interactive:active {
+        transform: translateY(0);
+      }
+
+      :host(:focus-visible) .card.interactive {
+        outline: 2px solid #3b82f6;
+        outline-offset: 2px;
+      }
+
+      ::slotted([slot="header"]) {
+        margin-bottom: 8px;
+      }
+      ::slotted([slot="footer"]) {
+        margin-top: 12px;
+      }
+    `;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'card';
+
+    const headerSlot = document.createElement('slot');
+    headerSlot.name = 'header';
+
+    const defaultSlot = document.createElement('slot');
+
+    const footerSlot = document.createElement('slot');
+    footerSlot.name = 'footer';
+
+    wrapper.appendChild(headerSlot);
+    wrapper.appendChild(defaultSlot);
+    wrapper.appendChild(footerSlot);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(wrapper);
+  }
+
+  private _update() {
+    const wrapper = this.shadowRoot?.querySelector('.card');
+    if (!wrapper) return;
+
+    wrapper.className = `card ${this.variant} pad-${this.padding}${this.interactive ? ' interactive' : ''}`;
+
+    if (this.interactive) {
+      this.setAttribute('role', 'button');
+      this.setAttribute('tabindex', '0');
+    } else {
+      this.removeAttribute('role');
+      this.removeAttribute('tabindex');
+    }
+  }
+}
+
+if (!customElements.get('elx-card')) {
+  customElements.define('elx-card', ElxCard);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './components/switch/switch';
 export * from './components/radio/radio';
 export * from './components/badge/badge';
 export * from './components/avatar/avatar';
+export * from './components/card/card';


### PR DESCRIPTION
## Summary
Adds `<elx-card>` layout component.

### Features
- 3 variants: elevated, outlined, filled
- 4 padding sizes: none, sm, md, lg
- Interactive mode with hover/active effects
- Header, default, footer slots

### Security
- Whitelist validation on variant, padding
- DOM APIs only, guarded registration

### Tests
- 10 passing tests