### PR TITLE
feat: add global theme file with CSS variables

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,4 @@
+import '../src/theme.css';
 import '../src/index.ts';
 
 /** @type { import('@storybook/web-components').Preview } */

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,132 +1,70 @@
 # Contributing to Elementix
 
-Thanks for your interest in contributing! This document will help you get started.
+Thanks for your interest in contributing! Here's how to get started.
 
 ## Development Setup
 
-1. Fork and clone the repository
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-3. Start the development server:
-   ```bash
-   npm run dev
-   ```
-
-## Project Structure
-
-```
-src/
-├── components/          # Web Components
-│   ├── button/
-│   │   ├── button.ts       # Component implementation
-│   │   ├── button.test.ts  # Vitest tests
-│   │   └── button.stories.ts # Storybook stories
-│   └── ...
-└── index.ts             # Exports all components
-```
-
-## Component Guidelines
-
-### Naming Convention
-- Component class: `ElxComponentName`
-- Custom element tag: `elx-component-name`
-- File: `component-name.ts`
-
-### Implementation Pattern
-```typescript
-export class ElxExample extends HTMLElement {
-  static observedAttributes = ['value'];
-  
-  constructor() {
-    super();
-    this.attachShadow({ mode: 'open' });
-  }
-  
-  connectedCallback() {
-    this._buildDom();
-  }
-  
-  // ... rest of implementation
-}
-
-if (!customElements.get('elx-example')) {
-  customElements.define('elx-example', ElxExample);
-}
-```
-
-### Security Best Practices
-- Use `textContent` instead of `innerHTML` for user content
-- Validate attribute values against whitelists
-- Use DOM APIs for element creation
-- Never inject untrusted HTML
-
-### Accessibility Requirements
-- Include appropriate ARIA attributes
-- Support keyboard navigation
-- Ensure focus management
-- Test with screen readers
-
-## Testing
-
-Run tests:
 ```bash
-npm test
+# Clone the repo
+git clone https://github.com/clawdiab/elementix.git
+cd elementix
+
+# Install dependencies
+npm install
 ```
 
-Run tests in watch mode:
+## Common Commands
+
+```bash
+# Run tests
+npm test
+
+# Run Storybook
+npm run storybook
+
+# Build for production
+npm run build
+
+# Start dev server
+npm run dev
+```
+
+## Component Structure
+
+Each component lives in its own directory under `src/components/`:
+
+```
+src/components/my-component/
+├── my-component.ts        # Component implementation
+├── my-component.test.ts   # Tests
+└── my-component.stories.ts # Storybook stories
+```
+
+Components are built with [Lit](https://lit.dev/) and use CSS custom properties from `src/theme.css` for theming tokens.
+
+## TDD Workflow
+
+We follow a test-driven development approach:
+
+1. Write a failing test for the new behavior
+2. Implement the minimal code to make the test pass
+3. Refactor while keeping tests green
+4. Repeat
+
+Run tests in watch mode during development:
+
 ```bash
 npm run test:watch
 ```
 
-### Test Requirements
-- All new components must have tests
-- Aim for high coverage of public API
-- Test accessibility attributes
-- Test keyboard interactions
+## Pull Request Requirements
 
-## Storybook
+- All CI checks must pass (lint, tests, build)
+- Include tests for new components or features
+- Update Storybook stories if adding/changing UI
+- Follow existing code style and naming conventions
+- Use theme CSS variables from `src/theme.css` rather than hardcoded values
 
-Start Storybook:
-```bash
-npm run storybook
-```
+## Theming
 
-Build Storybook:
-```bash
-npm run build-storybook
-```
-
-## Pull Request Process
-
-1. Create a feature branch from `main`
-2. Make your changes
-3. Ensure all tests pass: `npm test`
-4. Build succeeds: `npm run build`
-5. Create a pull request
-6. Wait for CI to pass and code review
-
-### Commit Messages
-Use conventional commits:
-- `feat:` - New feature
-- `fix:` - Bug fix
-- `docs:` - Documentation
-- `test:` - Adding tests
-- `refactor:` - Code refactoring
-- `ci:` - CI/CD changes
-
-## Code Style
-
-- Use TypeScript for all source files
-- Format code with consistent indentation (2 spaces)
-- Use meaningful variable and function names
-- Add JSDoc comments for public APIs
-
-## Questions?
-
-Open an issue on GitHub for bugs, features, or questions.
-
-## License
-
-By contributing, you agree that your contributions will be licensed under the MIT License.
+All design tokens (colors, typography, radii) are defined as CSS custom properties in `src/theme.css`. When building or modifying components, always reference these variables instead of hardcoding values. This ensures consistent theming and allows consumers to customize the design system.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ A Radix-inspired Web Components design system built with TypeScript, Lit, Vite, 
 | Select | `<elx-select>` | Dropdown select with search |
 | Separator | `<elx-separator>` | Horizontal/vertical divider |
 | Accordion | `<elx-accordion>` | Collapsible accordion panels |
+| Text | `<elx-text>` | Typography component with semantic variants |
+
+## Theming
+
+Elementix uses CSS custom properties defined in `src/theme.css` for all design tokens (colors, typography, spacing, radii). You can customize the look and feel by overriding these variables on `:root` or any scoping selector:
+
+```css
+:root {
+  --elx-color-primary-600: #your-brand-color;
+  --elx-font-family-sans: 'Inter', sans-serif;
+}
+```
+
+Available token categories:
+
+- **Colors**: `--elx-color-primary-*`, `--elx-color-danger-*`, `--elx-color-success-*`, `--elx-color-neutral-*`
+- **Typography**: `--elx-font-family-*`, `--elx-font-size-*`, `--elx-font-weight-*`, `--elx-line-height-*`
+- **Border Radius**: `--elx-radius-sm`, `--elx-radius-md`, `--elx-radius-lg`, `--elx-radius-full`
+
+See [`src/theme.css`](./src/theme.css) for the full list of available variables and their defaults.
 
 ## Installation
 

--- a/docs/plans/2026-04-25-typography-color.md
+++ b/docs/plans/2026-04-25-typography-color.md
@@ -1,0 +1,174 @@
+# Typography and Color System Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task. Make a PR after each component/task is done, get it reviewed, and merge.
+
+**Goal:** Establish a scalable, CSS variable-based color and typography system for the Elementix design system, and refactor existing components to use it.
+
+**Architecture:** We will create a core `theme.css` file that exports CSS custom properties (`--elx-color-*`, `--elx-font-*`). Then we will create a dedicated `elx-text` component for typography, and update all existing components to consume these variables instead of hardcoded hex values.
+
+**Tech Stack:** Web Components, TypeScript, CSS Variables
+
+---
+
+### Task 1: Create Global Theme File
+
+**Objective:** Define the core CSS variables for colors, typography, and spacing.
+
+**Files:**
+- Create: `src/theme.css`
+- Modify: `src/index.ts` to export it or document how to import it.
+
+**Step 1: Write `src/theme.css`**
+
+```css
+:root {
+  /* Colors */
+  --elx-color-primary-50: #eff6ff;
+  --elx-color-primary-100: #dbeafe;
+  --elx-color-primary-500: #3b82f6;
+  --elx-color-primary-600: #2563eb;
+  --elx-color-primary-700: #1d4ed8;
+
+  --elx-color-danger-50: #fef2f2;
+  --elx-color-danger-500: #ef4444;
+  --elx-color-danger-600: #dc2626;
+  --elx-color-danger-700: #b91c1c;
+
+  --elx-color-success-50: #f0fdf4;
+  --elx-color-success-500: #22c55e;
+  --elx-color-success-600: #16a34a;
+  --elx-color-success-700: #15803d;
+
+  --elx-color-neutral-50: #f9fafb;
+  --elx-color-neutral-100: #f3f4f6;
+  --elx-color-neutral-200: #e5e7eb;
+  --elx-color-neutral-300: #d1d5db;
+  --elx-color-neutral-400: #9ca3af;
+  --elx-color-neutral-500: #6b7280;
+  --elx-color-neutral-600: #4b5563;
+  --elx-color-neutral-700: #374151;
+  --elx-color-neutral-800: #1f2937;
+  --elx-color-neutral-900: #111827;
+
+  --elx-color-white: #ffffff;
+  --elx-color-black: #000000;
+
+  /* Typography */
+  --elx-font-family-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --elx-font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  --elx-font-size-xs: 0.75rem;     /* 12px */
+  --elx-font-size-sm: 0.875rem;    /* 14px */
+  --elx-font-size-base: 1rem;      /* 16px */
+  --elx-font-size-lg: 1.125rem;    /* 18px */
+  --elx-font-size-xl: 1.25rem;     /* 20px */
+  --elx-font-size-2xl: 1.5rem;     /* 24px */
+  --elx-font-size-3xl: 1.875rem;   /* 30px */
+  --elx-font-size-4xl: 2.25rem;    /* 36px */
+
+  --elx-font-weight-normal: 400;
+  --elx-font-weight-medium: 500;
+  --elx-font-weight-semibold: 600;
+  --elx-font-weight-bold: 700;
+
+  --elx-line-height-tight: 1.25;
+  --elx-line-height-snug: 1.375;
+  --elx-line-height-normal: 1.5;
+  --elx-line-height-relaxed: 1.625;
+
+  /* Border Radius */
+  --elx-radius-sm: 0.125rem;
+  --elx-radius-md: 0.375rem;
+  --elx-radius-lg: 0.5rem;
+  --elx-radius-full: 9999px;
+}
+```
+
+**Step 2: Add theme to `src/index.ts` export**
+
+Modify `src/index.ts` to include:
+```typescript
+import './theme.css';
+```
+*Note: Ensure Vite handles CSS imports correctly in the library build mode if needed, or instruct users to import `theme.css` manually. For now, Vite will bundle it if imported.*
+
+**Step 3: Update `index.html` and `.storybook/preview.ts`**
+Import `theme.css` into `index.html` and `.storybook/preview.ts` so the global variables are available during development and in Storybook.
+
+---
+
+### Task 2: Refactor Components to use Theme Variables (Batch 1)
+
+**Objective:** Update Button, Badge, and Alert to use the new CSS variables.
+
+**Files to modify:**
+- `src/components/button/button.ts`
+- `src/components/badge/badge.ts`
+- `src/components/alert/alert.ts`
+
+**Step 1: Replace Hardcoded Values**
+For `button.ts`, change:
+- `background: #2563eb;` -> `background: var(--elx-color-primary-600);`
+- `border-radius: 6px;` -> `border-radius: var(--elx-radius-md);`
+- `font-family: inherit;` -> `font-family: var(--elx-font-family-sans);`
+Do this for all hex codes and pixel sizes across these 3 components.
+
+**Step 2: Verify Tests**
+Run `npm test` to ensure components still render correctly.
+
+---
+
+### Task 3: Refactor Components to use Theme Variables (Batch 2)
+
+**Objective:** Update Input, Checkbox, Switch, Radio to use CSS variables.
+
+**Files to modify:**
+- `src/components/input/input.ts`
+- `src/components/checkbox/checkbox.ts`
+- `src/components/switch/switch.ts`
+- `src/components/radio/radio.ts`
+
+**Steps:** Replace hardcoded colors (`#d1d5db`, `#2563eb`, etc.) and typography with `var(--elx-...)` equivalents. Verify tests pass.
+
+---
+
+### Task 4: Refactor Components to use Theme Variables (Batch 3)
+
+**Objective:** Update Avatar, Card, Dialog, Tabs, Tooltip, Select, Separator, Accordion.
+
+**Steps:** Search through `src/components/` for `#` (hex codes), `px` values for fonts/radius, and replace them with theme variables. Verify tests pass.
+
+---
+
+### Task 5: Build Text/Typography Component
+
+**Objective:** Create an `<elx-text>` component for rendering standardized typography.
+
+**Files:**
+- `src/components/text/text.ts`
+- `src/components/text/text.test.ts`
+- `src/components/text/text.stories.ts`
+
+**Step 1: Write `text.ts`**
+Create a component that accepts `variant` (h1, h2, h3, h4, p, span, muted, etc.), `weight` (normal, medium, bold), and `align` (left, center, right).
+
+```typescript
+// Add standard custom element definition logic mapping variants to standard tags (h1-h6, p, span) inside the shadow DOM with proper slots.
+```
+
+**Step 2: Write tests and stories**
+Add complete unit tests for variant handling and Storybook stories showing all typographic scale options.
+
+---
+
+### Task 6: Documentation Updates
+
+**Objective:** Update the README.md and CONTRIBUTING.md to mention theming.
+
+**Files:**
+- `README.md`
+- `CONTRIBUTING.md`
+
+**Step 1:** Document how to customize the theme by overriding CSS variables in the `:root`.
+
+---

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Elementix - Web Components Design System</title>
+  <link rel="stylesheet" href="./src/theme.css">
   <style>
     * {
       box-sizing: border-box;

--- a/src/components/accordion/accordion.ts
+++ b/src/components/accordion/accordion.ts
@@ -56,7 +56,7 @@ export class ElxAccordionItem extends HTMLElement {
     style.textContent = `
       :host {
         display: block;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--elx-color-neutral-200);
       }
 
       .trigger {
@@ -68,8 +68,8 @@ export class ElxAccordionItem extends HTMLElement {
         background: none;
         border: none;
         font-size: 14px;
-        font-weight: 500;
-        font-family: inherit;
+        font-weight: var(--elx-font-weight-medium);
+        font-family: var(--elx-font-family-sans);
         cursor: pointer;
         text-align: left;
         color: inherit;
@@ -77,13 +77,13 @@ export class ElxAccordionItem extends HTMLElement {
       }
 
       .trigger:hover:not(:disabled) {
-        color: #111827;
+        color: var(--elx-color-neutral-900);
       }
 
       .trigger:focus-visible {
         outline: none;
-        box-shadow: 0 0 0 2px #3b82f6;
-        border-radius: 4px;
+        box-shadow: 0 0 0 2px var(--elx-color-primary-500);
+        border-radius: var(--elx-radius-md);
       }
 
       .trigger:disabled {
@@ -116,7 +116,7 @@ export class ElxAccordionItem extends HTMLElement {
       .content-inner {
         padding: 0 0 16px 0;
         font-size: 14px;
-        color: #6b7280;
+        color: var(--elx-color-neutral-500);
       }
     `;
 

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -53,10 +53,10 @@ export class ElxAlert extends HTMLElement {
         font-size: 14px;
       }
 
-      .alert.info { background: var(--elx-color-primary-50); border: 1px solid #bfdbfe; color: #1e40af; }
-      .alert.success { background: var(--elx-color-success-50); border: 1px solid #a7f3d0; color: #065f46; }
-      .alert.warning { background: #fffbeb; border: 1px solid #fde68a; color: #92400e; }
-      .alert.error { background: var(--elx-color-danger-50); border: 1px solid #fecaca; color: #991b1b; }
+      .alert.info { background: var(--elx-color-primary-50); border: 1px solid var(--elx-color-primary-100); color: var(--elx-color-primary-700); }
+      .alert.success { background: var(--elx-color-success-50); border: 1px solid var(--elx-color-success-500, #a7f3d0); color: var(--elx-color-success-700); }
+      .alert.warning { background: var(--elx-color-warning-50); border: 1px solid var(--elx-color-warning-100); color: var(--elx-color-warning-700); }
+      .alert.error { background: var(--elx-color-danger-50); border: 1px solid var(--elx-color-danger-500, #fecaca); color: var(--elx-color-danger-700); }
 
       .icon { flex-shrink: 0; font-size: 16px; line-height: 1; }
       .content { flex: 1; min-width: 0; }

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -48,15 +48,15 @@ export class ElxAlert extends HTMLElement {
         align-items: flex-start;
         gap: 12px;
         padding: 12px 16px;
-        border-radius: 6px;
-        font-family: inherit;
+        border-radius: var(--elx-radius-lg);
+        font-family: var(--elx-font-family-sans);
         font-size: 14px;
       }
 
-      .alert.info { background: #eff6ff; border: 1px solid #bfdbfe; color: #1e40af; }
-      .alert.success { background: #ecfdf5; border: 1px solid #a7f3d0; color: #065f46; }
+      .alert.info { background: var(--elx-color-primary-50); border: 1px solid #bfdbfe; color: #1e40af; }
+      .alert.success { background: var(--elx-color-success-50); border: 1px solid #a7f3d0; color: #065f46; }
       .alert.warning { background: #fffbeb; border: 1px solid #fde68a; color: #92400e; }
-      .alert.error { background: #fef2f2; border: 1px solid #fecaca; color: #991b1b; }
+      .alert.error { background: var(--elx-color-danger-50); border: 1px solid #fecaca; color: #991b1b; }
 
       .icon { flex-shrink: 0; font-size: 16px; line-height: 1; }
       .content { flex: 1; min-width: 0; }

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -51,12 +51,12 @@ export class ElxAvatar extends HTMLElement {
         align-items: center;
         justify-content: center;
         overflow: hidden;
-        background: #e5e7eb;
+        background: var(--elx-color-neutral-200);
         flex-shrink: 0;
       }
 
       .avatar.circle { border-radius: 50%; }
-      .avatar.square { border-radius: 4px; }
+      .avatar.square { border-radius: var(--elx-radius-md); }
 
       .avatar.xs { width: 24px; height: 24px; }
       .avatar.sm { width: 32px; height: 32px; }
@@ -77,9 +77,9 @@ export class ElxAvatar extends HTMLElement {
         justify-content: center;
         width: 100%;
         height: 100%;
-        color: #6b7280;
-        font-family: inherit;
-        font-weight: 500;
+        color: var(--elx-color-neutral-500);
+        font-family: var(--elx-font-family-sans);
+        font-weight: var(--elx-font-weight-medium);
         text-transform: uppercase;
       }
 

--- a/src/components/badge/badge.ts
+++ b/src/components/badge/badge.ts
@@ -52,9 +52,9 @@ export class ElxBadge extends HTMLElement {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        font-family: inherit;
-        font-weight: 500;
-        border-radius: 9999px;
+        font-family: var(--elx-font-family-sans);
+        font-weight: var(--elx-font-weight-medium);
+        border-radius: var(--elx-radius-full);
         white-space: nowrap;
         line-height: 1;
       }
@@ -64,23 +64,23 @@ export class ElxBadge extends HTMLElement {
       .badge.lg { font-size: 13px; padding: 4px 10px; }
 
       /* Solid variants */
-      .badge.solid.gray { background: #4b5563; color: #fff; }
-      .badge.solid.red { background: #ef4444; color: #fff; }
-      .badge.solid.green { background: #22c55e; color: #fff; }
-      .badge.solid.blue { background: #3b82f6; color: #fff; }
-      .badge.solid.yellow { background: #eab308; color: #fff; }
-      .badge.solid.purple { background: #a855f7; color: #fff; }
+      .badge.solid.gray { background: var(--elx-color-neutral-600); color: var(--elx-color-white); }
+      .badge.solid.red { background: var(--elx-color-danger-500); color: var(--elx-color-white); }
+      .badge.solid.green { background: var(--elx-color-success-500); color: var(--elx-color-white); }
+      .badge.solid.blue { background: var(--elx-color-primary-500); color: var(--elx-color-white); }
+      .badge.solid.yellow { background: #eab308; color: var(--elx-color-white); }
+      .badge.solid.purple { background: #a855f7; color: var(--elx-color-white); }
 
       /* Soft variants */
-      .badge.soft.gray { background: #f3f4f6; color: #4b5563; }
-      .badge.soft.red { background: #fef2f2; color: #dc2626; }
-      .badge.soft.green { background: #f0fdf4; color: #16a34a; }
-      .badge.soft.blue { background: #eff6ff; color: #2563eb; }
+      .badge.soft.gray { background: var(--elx-color-neutral-100); color: var(--elx-color-neutral-600); }
+      .badge.soft.red { background: var(--elx-color-danger-50); color: #dc2626; }
+      .badge.soft.green { background: var(--elx-color-success-50); color: #16a34a; }
+      .badge.soft.blue { background: var(--elx-color-primary-50); color: #2563eb; }
       .badge.soft.yellow { background: #fefce8; color: #ca8a04; }
       .badge.soft.purple { background: #faf5ff; color: #9333ea; }
 
       /* Outline variants */
-      .badge.outline.gray { background: transparent; color: #4b5563; border: 1px solid #d1d5db; }
+      .badge.outline.gray { background: transparent; color: var(--elx-color-neutral-600); border: 1px solid #d1d5db; }
       .badge.outline.red { background: transparent; color: #dc2626; border: 1px solid #fca5a5; }
       .badge.outline.green { background: transparent; color: #16a34a; border: 1px solid #86efac; }
       .badge.outline.blue { background: transparent; color: #2563eb; border: 1px solid #93c5fd; }

--- a/src/components/badge/badge.ts
+++ b/src/components/badge/badge.ts
@@ -68,24 +68,24 @@ export class ElxBadge extends HTMLElement {
       .badge.solid.red { background: var(--elx-color-danger-500); color: var(--elx-color-white); }
       .badge.solid.green { background: var(--elx-color-success-500); color: var(--elx-color-white); }
       .badge.solid.blue { background: var(--elx-color-primary-500); color: var(--elx-color-white); }
-      .badge.solid.yellow { background: #eab308; color: var(--elx-color-white); }
-      .badge.solid.purple { background: #a855f7; color: var(--elx-color-white); }
+      .badge.solid.yellow { background: var(--elx-color-warning-500); color: var(--elx-color-white); }
+      .badge.solid.purple { background: var(--elx-color-purple-500); color: var(--elx-color-white); }
 
       /* Soft variants */
       .badge.soft.gray { background: var(--elx-color-neutral-100); color: var(--elx-color-neutral-600); }
-      .badge.soft.red { background: var(--elx-color-danger-50); color: #dc2626; }
-      .badge.soft.green { background: var(--elx-color-success-50); color: #16a34a; }
-      .badge.soft.blue { background: var(--elx-color-primary-50); color: #2563eb; }
-      .badge.soft.yellow { background: #fefce8; color: #ca8a04; }
-      .badge.soft.purple { background: #faf5ff; color: #9333ea; }
+      .badge.soft.red { background: var(--elx-color-danger-50); color: var(--elx-color-danger-600); }
+      .badge.soft.green { background: var(--elx-color-success-50); color: var(--elx-color-success-600); }
+      .badge.soft.blue { background: var(--elx-color-primary-50); color: var(--elx-color-primary-600); }
+      .badge.soft.yellow { background: var(--elx-color-warning-50); color: var(--elx-color-warning-600); }
+      .badge.soft.purple { background: var(--elx-color-purple-50); color: var(--elx-color-purple-600); }
 
       /* Outline variants */
-      .badge.outline.gray { background: transparent; color: var(--elx-color-neutral-600); border: 1px solid #d1d5db; }
-      .badge.outline.red { background: transparent; color: #dc2626; border: 1px solid #fca5a5; }
-      .badge.outline.green { background: transparent; color: #16a34a; border: 1px solid #86efac; }
-      .badge.outline.blue { background: transparent; color: #2563eb; border: 1px solid #93c5fd; }
-      .badge.outline.yellow { background: transparent; color: #ca8a04; border: 1px solid #fde047; }
-      .badge.outline.purple { background: transparent; color: #9333ea; border: 1px solid #d8b4fe; }
+      .badge.outline.gray { background: transparent; color: var(--elx-color-neutral-600); border: 1px solid var(--elx-color-neutral-300); }
+      .badge.outline.red { background: transparent; color: var(--elx-color-danger-600); border: 1px solid var(--elx-color-danger-500); }
+      .badge.outline.green { background: transparent; color: var(--elx-color-success-600); border: 1px solid var(--elx-color-success-500); }
+      .badge.outline.blue { background: transparent; color: var(--elx-color-primary-600); border: 1px solid var(--elx-color-primary-500); }
+      .badge.outline.yellow { background: transparent; color: var(--elx-color-warning-600); border: 1px solid var(--elx-color-warning-500); }
+      .badge.outline.purple { background: transparent; color: var(--elx-color-purple-600); border: 1px solid var(--elx-color-purple-500); }
     `;
 
     this._span = document.createElement('span');

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -50,11 +50,11 @@ export class ElxButton extends HTMLElement {
       }
 
       button {
-        font-family: inherit;
+        font-family: var(--elx-font-family-sans);
         cursor: pointer;
         border: none;
-        border-radius: 6px;
-        font-weight: 500;
+        border-radius: var(--elx-radius-lg);
+        font-weight: var(--elx-font-weight-medium);
         transition: background-color 0.15s ease, opacity 0.15s ease;
         line-height: 1;
       }
@@ -65,7 +65,7 @@ export class ElxButton extends HTMLElement {
       }
 
       button:focus-visible {
-        outline: 2px solid #2563eb;
+        outline: 2px solid var(--elx-color-primary-600);
         outline-offset: 2px;
       }
 
@@ -75,17 +75,17 @@ export class ElxButton extends HTMLElement {
       button.lg { padding: 12px 24px; font-size: 16px; }
 
       /* Variants */
-      button.primary { background: #2563eb; color: #fff; }
-      button.primary:hover:not(:disabled) { background: #1d4ed8; }
+      button.primary { background: var(--elx-color-primary-600); color: var(--elx-color-white); }
+      button.primary:hover:not(:disabled) { background: var(--elx-color-primary-700); }
 
-      button.secondary { background: #e5e7eb; color: #1f2937; }
-      button.secondary:hover:not(:disabled) { background: #d1d5db; }
+      button.secondary { background: var(--elx-color-neutral-200); color: var(--elx-color-neutral-800); }
+      button.secondary:hover:not(:disabled) { background: var(--elx-color-neutral-300); }
 
-      button.danger { background: #dc2626; color: #fff; }
-      button.danger:hover:not(:disabled) { background: #b91c1c; }
+      button.danger { background: var(--elx-color-danger-600); color: var(--elx-color-white); }
+      button.danger:hover:not(:disabled) { background: var(--elx-color-danger-700); }
 
-      button.ghost { background: transparent; color: #2563eb; }
-      button.ghost:hover:not(:disabled) { background: #eff6ff; }
+      button.ghost { background: transparent; color: var(--elx-color-primary-600); }
+      button.ghost:hover:not(:disabled) { background: var(--elx-color-primary-50); }
     `;
 
     this._button = document.createElement('button');

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -36,21 +36,21 @@ export class ElxCard extends HTMLElement {
       :host { display: block; }
 
       .card {
-        border-radius: 8px;
-        font-family: inherit;
+        border-radius: var(--elx-radius-lg);
+        font-family: var(--elx-font-family-sans);
         transition: box-shadow 0.15s ease, transform 0.15s ease;
       }
 
       .card.elevated {
-        background: #fff;
+        background: var(--elx-color-white);
         box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08);
       }
       .card.outlined {
-        background: #fff;
-        border: 1px solid #e5e7eb;
+        background: var(--elx-color-white);
+        border: 1px solid var(--elx-color-neutral-200);
       }
       .card.filled {
-        background: #f3f4f6;
+        background: var(--elx-color-neutral-100);
       }
 
       .card.pad-none { padding: 0; }
@@ -68,7 +68,7 @@ export class ElxCard extends HTMLElement {
       }
 
       :host(:focus-visible) .card.interactive {
-        outline: 2px solid #3b82f6;
+        outline: 2px solid var(--elx-color-primary-500);
         outline-offset: 2px;
       }
 

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -63,20 +63,20 @@ export class ElxCheckbox extends HTMLElement {
         gap: 8px;
         cursor: pointer;
         user-select: none;
-        font-family: inherit;
-        color: #1f2937;
+        font-family: var(--elx-font-family-sans);
+        color: var(--elx-color-neutral-800);
       }
 
-      label.disabled { cursor: not-allowed; color: #9ca3af; }
+      label.disabled { cursor: not-allowed; color: var(--elx-color-neutral-400); }
 
       .checkbox-box {
         position: relative;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        border: 2px solid #d1d5db;
-        border-radius: 4px;
-        background: #fff;
+        border: 2px solid var(--elx-color-neutral-300);
+        border-radius: var(--elx-radius-md);
+        background: var(--elx-color-white);
         transition: all 0.15s ease;
         flex-shrink: 0;
       }
@@ -86,18 +86,18 @@ export class ElxCheckbox extends HTMLElement {
       .checkbox-box.lg { width: 22px; height: 22px; }
 
       .checkbox-box.checked {
-        background: #2563eb;
-        border-color: #2563eb;
+        background: var(--elx-color-primary-600);
+        border-color: var(--elx-color-primary-600);
       }
 
       .checkbox-box.indeterminate {
-        background: #2563eb;
-        border-color: #2563eb;
+        background: var(--elx-color-primary-600);
+        border-color: var(--elx-color-primary-600);
       }
 
       .checkbox-box.disabled {
-        background: #f3f4f6;
-        border-color: #e5e7eb;
+        background: var(--elx-color-neutral-100);
+        border-color: var(--elx-color-neutral-200);
       }
 
       .checkbox-box.checked.disabled {
@@ -107,7 +107,7 @@ export class ElxCheckbox extends HTMLElement {
 
       .checkmark {
         display: none;
-        color: #fff;
+        color: var(--elx-color-white);
       }
 
       .checkmark.visible { display: block; }
@@ -132,7 +132,7 @@ export class ElxCheckbox extends HTMLElement {
 
       input:focus-visible + .checkbox-box {
         box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.3);
-        border-color: #2563eb;
+        border-color: var(--elx-color-primary-600);
       }
     `;
 

--- a/src/components/dialog/dialog.ts
+++ b/src/components/dialog/dialog.ts
@@ -46,13 +46,13 @@ export class ElxDialog extends HTMLElement {
       }
 
       .dialog {
-        background: #fff;
-        border-radius: 8px;
+        background: var(--elx-color-white);
+        border-radius: var(--elx-radius-lg);
         box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1), 0 10px 10px -5px rgba(0,0,0,0.04);
         max-width: 90vw;
         max-height: 90vh;
         overflow: auto;
-        font-family: inherit;
+        font-family: var(--elx-font-family-sans);
       }
 
       .header {
@@ -60,12 +60,12 @@ export class ElxDialog extends HTMLElement {
         align-items: center;
         justify-content: space-between;
         padding: 16px;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--elx-color-neutral-200);
       }
 
       .title {
         font-size: 18px;
-        font-weight: 600;
+        font-weight: var(--elx-font-weight-semibold);
         margin: 0;
       }
 
@@ -76,9 +76,9 @@ export class ElxDialog extends HTMLElement {
         padding: 4px;
         font-size: 20px;
         line-height: 1;
-        color: #6b7280;
+        color: var(--elx-color-neutral-500);
       }
-      .close-btn:hover { color: #111; }
+      .close-btn:hover { color: var(--elx-color-neutral-900); }
 
       .content { padding: 16px; }
       .footer {
@@ -86,7 +86,7 @@ export class ElxDialog extends HTMLElement {
         justify-content: flex-end;
         gap: 8px;
         padding: 16px;
-        border-top: 1px solid #e5e7eb;
+        border-top: 1px solid var(--elx-color-neutral-200);
       }
     `;
 

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -83,30 +83,30 @@ export class ElxInput extends HTMLElement {
     style.textContent = `
       :host { display: block; }
       .input-wrapper { display: flex; flex-direction: column; gap: 4px; }
-      label { font-size: 14px; font-weight: 500; color: #374151; }
+      label { font-size: 14px; font-weight: var(--elx-font-weight-medium); color: var(--elx-color-neutral-700); }
       input {
-        font-family: inherit;
-        border: 1px solid #d1d5db;
-        border-radius: 6px;
-        background: #fff;
-        color: #1f2937;
+        font-family: var(--elx-font-family-sans);
+        border: 1px solid var(--elx-color-neutral-300);
+        border-radius: var(--elx-radius-lg);
+        background: var(--elx-color-white);
+        color: var(--elx-color-neutral-800);
         transition: border-color 0.15s ease, box-shadow 0.15s ease;
         width: 100%;
         box-sizing: border-box;
       }
       input:focus, input:focus-visible {
         outline: none;
-        border-color: #2563eb;
+        border-color: var(--elx-color-primary-600);
         box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
       }
-      input:disabled { background: #f3f4f6; color: #9ca3af; cursor: not-allowed; }
-      input:read-only { background: #f9fafb; }
-      input.error { border-color: #dc2626; }
-      input.error:focus { border-color: #dc2626; box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1); }
+      input:disabled { background: var(--elx-color-neutral-100); color: var(--elx-color-neutral-400); cursor: not-allowed; }
+      input:read-only { background: var(--elx-color-neutral-50); }
+      input.error { border-color: var(--elx-color-danger-600); }
+      input.error:focus { border-color: var(--elx-color-danger-600); box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1); }
       input.sm { padding: 6px 10px; font-size: 13px; }
       input.md { padding: 8px 12px; font-size: 14px; }
       input.lg { padding: 12px 16px; font-size: 16px; }
-      input::placeholder { color: #9ca3af; }
+      input::placeholder { color: var(--elx-color-neutral-400); }
     `;
 
     const wrapper = document.createElement('div');

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -54,10 +54,10 @@ export class ElxRadio extends HTMLElement {
         gap: 8px;
         cursor: pointer;
         user-select: none;
-        font-family: inherit;
-        color: #1f2937;
+        font-family: var(--elx-font-family-sans);
+        color: var(--elx-color-neutral-800);
       }
-      label.disabled { cursor: not-allowed; color: #9ca3af; }
+      label.disabled { cursor: not-allowed; color: var(--elx-color-neutral-400); }
 
       input {
         position: absolute;
@@ -73,9 +73,9 @@ export class ElxRadio extends HTMLElement {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        border: 2px solid #d1d5db;
+        border: 2px solid var(--elx-color-neutral-300);
         border-radius: 50%;
-        background: #fff;
+        background: var(--elx-color-white);
         transition: all 0.15s ease;
         flex-shrink: 0;
       }
@@ -83,13 +83,13 @@ export class ElxRadio extends HTMLElement {
       .radio-circle.md { width: 18px; height: 18px; }
       .radio-circle.lg { width: 22px; height: 22px; }
 
-      .radio-circle.checked { border-color: #2563eb; }
-      .radio-circle.disabled { background: #f3f4f6; border-color: #e5e7eb; }
+      .radio-circle.checked { border-color: var(--elx-color-primary-600); }
+      .radio-circle.disabled { background: var(--elx-color-neutral-100); border-color: var(--elx-color-neutral-200); }
       .radio-circle.checked.disabled { border-color: #93c5fd; }
 
       .dot {
         border-radius: 50%;
-        background: #2563eb;
+        background: var(--elx-color-primary-600);
         display: none;
       }
       .dot.visible { display: block; }
@@ -100,7 +100,7 @@ export class ElxRadio extends HTMLElement {
 
       input:focus-visible + .radio-circle {
         box-shadow: 0 0 0 3px rgba(37,99,235,0.3);
-        border-color: #2563eb;
+        border-color: var(--elx-color-primary-600);
       }
 
       .label-text.sm { font-size: 13px; }

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -72,7 +72,7 @@ export class ElxSelect extends HTMLElement {
       :host {
         display: inline-block;
         position: relative;
-        font-family: inherit;
+        font-family: var(--elx-font-family-sans);
       }
 
       .trigger {
@@ -82,9 +82,9 @@ export class ElxSelect extends HTMLElement {
         gap: 8px;
         padding: 8px 12px;
         min-width: 160px;
-        background: white;
-        border: 1px solid #d1d5db;
-        border-radius: 6px;
+        background: var(--elx-color-white);
+        border: 1px solid var(--elx-color-neutral-300);
+        border-radius: var(--elx-radius-lg);
         font-size: 14px;
         cursor: pointer;
         text-align: left;
@@ -92,12 +92,12 @@ export class ElxSelect extends HTMLElement {
       }
 
       .trigger:hover:not(:disabled) {
-        border-color: #9ca3af;
+        border-color: var(--elx-color-neutral-400);
       }
 
       .trigger:focus-visible {
         outline: none;
-        border-color: #3b82f6;
+        border-color: var(--elx-color-primary-500);
         box-shadow: 0 0 0 3px rgb(59 130 246 / 0.2);
       }
 
@@ -114,7 +114,7 @@ export class ElxSelect extends HTMLElement {
       }
 
       .trigger-text.placeholder {
-        color: #9ca3af;
+        color: var(--elx-color-neutral-400);
       }
 
       .arrow {
@@ -133,9 +133,9 @@ export class ElxSelect extends HTMLElement {
         left: 0;
         right: 0;
         margin-top: 4px;
-        background: white;
-        border: 1px solid #d1d5db;
-        border-radius: 6px;
+        background: var(--elx-color-white);
+        border: 1px solid var(--elx-color-neutral-300);
+        border-radius: var(--elx-radius-lg);
         box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
         max-height: 240px;
         overflow-y: auto;
@@ -161,12 +161,12 @@ export class ElxSelect extends HTMLElement {
 
       .option:hover,
       .option.focused {
-        background-color: #f3f4f6;
+        background-color: var(--elx-color-neutral-100);
       }
 
       .option.selected {
-        background-color: #eff6ff;
-        color: #2563eb;
+        background-color: var(--elx-color-primary-50);
+        color: var(--elx-color-primary-600);
       }
 
       .option.disabled {

--- a/src/components/separator/separator.ts
+++ b/src/components/separator/separator.ts
@@ -43,7 +43,7 @@ export class ElxSeparator extends HTMLElement {
 
       .separator {
         border: none;
-        background-color: #e5e7eb;
+        background-color: var(--elx-color-neutral-200);
       }
 
       .separator.horizontal {

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -55,10 +55,10 @@ export class ElxSwitch extends HTMLElement {
         gap: 10px;
         cursor: pointer;
         user-select: none;
-        font-family: inherit;
-        color: #1f2937;
+        font-family: var(--elx-font-family-sans);
+        color: var(--elx-color-neutral-800);
       }
-      label.disabled { cursor: not-allowed; color: #9ca3af; }
+      label.disabled { cursor: not-allowed; color: var(--elx-color-neutral-400); }
 
       input {
         position: absolute;
@@ -72,8 +72,8 @@ export class ElxSwitch extends HTMLElement {
 
       .track {
         position: relative;
-        border-radius: 9999px;
-        background: #d1d5db;
+        border-radius: var(--elx-radius-full);
+        background: var(--elx-color-neutral-300);
         transition: background 0.2s ease;
         flex-shrink: 0;
       }
@@ -81,14 +81,14 @@ export class ElxSwitch extends HTMLElement {
       .track.md { width: 44px; height: 24px; }
       .track.lg { width: 56px; height: 30px; }
 
-      .track.checked { background: #2563eb; }
+      .track.checked { background: var(--elx-color-primary-600); }
       .track.disabled { opacity: 0.5; }
 
       .thumb {
         position: absolute;
         top: 2px; left: 2px;
         border-radius: 50%;
-        background: #fff;
+        background: var(--elx-color-white);
         box-shadow: 0 1px 3px rgba(0,0,0,0.2);
         transition: transform 0.2s ease;
       }

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -67,7 +67,7 @@ export class ElxTabs extends HTMLElement {
 
       .tab-list {
         display: flex;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--elx-color-neutral-200);
         gap: 0;
       }
 
@@ -76,24 +76,24 @@ export class ElxTabs extends HTMLElement {
         border: none;
         background: transparent;
         cursor: pointer;
-        font-family: inherit;
+        font-family: var(--elx-font-family-sans);
         font-size: 14px;
-        color: #6b7280;
+        color: var(--elx-color-neutral-500);
         border-bottom: 2px solid transparent;
         transition: color 0.15s, border-color 0.15s;
         position: relative;
         bottom: -1px;
       }
 
-      .tab:hover { color: #111; }
+      .tab:hover { color: var(--elx-color-neutral-900); }
       .tab[aria-selected="true"] {
-        color: #3b82f6;
-        border-bottom-color: #3b82f6;
-        font-weight: 500;
+        color: var(--elx-color-primary-500);
+        border-bottom-color: var(--elx-color-primary-500);
+        font-weight: var(--elx-font-weight-medium);
       }
 
       .tab:focus-visible {
-        outline: 2px solid #3b82f6;
+        outline: 2px solid var(--elx-color-primary-500);
         outline-offset: -2px;
       }
     `;

--- a/src/components/text/text.stories.ts
+++ b/src/components/text/text.stories.ts
@@ -1,0 +1,61 @@
+import { html } from 'lit';
+import './text';
+
+export default {
+  title: 'Components/Text',
+  tags: ['autodocs'],
+  argTypes: {
+    as: {
+      control: { type: 'select' },
+      options: ['h1', 'h2', 'h3', 'h4', 'p', 'span', 'small'],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl'],
+    },
+    weight: {
+      control: { type: 'select' },
+      options: ['normal', 'medium', 'semibold', 'bold'],
+    },
+    color: {
+      control: { type: 'select' },
+      options: ['default', 'muted', 'primary', 'danger', 'success'],
+    },
+    align: {
+      control: { type: 'select' },
+      options: ['left', 'center', 'right'],
+    },
+    label: { control: 'text' },
+  },
+};
+
+const Template = ({ as, size, weight, color, align, label }: any) => html`
+  <elx-text
+    as=${as}
+    size=${size}
+    weight=${weight}
+    color=${color}
+    align=${align}
+  >${label}</elx-text>
+`;
+
+export const Paragraph = Template.bind({});
+(Paragraph as any).args = { as: 'p', size: 'base', weight: 'normal', color: 'default', align: 'left', label: 'This is a paragraph of text.' };
+
+export const Heading1 = Template.bind({});
+(Heading1 as any).args = { as: 'h1', size: '4xl', weight: 'semibold', color: 'default', align: 'left', label: 'Heading 1' };
+
+export const Heading2 = Template.bind({});
+(Heading2 as any).args = { as: 'h2', size: '3xl', weight: 'semibold', color: 'default', align: 'left', label: 'Heading 2' };
+
+export const Muted = Template.bind({});
+(Muted as any).args = { as: 'p', size: 'sm', weight: 'normal', color: 'muted', align: 'left', label: 'Muted helper text' };
+
+export const Primary = Template.bind({});
+(Primary as any).args = { as: 'span', size: 'base', weight: 'medium', color: 'primary', align: 'left', label: 'Primary colored text' };
+
+export const Danger = Template.bind({});
+(Danger as any).args = { as: 'p', size: 'base', weight: 'medium', color: 'danger', align: 'left', label: 'Something went wrong.' };
+
+export const Centered = Template.bind({});
+(Centered as any).args = { as: 'p', size: 'lg', weight: 'normal', color: 'default', align: 'center', label: 'Centered text' };

--- a/src/components/text/text.test.ts
+++ b/src/components/text/text.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './text';
+
+describe('elx-text', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-text')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with default tag (p)', async () => {
+    const el = document.createElement('elx-text');
+    document.body.appendChild(el);
+
+    const inner = el.shadowRoot!.querySelector('p');
+    expect(inner).toBeTruthy();
+  });
+
+  it('renders with different tags', async () => {
+    const tags = ['h1', 'h2', 'h3', 'h4', 'span', 'small'] as const;
+
+    for (const tag of tags) {
+      document.body.innerHTML = '';
+      const el = document.createElement('elx-text');
+      el.setAttribute('as', tag);
+      document.body.appendChild(el);
+
+      const inner = el.shadowRoot!.querySelector(tag);
+      expect(inner, `expected <${tag}> to be rendered`).toBeTruthy();
+    }
+  });
+
+  it('applies size prop correctly', async () => {
+    const el = document.createElement('elx-text');
+    el.setAttribute('size', 'xl');
+    document.body.appendChild(el);
+
+    const inner = el.shadowRoot!.querySelector('p');
+    expect(inner!.style.fontSize).toBe('var(--elx-font-size-xl)');
+  });
+
+  it('applies weight prop correctly', async () => {
+    const el = document.createElement('elx-text');
+    el.setAttribute('weight', 'bold');
+    document.body.appendChild(el);
+
+    const inner = el.shadowRoot!.querySelector('p');
+    expect(inner!.style.fontWeight).toBe('var(--elx-font-weight-bold)');
+  });
+
+  it('applies color prop correctly', async () => {
+    const colorMap: Record<string, string> = {
+      default: 'var(--elx-color-neutral-900)',
+      muted: 'var(--elx-color-neutral-500)',
+      primary: 'var(--elx-color-primary-600)',
+      danger: 'var(--elx-color-danger-600)',
+      success: 'var(--elx-color-success-600)',
+    };
+
+    for (const [color, cssVar] of Object.entries(colorMap)) {
+      document.body.innerHTML = '';
+      const el = document.createElement('elx-text');
+      el.setAttribute('color', color);
+      document.body.appendChild(el);
+
+      const inner = el.shadowRoot!.querySelector('p');
+      expect(inner!.style.color, `color="${color}" should map to ${cssVar}`).toBe(cssVar);
+    }
+  });
+
+  it('applies align prop correctly', async () => {
+    const el = document.createElement('elx-text');
+    el.setAttribute('align', 'center');
+    document.body.appendChild(el);
+
+    const inner = el.shadowRoot!.querySelector('p');
+    expect(inner!.style.textAlign).toBe('center');
+  });
+
+  it('renders slot content', async () => {
+    const el = document.createElement('elx-text');
+    el.textContent = 'Hello world';
+    document.body.appendChild(el);
+
+    const slot = el.shadowRoot!.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('defaults h1-h4 weight to semibold', async () => {
+    for (const tag of ['h1', 'h2', 'h3', 'h4'] as const) {
+      document.body.innerHTML = '';
+      const el = document.createElement('elx-text');
+      el.setAttribute('as', tag);
+      document.body.appendChild(el);
+
+      const inner = el.shadowRoot!.querySelector(tag);
+      expect(inner!.style.fontWeight, `${tag} should default to semibold`).toBe('var(--elx-font-weight-semibold)');
+    }
+  });
+
+  it('defaults size based on as prop', async () => {
+    const sizeMap: Record<string, string> = {
+      h1: '4xl',
+      h2: '3xl',
+      h3: '2xl',
+      h4: 'xl',
+      p: 'base',
+      span: 'base',
+      small: 'sm',
+    };
+
+    for (const [tag, size] of Object.entries(sizeMap)) {
+      document.body.innerHTML = '';
+      const el = document.createElement('elx-text');
+      el.setAttribute('as', tag);
+      document.body.appendChild(el);
+
+      const inner = el.shadowRoot!.querySelector(tag) as HTMLElement;
+      expect(inner!.style.fontSize, `as="${tag}" should default to size ${size}`).toBe(`var(--elx-font-size-${size})`);
+    }
+  });
+
+  it('ignores invalid as values', async () => {
+    const el = document.createElement('elx-text');
+    el.setAttribute('as', '<script>alert(1)</script>');
+    document.body.appendChild(el);
+
+    const inner = el.shadowRoot!.querySelector('p');
+    expect(inner).toBeTruthy();
+  });
+
+  it('updates when attributes change', async () => {
+    const el = document.createElement('elx-text');
+    document.body.appendChild(el);
+
+    el.setAttribute('as', 'h1');
+    const h1 = el.shadowRoot!.querySelector('h1');
+    expect(h1).toBeTruthy();
+
+    el.setAttribute('color', 'danger');
+    const inner = el.shadowRoot!.querySelector('h1');
+    expect(inner!.style.color).toBe('var(--elx-color-danger-600)');
+  });
+});

--- a/src/components/text/text.ts
+++ b/src/components/text/text.ts
@@ -1,0 +1,144 @@
+const VALID_TAGS = ['h1', 'h2', 'h3', 'h4', 'p', 'span', 'small'] as const;
+const VALID_SIZES = ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
+const VALID_WEIGHTS = ['normal', 'medium', 'semibold', 'bold'] as const;
+const VALID_COLORS = ['default', 'muted', 'primary', 'danger', 'success'] as const;
+const VALID_ALIGNS = ['left', 'center', 'right'] as const;
+
+type Tag = typeof VALID_TAGS[number];
+type Size = typeof VALID_SIZES[number];
+type Weight = typeof VALID_WEIGHTS[number];
+type Color = typeof VALID_COLORS[number];
+type Align = typeof VALID_ALIGNS[number];
+
+const DEFAULT_SIZES: Record<Tag, Size> = {
+  h1: '4xl',
+  h2: '3xl',
+  h3: '2xl',
+  h4: 'xl',
+  p: 'base',
+  span: 'base',
+  small: 'sm',
+};
+
+const COLOR_MAP: Record<Color, string> = {
+  default: 'var(--elx-color-neutral-900)',
+  muted: 'var(--elx-color-neutral-500)',
+  primary: 'var(--elx-color-primary-600)',
+  danger: 'var(--elx-color-danger-600)',
+  success: 'var(--elx-color-success-600)',
+};
+
+export class ElxText extends HTMLElement {
+  static observedAttributes = ['as', 'size', 'weight', 'color', 'align'];
+
+  private _element: HTMLElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+
+  attributeChangedCallback() {
+    this._update();
+  }
+
+  get as(): Tag {
+    const val = this.getAttribute('as');
+    return VALID_TAGS.includes(val as Tag) ? (val as Tag) : 'p';
+  }
+
+  set as(val: string) {
+    this.setAttribute('as', val);
+  }
+
+  get size(): Size {
+    const val = this.getAttribute('size');
+    if (val && VALID_SIZES.includes(val as Size)) {
+      return val as Size;
+    }
+    return DEFAULT_SIZES[this.as];
+  }
+
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
+
+  get weight(): Weight {
+    const val = this.getAttribute('weight');
+    if (val && VALID_WEIGHTS.includes(val as Weight)) {
+      return val as Weight;
+    }
+    // h1-h4 default to semibold
+    if (['h1', 'h2', 'h3', 'h4'].includes(this.as)) {
+      return 'semibold';
+    }
+    return 'normal';
+  }
+
+  set weight(val: string) {
+    this.setAttribute('weight', val);
+  }
+
+  get color(): Color {
+    const val = this.getAttribute('color');
+    return VALID_COLORS.includes(val as Color) ? (val as Color) : 'default';
+  }
+
+  set color(val: string) {
+    this.setAttribute('color', val);
+  }
+
+  get align(): Align {
+    const val = this.getAttribute('align');
+    return VALID_ALIGNS.includes(val as Align) ? (val as Align) : 'left';
+  }
+
+  set align(val: string) {
+    this.setAttribute('align', val);
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: block;
+      }
+
+      ::slotted(*) {
+        margin: 0;
+      }
+    `;
+
+    this._element = document.createElement(this.as);
+    this._element.appendChild(document.createElement('slot'));
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(this._element);
+  }
+
+  private _update() {
+    if (!this._element) return;
+
+    // Update tag if 'as' changed
+    if (this._element.tagName.toLowerCase() !== this.as) {
+      const newElement = document.createElement(this.as);
+      newElement.appendChild(document.createElement('slot'));
+      this._element.replaceWith(newElement);
+      this._element = newElement;
+    }
+
+    this._element.style.fontSize = `var(--elx-font-size-${this.size})`;
+    this._element.style.fontWeight = `var(--elx-font-weight-${this.weight})`;
+    this._element.style.color = COLOR_MAP[this.color];
+    this._element.style.textAlign = this.align;
+  }
+}
+
+if (!customElements.get('elx-text')) {
+  customElements.define('elx-text', ElxText);
+}

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -63,11 +63,11 @@ export class ElxTooltip extends HTMLElement {
         position: absolute;
         z-index: 1000;
         padding: 6px 12px;
-        background-color: #1f2937;
-        color: white;
+        background-color: var(--elx-color-neutral-800);
+        color: var(--elx-color-white);
         font-size: 12px;
-        font-family: inherit;
-        border-radius: 6px;
+        font-family: var(--elx-font-family-sans);
+        border-radius: var(--elx-radius-lg);
         pointer-events: none;
         white-space: nowrap;
         opacity: 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export * from './components/tooltip/tooltip';
 export * from './components/select/select';
 export * from './components/separator/separator';
 export * from './components/accordion/accordion';
+export * from './components/text/text';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 // Elementix - Web Components Design System
+import './theme.css';
 export * from './components/button/button';
 export * from './components/input/input';
 export * from './components/checkbox/checkbox';

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,61 @@
+:root {
+  /* Colors */
+  --elx-color-primary-50: #eff6ff;
+  --elx-color-primary-100: #dbeafe;
+  --elx-color-primary-500: #3b82f6;
+  --elx-color-primary-600: #2563eb;
+  --elx-color-primary-700: #1d4ed8;
+
+  --elx-color-danger-50: #fef2f2;
+  --elx-color-danger-500: #ef4444;
+  --elx-color-danger-600: #dc2626;
+  --elx-color-danger-700: #b91c1c;
+
+  --elx-color-success-50: #f0fdf4;
+  --elx-color-success-500: #22c55e;
+  --elx-color-success-600: #16a34a;
+  --elx-color-success-700: #15803d;
+
+  --elx-color-neutral-50: #f9fafb;
+  --elx-color-neutral-100: #f3f4f6;
+  --elx-color-neutral-200: #e5e7eb;
+  --elx-color-neutral-300: #d1d5db;
+  --elx-color-neutral-400: #9ca3af;
+  --elx-color-neutral-500: #6b7280;
+  --elx-color-neutral-600: #4b5563;
+  --elx-color-neutral-700: #374151;
+  --elx-color-neutral-800: #1f2937;
+  --elx-color-neutral-900: #111827;
+
+  --elx-color-white: #ffffff;
+  --elx-color-black: #000000;
+
+  /* Typography */
+  --elx-font-family-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --elx-font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  --elx-font-size-xs: 0.75rem;     /* 12px */
+  --elx-font-size-sm: 0.875rem;    /* 14px */
+  --elx-font-size-base: 1rem;      /* 16px */
+  --elx-font-size-lg: 1.125rem;    /* 18px */
+  --elx-font-size-xl: 1.25rem;     /* 20px */
+  --elx-font-size-2xl: 1.5rem;     /* 24px */
+  --elx-font-size-3xl: 1.875rem;   /* 30px */
+  --elx-font-size-4xl: 2.25rem;    /* 36px */
+
+  --elx-font-weight-normal: 400;
+  --elx-font-weight-medium: 500;
+  --elx-font-weight-semibold: 600;
+  --elx-font-weight-bold: 700;
+
+  --elx-line-height-tight: 1.25;
+  --elx-line-height-snug: 1.375;
+  --elx-line-height-normal: 1.5;
+  --elx-line-height-relaxed: 1.625;
+
+  /* Border Radius */
+  --elx-radius-sm: 0.125rem;
+  --elx-radius-md: 0.375rem;
+  --elx-radius-lg: 0.5rem;
+  --elx-radius-full: 9999px;
+}

--- a/src/theme.css
+++ b/src/theme.css
@@ -16,6 +16,18 @@
   --elx-color-success-600: #16a34a;
   --elx-color-success-700: #15803d;
 
+  --elx-color-warning-50: #fffbeb;
+  --elx-color-warning-100: #fef3c7;
+  --elx-color-warning-500: #f59e0b;
+  --elx-color-warning-600: #d97706;
+  --elx-color-warning-700: #b45309;
+
+  --elx-color-purple-50: #faf5ff;
+  --elx-color-purple-100: #f3e8ff;
+  --elx-color-purple-500: #a855f7;
+  --elx-color-purple-600: #9333ea;
+  --elx-color-purple-700: #7e22ce;
+
   --elx-color-neutral-50: #f9fafb;
   --elx-color-neutral-100: #f3f4f6;
   --elx-color-neutral-200: #e5e7eb;


### PR DESCRIPTION
- Add `src/theme.css` with CSS custom properties for colors, typography, and border radius
- Import theme in `src/index.ts`, `index.html`, and `.storybook/preview.js`
- Foundation for consistent theming across all components