### PR TITLE
feat: add elx-alert component

### DIFF
--- a/src/components/alert/alert.stories.ts
+++ b/src/components/alert/alert.stories.ts
@@ -1,0 +1,41 @@
+import { html } from 'lit';
+import './alert';
+
+export default {
+  title: 'Components/Alert',
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: { type: 'select' }, options: ['info', 'success', 'warning', 'error'] },
+    dismissible: { control: 'boolean' }
+  }
+};
+
+const Template = ({ variant, dismissible }: any) => html`
+  <elx-alert variant=${variant} ?dismissible=${dismissible}>
+    This is an ${variant} alert message.
+  </elx-alert>
+`;
+
+export const Info = Template.bind({});
+(Info as any).args = { variant: 'info', dismissible: false };
+
+export const Success = Template.bind({});
+(Success as any).args = { variant: 'success', dismissible: false };
+
+export const Warning = Template.bind({});
+(Warning as any).args = { variant: 'warning', dismissible: false };
+
+export const Error = Template.bind({});
+(Error as any).args = { variant: 'error', dismissible: false };
+
+export const Dismissible = Template.bind({});
+(Dismissible as any).args = { variant: 'info', dismissible: true };
+
+export const AllVariants = () => html`
+  <div style="display:flex;flex-direction:column;gap:12px;max-width:400px">
+    <elx-alert variant="info">Information message</elx-alert>
+    <elx-alert variant="success">Success message</elx-alert>
+    <elx-alert variant="warning">Warning message</elx-alert>
+    <elx-alert variant="error">Error message</elx-alert>
+  </div>
+`;

--- a/src/components/alert/alert.test.ts
+++ b/src/components/alert/alert.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './alert';
+
+describe('elx-alert', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-alert')).toBeDefined();
+  });
+
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('renders with default variant (info)', () => {
+    const el = document.createElement('elx-alert');
+    document.body.appendChild(el);
+    const alert = el.shadowRoot!.querySelector('.alert');
+    expect(alert!.classList.contains('info')).toBe(true);
+  });
+
+  it('applies success variant', () => {
+    const el = document.createElement('elx-alert');
+    el.setAttribute('variant', 'success');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.alert')!.classList.contains('success')).toBe(true);
+  });
+
+  it('applies warning variant', () => {
+    const el = document.createElement('elx-alert');
+    el.setAttribute('variant', 'warning');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.alert')!.classList.contains('warning')).toBe(true);
+  });
+
+  it('applies error variant', () => {
+    const el = document.createElement('elx-alert');
+    el.setAttribute('variant', 'error');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.alert')!.classList.contains('error')).toBe(true);
+  });
+
+  it('ignores invalid variant, defaults to info', () => {
+    const el = document.createElement('elx-alert');
+    el.setAttribute('variant', 'critical');
+    document.body.appendChild(el);
+    expect(el.variant).toBe('info');
+  });
+
+  it('shows close button when dismissible', () => {
+    const el = document.createElement('elx-alert');
+    el.setAttribute('dismissible', '');
+    document.body.appendChild(el);
+    const btn = el.shadowRoot!.querySelector('.close-btn') as HTMLButtonElement;
+    expect(btn.style.display).toBe('block');
+  });
+
+  it('hides close button when not dismissible', () => {
+    const el = document.createElement('elx-alert');
+    document.body.appendChild(el);
+    const btn = el.shadowRoot!.querySelector('.close-btn') as HTMLButtonElement;
+    expect(btn.style.display).toBe('none');
+  });
+
+  it('fires close event and removes on dismiss click', () => {
+    const el = document.createElement('elx-alert');
+    el.setAttribute('dismissible', '');
+    document.body.appendChild(el);
+    let fired = false;
+    el.addEventListener('close', () => { fired = true; });
+    const btn = el.shadowRoot!.querySelector('.close-btn') as HTMLButtonElement;
+    btn.click();
+    expect(fired).toBe(true);
+    expect(document.body.contains(el)).toBe(false);
+  });
+
+  it('renders slot content', () => {
+    const el = document.createElement('elx-alert');
+    el.innerHTML = '<span id="msg">Alert message</span>';
+    document.body.appendChild(el);
+    const slot = el.shadowRoot!.querySelector('slot') as HTMLSlotElement;
+    expect(slot).toBeTruthy();
+  });
+
+  it('shows correct icon for each variant', () => {
+    const icons: Record<string, string> = { info: 'ℹ️', success: '✓', warning: '⚠', error: '✕' };
+    Object.entries(icons).forEach(([variant, icon]) => {
+      const el = document.createElement('elx-alert');
+      el.setAttribute('variant', variant);
+      document.body.appendChild(el);
+      const iconEl = el.shadowRoot!.querySelector('.icon') as HTMLElement;
+      expect(iconEl.textContent).toBe(icon);
+    });
+  });
+
+  it('preserves DOM across attribute updates', () => {
+    const el = document.createElement('elx-alert');
+    document.body.appendChild(el);
+    const alert1 = el.shadowRoot!.querySelector('.alert');
+    el.setAttribute('variant', 'error');
+    el.setAttribute('dismissible', '');
+    const alert2 = el.shadowRoot!.querySelector('.alert');
+    expect(alert1).toBe(alert2);
+  });
+});

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -1,0 +1,122 @@
+const VALID_VARIANTS = ['info', 'success', 'warning', 'error'] as const;
+
+type Variant = typeof VALID_VARIANTS[number];
+
+const ICONS: Record<Variant, string> = {
+  info: 'ℹ️',
+  success: '✓',
+  warning: '⚠',
+  error: '✕'
+};
+
+export class ElxAlert extends HTMLElement {
+  static observedAttributes = ['variant', 'dismissible'];
+
+  private _closeBtn: HTMLButtonElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() { this._buildDom(); this._update(); }
+  disconnectedCallback() { this._closeBtn?.removeEventListener('click', this._onClose); }
+
+  attributeChangedCallback() { this._update(); }
+
+  get variant(): Variant {
+    const val = this.getAttribute('variant');
+    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1 ? (val as Variant) : 'info';
+  }
+  set variant(val: string) { this.setAttribute('variant', val); }
+
+  get dismissible(): boolean { return this.hasAttribute('dismissible'); }
+  set dismissible(val: boolean) { val ? this.setAttribute('dismissible', '') : this.removeAttribute('dismissible'); }
+
+  private _onClose = () => {
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+    this.remove();
+  };
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: block; }
+
+      .alert {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 12px 16px;
+        border-radius: 6px;
+        font-family: inherit;
+        font-size: 14px;
+      }
+
+      .alert.info { background: #eff6ff; border: 1px solid #bfdbfe; color: #1e40af; }
+      .alert.success { background: #ecfdf5; border: 1px solid #a7f3d0; color: #065f46; }
+      .alert.warning { background: #fffbeb; border: 1px solid #fde68a; color: #92400e; }
+      .alert.error { background: #fef2f2; border: 1px solid #fecaca; color: #991b1b; }
+
+      .icon { flex-shrink: 0; font-size: 16px; line-height: 1; }
+      .content { flex: 1; min-width: 0; }
+      .close-btn {
+        flex-shrink: 0;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        font-size: 16px;
+        line-height: 1;
+        opacity: 0.6;
+        color: inherit;
+      }
+      .close-btn:hover { opacity: 1; }
+    `;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'alert';
+
+    const icon = document.createElement('span');
+    icon.className = 'icon';
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    const slot = document.createElement('slot');
+    content.appendChild(slot);
+
+    this._closeBtn = document.createElement('button');
+    this._closeBtn.className = 'close-btn';
+    this._closeBtn.type = 'button';
+    this._closeBtn.setAttribute('aria-label', 'Dismiss alert');
+    this._closeBtn.addEventListener('click', this._onClose);
+
+    wrapper.appendChild(icon);
+    wrapper.appendChild(content);
+    wrapper.appendChild(this._closeBtn);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(wrapper);
+  }
+
+  private _update() {
+    const wrapper = this.shadowRoot?.querySelector('.alert');
+    const icon = this.shadowRoot?.querySelector('.icon');
+    if (!wrapper || !icon) return;
+
+    const variant = this.variant;
+    wrapper.className = `alert ${variant}`;
+    icon.textContent = ICONS[variant];
+
+    if (this.dismissible) {
+      this._closeBtn!.style.display = 'block';
+      this._closeBtn!.textContent = '✕';
+    } else {
+      this._closeBtn!.style.display = 'none';
+    }
+  }
+}
+
+if (!customElements.get('elx-alert')) {
+  customElements.define('elx-alert', ElxAlert);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from './components/radio/radio';
 export * from './components/badge/badge';
 export * from './components/avatar/avatar';
 export * from './components/card/card';
+export * from './components/alert/alert';


### PR DESCRIPTION
## Summary
Adds `<elx-alert>` component.

### Features
- 4 variants: info, success, warning, error with color-coded styles
- Dismissible mode with close button
- Fires `close` event and self-removes on dismiss
- Icon per variant

### Security
- Whitelist validation on variant
- DOM APIs only, guarded registration

### Tests
- 11 passing tests