### PR TITLE
feat: add elx-dialog component

### DIFF
--- a/src/components/dialog/dialog.stories.ts
+++ b/src/components/dialog/dialog.stories.ts
@@ -1,0 +1,32 @@
+import { html } from 'lit';
+import './dialog';
+
+export default {
+  title: 'Components/Dialog',
+  tags: ['autodocs'],
+};
+
+const showDialog = (id: string) => {
+  const dialog = document.querySelector(id) as any;
+  dialog?.show();
+};
+
+export const Default = () => html`
+  <elx-button onclick="document.querySelector('#dialog1').show()">Open Dialog</elx-button>
+  <elx-dialog id="dialog1">
+    <span slot="title">Dialog Title</span>
+    <p>This is the dialog content. You can put anything here.</p>
+    <div slot="footer">
+      <elx-button variant="ghost" onclick="document.querySelector('#dialog1').close()">Cancel</elx-button>
+      <elx-button onclick="document.querySelector('#dialog1').close()">Confirm</elx-button>
+    </div>
+  </elx-dialog>
+`;
+
+export const Simple = () => html`
+  <elx-button onclick="document.querySelector('#dialog2').show()">Simple Dialog</elx-button>
+  <elx-dialog id="dialog2">
+    <span slot="title">Information</span>
+    <p>A simple dialog with just a message and close button.</p>
+  </elx-dialog>
+`;

--- a/src/components/dialog/dialog.test.ts
+++ b/src/components/dialog/dialog.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './dialog';
+
+describe('elx-dialog', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-dialog')).toBeDefined();
+  });
+
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('renders with overlay and dialog', () => {
+    const el = document.createElement('elx-dialog');
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('.overlay')).toBeTruthy();
+    expect(el.shadowRoot!.querySelector('.dialog')).toBeTruthy();
+  });
+
+  it('is hidden by default', () => {
+    const el = document.createElement('elx-dialog');
+    document.body.appendChild(el);
+    const overlay = el.shadowRoot!.querySelector('.overlay') as HTMLElement;
+    expect(overlay.classList.contains('open')).toBe(false);
+  });
+
+  it('shows when open attribute is set', () => {
+    const el = document.createElement('elx-dialog');
+    el.setAttribute('open', '');
+    document.body.appendChild(el);
+    const overlay = el.shadowRoot!.querySelector('.overlay') as HTMLElement;
+    expect(overlay.classList.contains('open')).toBe(true);
+  });
+
+  it('show() method opens dialog', () => {
+    const el = document.createElement('elx-dialog');
+    document.body.appendChild(el);
+    (el as any).show();
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  it('close() method closes dialog', () => {
+    const el = document.createElement('elx-dialog');
+    el.setAttribute('open', '');
+    document.body.appendChild(el);
+    (el as any).close();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('fires close event on close()', () => {
+    const el = document.createElement('elx-dialog');
+    el.setAttribute('open', '');
+    document.body.appendChild(el);
+    let fired = false;
+    el.addEventListener('close', () => { fired = true; });
+    (el as any).close();
+    expect(fired).toBe(true);
+  });
+
+  it('closes on overlay click', () => {
+    const el = document.createElement('elx-dialog');
+    el.setAttribute('open', '');
+    document.body.appendChild(el);
+    const overlay = el.shadowRoot!.querySelector('.overlay') as HTMLElement;
+    overlay.click();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('does not close when clicking dialog content', () => {
+    const el = document.createElement('elx-dialog');
+    el.setAttribute('open', '');
+    document.body.appendChild(el);
+    const dialog = el.shadowRoot!.querySelector('.dialog') as HTMLElement;
+    dialog.click();
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  it('closes on Escape key', () => {
+    const el = document.createElement('elx-dialog');
+    el.setAttribute('open', '');
+    document.body.appendChild(el);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('has role=dialog and aria-modal', () => {
+    const el = document.createElement('elx-dialog');
+    document.body.appendChild(el);
+    const dialog = el.shadowRoot!.querySelector('.dialog') as HTMLElement;
+    expect(dialog.getAttribute('role')).toBe('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('renders title, content, and footer slots', () => {
+    const el = document.createElement('elx-dialog');
+    document.body.appendChild(el);
+    const slots = el.shadowRoot!.querySelectorAll('slot');
+    expect(slots.length).toBe(3);
+    expect(slots[0].name).toBe('title');
+    expect(slots[1].name).toBe('');
+    expect(slots[2].name).toBe('footer');
+  });
+
+  it('close button has aria-label', () => {
+    const el = document.createElement('elx-dialog');
+    document.body.appendChild(el);
+    const btn = el.shadowRoot!.querySelector('.close-btn') as HTMLButtonElement;
+    expect(btn.getAttribute('aria-label')).toBe('Close dialog');
+  });
+});

--- a/src/components/dialog/dialog.ts
+++ b/src/components/dialog/dialog.ts
@@ -1,0 +1,208 @@
+export class ElxDialog extends HTMLElement {
+  static observedAttributes = ['open'];
+
+  private _previousActive: HTMLElement | null = null;
+  private _focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() { this._buildDom(); this._update(); }
+  disconnectedCallback() { this._restoreFocus(); }
+
+  attributeChangedCallback() { this._update(); }
+
+  get open(): boolean { return this.hasAttribute('open'); }
+  set open(val: boolean) {
+    val ? this.setAttribute('open', '') : this.removeAttribute('open');
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: contents; }
+
+      .overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.5);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.2s ease, visibility 0.2s ease;
+      }
+
+      .overlay.open {
+        opacity: 1;
+        visibility: visible;
+      }
+
+      .dialog {
+        background: #fff;
+        border-radius: 8px;
+        box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1), 0 10px 10px -5px rgba(0,0,0,0.04);
+        max-width: 90vw;
+        max-height: 90vh;
+        overflow: auto;
+        font-family: inherit;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px;
+        border-bottom: 1px solid #e5e7eb;
+      }
+
+      .title {
+        font-size: 18px;
+        font-weight: 600;
+        margin: 0;
+      }
+
+      .close-btn {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: 4px;
+        font-size: 20px;
+        line-height: 1;
+        color: #6b7280;
+      }
+      .close-btn:hover { color: #111; }
+
+      .content { padding: 16px; }
+      .footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        padding: 16px;
+        border-top: 1px solid #e5e7eb;
+      }
+    `;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'overlay';
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) this.close();
+    });
+
+    const dialog = document.createElement('div');
+    dialog.className = 'dialog';
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+
+    const header = document.createElement('div');
+    header.className = 'header';
+
+    const title = document.createElement('h2');
+    title.className = 'title';
+    const titleSlot = document.createElement('slot');
+    titleSlot.name = 'title';
+    title.appendChild(titleSlot);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'close-btn';
+    closeBtn.type = 'button';
+    closeBtn.setAttribute('aria-label', 'Close dialog');
+    closeBtn.textContent = '✕';
+    closeBtn.addEventListener('click', () => this.close());
+
+    header.appendChild(title);
+    header.appendChild(closeBtn);
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    const defaultSlot = document.createElement('slot');
+    content.appendChild(defaultSlot);
+
+    const footer = document.createElement('div');
+    footer.className = 'footer';
+    const footerSlot = document.createElement('slot');
+    footerSlot.name = 'footer';
+    footer.appendChild(footerSlot);
+
+    dialog.appendChild(header);
+    dialog.appendChild(content);
+    dialog.appendChild(footer);
+    overlay.appendChild(dialog);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(overlay);
+
+    document.addEventListener('keydown', this._onKeydown);
+  }
+
+  private _update() {
+    const overlay = this.shadowRoot?.querySelector('.overlay');
+    if (!overlay) return;
+
+    if (this.open) {
+      overlay.classList.add('open');
+      this._trapFocus();
+    } else {
+      overlay.classList.remove('open');
+      this._restoreFocus();
+    }
+  }
+
+  private _onKeydown = (e: KeyboardEvent) => {
+    if (!this.open) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.close();
+    }
+    if (e.key === 'Tab') {
+      this._handleTab(e);
+    }
+  };
+
+  private _handleTab(e: KeyboardEvent) {
+    const dialog = this.shadowRoot!.querySelector('.dialog') as HTMLElement;
+    const focusables = dialog.querySelectorAll<HTMLElement>(this._focusableSelector);
+    if (focusables.length === 0) return;
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  private _trapFocus() {
+    this._previousActive = document.activeElement as HTMLElement;
+    const dialog = this.shadowRoot!.querySelector('.dialog') as HTMLElement;
+    const firstFocusable = dialog.querySelector<HTMLElement>(this._focusableSelector);
+    if (firstFocusable) {
+      firstFocusable.focus();
+    }
+  }
+
+  private _restoreFocus() {
+    if (this._previousActive) {
+      this._previousActive.focus();
+      this._previousActive = null;
+    }
+  }
+
+  public show() { this.open = true; }
+  public close() {
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+  }
+}
+
+if (!customElements.get('elx-dialog')) {
+  customElements.define('elx-dialog', ElxDialog);
+}

--- a/src/components/dialog/dialog.ts
+++ b/src/components/dialog/dialog.ts
@@ -10,7 +10,10 @@ export class ElxDialog extends HTMLElement {
   }
 
   connectedCallback() { this._buildDom(); this._update(); }
-  disconnectedCallback() { this._restoreFocus(); }
+  disconnectedCallback() {
+    this._restoreFocus();
+    document.removeEventListener('keydown', this._onKeydown);
+  }
 
   attributeChangedCallback() { this._update(); }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from './components/badge/badge';
 export * from './components/avatar/avatar';
 export * from './components/card/card';
 export * from './components/alert/alert';
+export * from './components/dialog/dialog';


### PR DESCRIPTION
## Summary
Adds `<elx-dialog>` modal component.

### Features
- Modal overlay with backdrop click to close
- Focus trap and Escape key support
- Title, content, footer slots
- show()/close() API with close event

### Accessibility
- role=dialog, aria-modal=true
- Focus trap with Tab cycling
- Close button with aria-label
- Escape key dismissal

### Security
- DOM APIs only, guarded registration

### Tests
- 12 passing tests