### PR TITLE
feat: add ESLint + Prettier setup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,22 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  prettier,
+  {
+    ignores: ['dist/', 'node_modules/', '*.config.*', '.storybook/'],
+  },
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/explicit-member-accessibility': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-expressions': ['error', { allowTernary: true }],
+      'no-useless-assignment': 'off',
+    },
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,18 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@storybook/addon-essentials": "^8.0.0",
         "@storybook/addon-links": "^8.0.0",
         "@storybook/web-components": "^8.0.0",
         "@storybook/web-components-vite": "^8.0.0",
+        "eslint": "^10.2.1",
+        "eslint-config-prettier": "^10.1.8",
         "jsdom": "^29.0.2",
         "lit": "^3.3.2",
+        "prettier": "^3.8.3",
         "typescript": "^5.4.0",
+        "typescript-eslint": "^8.59.0",
         "vite": "^5.2.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^1.5.0"
@@ -753,6 +758,150 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
@@ -769,6 +918,72 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jest/schemas": {
@@ -1873,10 +2088,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1911,6 +2140,236 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -2147,6 +2606,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -2541,6 +3010,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -2722,6 +3198,181 @@
         "esbuild": ">=0.12 <1"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2737,6 +3388,42 @@
         "node": ">=4"
       }
     },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2745,6 +3432,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -2785,6 +3482,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2801,6 +3512,75 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -2934,6 +3714,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3056,6 +3849,16 @@
         "node": ">=16.17.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-lazy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
@@ -3064,6 +3867,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inherits": {
@@ -3139,6 +3952,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -3158,6 +3981,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3304,10 +4140,24 @@
         }
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3324,12 +4174,36 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lit": {
       "version": "3.3.2",
@@ -3380,6 +4254,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/loupe": {
@@ -3536,6 +4426,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -3600,6 +4497,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
@@ -3611,6 +4526,51 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3635,6 +4595,16 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -3760,6 +4730,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -4209,6 +5205,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tinypool": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
@@ -4275,6 +5288,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -4292,6 +5318,19 @@
       "dev": true,
       "license": "0BSD",
       "peer": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
@@ -4315,6 +5354,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/ufo": {
@@ -4356,6 +5419,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util": {
@@ -5153,6 +6226,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\""
   },
   "keywords": [
     "web-components",
@@ -26,13 +30,18 @@
   "author": "clawdiab",
   "license": "MIT",
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@storybook/addon-essentials": "^8.0.0",
     "@storybook/addon-links": "^8.0.0",
     "@storybook/web-components": "^8.0.0",
     "@storybook/web-components-vite": "^8.0.0",
+    "eslint": "^10.2.1",
+    "eslint-config-prettier": "^10.1.8",
     "jsdom": "^29.0.2",
     "lit": "^3.3.2",
+    "prettier": "^3.8.3",
     "typescript": "^5.4.0",
+    "typescript-eslint": "^8.59.0",
     "vite": "^5.2.0",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^1.5.0"

--- a/src/components/accordion/accordion.ts
+++ b/src/components/accordion/accordion.ts
@@ -25,19 +25,31 @@ export class ElxAccordionItem extends HTMLElement {
     }
   }
 
-  get value(): string { return this.getAttribute('value') ?? ''; }
-  set value(val: string) { this.setAttribute('value', val); }
+  get value(): string {
+    return this.getAttribute('value') ?? '';
+  }
+  set value(val: string) {
+    this.setAttribute('value', val);
+  }
 
-  get label(): string { return this.getAttribute('label') ?? ''; }
-  set label(val: string) { this.setAttribute('label', val); }
+  get label(): string {
+    return this.getAttribute('label') ?? '';
+  }
+  set label(val: string) {
+    this.setAttribute('label', val);
+  }
 
-  get disabled(): boolean { return this.hasAttribute('disabled'); }
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
   set disabled(val: boolean) {
     if (val) this.setAttribute('disabled', '');
     else this.removeAttribute('disabled');
   }
 
-  get open(): boolean { return this._open; }
+  get open(): boolean {
+    return this._open;
+  }
 
   toggle(force?: boolean) {
     if (this.disabled) return;
@@ -45,7 +57,9 @@ export class ElxAccordionItem extends HTMLElement {
     if (next === this._open) return;
     this._open = next;
     this._updateState();
-    this.dispatchEvent(new CustomEvent('toggle', { detail: { value: this.value, open: this._open }, bubbles: true }));
+    this.dispatchEvent(
+      new CustomEvent('toggle', { detail: { value: this.value, open: this._open }, bubbles: true }),
+    );
   }
 
   private _buildDom() {
@@ -138,7 +152,10 @@ export class ElxAccordionItem extends HTMLElement {
     arrow.setAttribute('fill', 'currentColor');
     const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
     path.setAttribute('fill-rule', 'evenodd');
-    path.setAttribute('d', 'M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z');
+    path.setAttribute(
+      'd',
+      'M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z',
+    );
     path.setAttribute('clip-rule', 'evenodd');
     arrow.appendChild(path);
 
@@ -215,7 +232,7 @@ export class ElxAccordion extends HTMLElement {
 
   private _onItemToggle = (e: CustomEvent) => {
     if (this.type === 'single' && e.detail.open) {
-      this._getItems().forEach(item => {
+      this._getItems().forEach((item) => {
         if (item !== e.target && item.open) {
           item.toggle(false);
         }
@@ -227,8 +244,8 @@ export class ElxAccordion extends HTMLElement {
     const target = e.target as HTMLElement;
     if (!target.closest('elx-accordion-item')) return;
 
-    const items = this._getItems().filter(i => !i.disabled);
-    const currentItem = (target.closest('elx-accordion-item') as ElxAccordionItem);
+    const items = this._getItems().filter((i) => !i.disabled);
+    const currentItem = target.closest('elx-accordion-item') as ElxAccordionItem;
     const currentIndex = items.indexOf(currentItem);
     if (currentIndex === -1) return;
 

--- a/src/components/alert/alert.stories.ts
+++ b/src/components/alert/alert.stories.ts
@@ -6,8 +6,8 @@ export default {
   tags: ['autodocs'],
   argTypes: {
     variant: { control: { type: 'select' }, options: ['info', 'success', 'warning', 'error'] },
-    dismissible: { control: 'boolean' }
-  }
+    dismissible: { control: 'boolean' },
+  },
 };
 
 const Template = ({ variant, dismissible }: any) => html`

--- a/src/components/alert/alert.test.ts
+++ b/src/components/alert/alert.test.ts
@@ -6,7 +6,9 @@ describe('elx-alert', () => {
     expect(customElements.get('elx-alert')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders with default variant (info)', () => {
     const el = document.createElement('elx-alert');
@@ -63,7 +65,9 @@ describe('elx-alert', () => {
     el.setAttribute('dismissible', '');
     document.body.appendChild(el);
     let fired = false;
-    el.addEventListener('close', () => { fired = true; });
+    el.addEventListener('close', () => {
+      fired = true;
+    });
     const btn = el.shadowRoot!.querySelector('.close-btn') as HTMLButtonElement;
     btn.click();
     expect(fired).toBe(true);

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -1,12 +1,12 @@
 const VALID_VARIANTS = ['info', 'success', 'warning', 'error'] as const;
 
-type Variant = typeof VALID_VARIANTS[number];
+type Variant = (typeof VALID_VARIANTS)[number];
 
 const ICONS: Record<Variant, string> = {
   info: 'ℹ️',
   success: '✓',
   warning: '⚠',
-  error: '✕'
+  error: '✕',
 };
 
 export class ElxAlert extends HTMLElement {
@@ -19,19 +19,34 @@ export class ElxAlert extends HTMLElement {
     this.attachShadow({ mode: 'open' });
   }
 
-  connectedCallback() { this._buildDom(); this._update(); }
-  disconnectedCallback() { this._closeBtn?.removeEventListener('click', this._onClose); }
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+  disconnectedCallback() {
+    this._closeBtn?.removeEventListener('click', this._onClose);
+  }
 
-  attributeChangedCallback() { this._update(); }
+  attributeChangedCallback() {
+    this._update();
+  }
 
   get variant(): Variant {
     const val = this.getAttribute('variant');
-    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1 ? (val as Variant) : 'info';
+    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1
+      ? (val as Variant)
+      : 'info';
   }
-  set variant(val: string) { this.setAttribute('variant', val); }
+  set variant(val: string) {
+    this.setAttribute('variant', val);
+  }
 
-  get dismissible(): boolean { return this.hasAttribute('dismissible'); }
-  set dismissible(val: boolean) { val ? this.setAttribute('dismissible', '') : this.removeAttribute('dismissible'); }
+  get dismissible(): boolean {
+    return this.hasAttribute('dismissible');
+  }
+  set dismissible(val: boolean) {
+    val ? this.setAttribute('dismissible', '') : this.removeAttribute('dismissible');
+  }
 
   private _onClose = () => {
     this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));

--- a/src/components/avatar/avatar.stories.ts
+++ b/src/components/avatar/avatar.stories.ts
@@ -9,8 +9,8 @@ export default {
     alt: { control: 'text' },
     fallback: { control: 'text' },
     size: { control: { type: 'select' }, options: ['xs', 'sm', 'md', 'lg', 'xl'] },
-    shape: { control: { type: 'select' }, options: ['circle', 'square'] }
-  }
+    shape: { control: { type: 'select' }, options: ['circle', 'square'] },
+  },
 };
 
 const Template = ({ src, alt, fallback, size, shape }: any) => html`
@@ -18,7 +18,13 @@ const Template = ({ src, alt, fallback, size, shape }: any) => html`
 `;
 
 export const Default = Template.bind({});
-(Default as any).args = { src: 'https://i.pravatar.cc/150?img=1', alt: 'User', fallback: 'JD', size: 'md', shape: 'circle' };
+(Default as any).args = {
+  src: 'https://i.pravatar.cc/150?img=1',
+  alt: 'User',
+  fallback: 'JD',
+  size: 'md',
+  shape: 'circle',
+};
 
 export const Fallback = Template.bind({});
 (Fallback as any).args = { src: '', alt: '', fallback: 'AB', size: 'md', shape: 'circle' };
@@ -36,6 +42,11 @@ export const Sizes = () => html`
 export const Square = () => html`
   <div style="display:flex;gap:12px;align-items:center">
     <elx-avatar shape="square" size="md" fallback="SQ"></elx-avatar>
-    <elx-avatar shape="square" size="lg" src="https://i.pravatar.cc/150?img=3" alt="Square avatar"></elx-avatar>
+    <elx-avatar
+      shape="square"
+      size="lg"
+      src="https://i.pravatar.cc/150?img=3"
+      alt="Square avatar"
+    ></elx-avatar>
   </div>
 `;

--- a/src/components/avatar/avatar.test.ts
+++ b/src/components/avatar/avatar.test.ts
@@ -6,7 +6,9 @@ describe('elx-avatar', () => {
     expect(customElements.get('elx-avatar')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders with default props', () => {
     const el = document.createElement('elx-avatar');

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -1,8 +1,8 @@
 const VALID_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
 const VALID_SHAPES = ['circle', 'square'] as const;
 
-type Size = typeof VALID_SIZES[number];
-type Shape = typeof VALID_SHAPES[number];
+type Size = (typeof VALID_SIZES)[number];
+type Shape = (typeof VALID_SHAPES)[number];
 
 export class ElxAvatar extends HTMLElement {
   static observedAttributes = ['src', 'alt', 'fallback', 'size', 'shape'];
@@ -16,29 +16,52 @@ export class ElxAvatar extends HTMLElement {
     this.attachShadow({ mode: 'open' });
   }
 
-  connectedCallback() { this._buildDom(); this._update(); }
-  attributeChangedCallback() { this._update(); }
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+  attributeChangedCallback() {
+    this._update();
+  }
 
-  get src(): string { return this.getAttribute('src') ?? ''; }
-  set src(val: string) { this.setAttribute('src', val); }
+  get src(): string {
+    return this.getAttribute('src') ?? '';
+  }
+  set src(val: string) {
+    this.setAttribute('src', val);
+  }
 
-  get alt(): string { return this.getAttribute('alt') ?? ''; }
-  set alt(val: string) { this.setAttribute('alt', val); }
+  get alt(): string {
+    return this.getAttribute('alt') ?? '';
+  }
+  set alt(val: string) {
+    this.setAttribute('alt', val);
+  }
 
-  get fallback(): string { return this.getAttribute('fallback') ?? ''; }
-  set fallback(val: string) { this.setAttribute('fallback', val); }
+  get fallback(): string {
+    return this.getAttribute('fallback') ?? '';
+  }
+  set fallback(val: string) {
+    this.setAttribute('fallback', val);
+  }
 
   get size(): Size {
     const val = this.getAttribute('size');
     return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
   }
-  set size(val: string) { this.setAttribute('size', val); }
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
 
   get shape(): Shape {
     const val = this.getAttribute('shape');
-    return (VALID_SHAPES as readonly string[]).indexOf(val as string) !== -1 ? (val as Shape) : 'circle';
+    return (VALID_SHAPES as readonly string[]).indexOf(val as string) !== -1
+      ? (val as Shape)
+      : 'circle';
   }
-  set shape(val: string) { this.setAttribute('shape', val); }
+  set shape(val: string) {
+    this.setAttribute('shape', val);
+  }
 
   private _buildDom() {
     const style = document.createElement('style');

--- a/src/components/badge/badge.stories.ts
+++ b/src/components/badge/badge.stories.ts
@@ -6,10 +6,13 @@ export default {
   tags: ['autodocs'],
   argTypes: {
     variant: { control: { type: 'select' }, options: ['solid', 'soft', 'outline'] },
-    color: { control: { type: 'select' }, options: ['gray', 'red', 'green', 'blue', 'yellow', 'purple'] },
+    color: {
+      control: { type: 'select' },
+      options: ['gray', 'red', 'green', 'blue', 'yellow', 'purple'],
+    },
     size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
-    text: { control: 'text' }
-  }
+    text: { control: 'text' },
+  },
 };
 
 const Template = ({ variant, color, size, text }: any) => html`

--- a/src/components/badge/badge.test.ts
+++ b/src/components/badge/badge.test.ts
@@ -6,7 +6,9 @@ describe('elx-badge', () => {
     expect(customElements.get('elx-badge')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders with default props', () => {
     const el = document.createElement('elx-badge');

--- a/src/components/badge/badge.ts
+++ b/src/components/badge/badge.ts
@@ -2,9 +2,9 @@ const VALID_VARIANTS = ['solid', 'soft', 'outline'] as const;
 const VALID_COLORS = ['gray', 'red', 'green', 'blue', 'yellow', 'purple'] as const;
 const VALID_SIZES = ['sm', 'md', 'lg'] as const;
 
-type Variant = typeof VALID_VARIANTS[number];
-type Color = typeof VALID_COLORS[number];
-type Size = typeof VALID_SIZES[number];
+type Variant = (typeof VALID_VARIANTS)[number];
+type Color = (typeof VALID_COLORS)[number];
+type Size = (typeof VALID_SIZES)[number];
 
 export class ElxBadge extends HTMLElement {
   static observedAttributes = ['variant', 'color', 'size'];
@@ -27,21 +27,31 @@ export class ElxBadge extends HTMLElement {
 
   get variant(): Variant {
     const val = this.getAttribute('variant');
-    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1 ? (val as Variant) : 'solid';
+    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1
+      ? (val as Variant)
+      : 'solid';
   }
-  set variant(val: string) { this.setAttribute('variant', val); }
+  set variant(val: string) {
+    this.setAttribute('variant', val);
+  }
 
   get color(): Color {
     const val = this.getAttribute('color');
-    return (VALID_COLORS as readonly string[]).indexOf(val as string) !== -1 ? (val as Color) : 'gray';
+    return (VALID_COLORS as readonly string[]).indexOf(val as string) !== -1
+      ? (val as Color)
+      : 'gray';
   }
-  set color(val: string) { this.setAttribute('color', val); }
+  set color(val: string) {
+    this.setAttribute('color', val);
+  }
 
   get size(): Size {
     const val = this.getAttribute('size');
     return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
   }
-  set size(val: string) { this.setAttribute('size', val); }
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
 
   private _buildDom() {
     const style = document.createElement('style');

--- a/src/components/button/button.stories.ts
+++ b/src/components/button/button.stories.ts
@@ -7,23 +7,19 @@ export default {
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: ['primary', 'secondary', 'danger', 'ghost']
+      options: ['primary', 'secondary', 'danger', 'ghost'],
     },
     size: {
       control: { type: 'select' },
-      options: ['sm', 'md', 'lg']
+      options: ['sm', 'md', 'lg'],
     },
     disabled: { control: 'boolean' },
-    label: { control: 'text' }
-  }
+    label: { control: 'text' },
+  },
 };
 
 const Template = ({ variant, size, disabled, label }: any) => html`
-  <elx-button
-    variant=${variant}
-    size=${size}
-    ?disabled=${disabled}
-  >${label}</elx-button>
+  <elx-button variant=${variant} size=${size} ?disabled=${disabled}>${label}</elx-button>
 `;
 
 export const Primary = Template.bind({});

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -1,8 +1,8 @@
 const VALID_VARIANTS = ['primary', 'secondary', 'danger', 'ghost'] as const;
 const VALID_SIZES = ['sm', 'md', 'lg'] as const;
 
-type Variant = typeof VALID_VARIANTS[number];
-type Size = typeof VALID_SIZES[number];
+type Variant = (typeof VALID_VARIANTS)[number];
+type Size = (typeof VALID_SIZES)[number];
 
 export class ElxButton extends HTMLElement {
   static observedAttributes = ['variant', 'size', 'disabled'];

--- a/src/components/card/card.stories.ts
+++ b/src/components/card/card.stories.ts
@@ -7,8 +7,8 @@ export default {
   argTypes: {
     variant: { control: { type: 'select' }, options: ['elevated', 'outlined', 'filled'] },
     padding: { control: { type: 'select' }, options: ['none', 'sm', 'md', 'lg'] },
-    interactive: { control: 'boolean' }
-  }
+    interactive: { control: 'boolean' },
+  },
 };
 
 const Template = ({ variant, padding, interactive }: any) => html`

--- a/src/components/card/card.test.ts
+++ b/src/components/card/card.test.ts
@@ -6,7 +6,9 @@ describe('elx-card', () => {
     expect(customElements.get('elx-card')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders with default props', () => {
     const el = document.createElement('elx-card');
@@ -40,7 +42,7 @@ describe('elx-card', () => {
 
   it('applies padding sizes', () => {
     const sizes = ['none', 'sm', 'md', 'lg'] as const;
-    sizes.forEach(size => {
+    sizes.forEach((size) => {
       const el = document.createElement('elx-card');
       el.setAttribute('padding', size);
       document.body.appendChild(el);

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -1,8 +1,8 @@
 const VALID_VARIANTS = ['elevated', 'outlined', 'filled'] as const;
 const VALID_PADDINGS = ['none', 'sm', 'md', 'lg'] as const;
 
-type Variant = typeof VALID_VARIANTS[number];
-type Padding = typeof VALID_PADDINGS[number];
+type Variant = (typeof VALID_VARIANTS)[number];
+type Padding = (typeof VALID_PADDINGS)[number];
 
 export class ElxCard extends HTMLElement {
   static observedAttributes = ['variant', 'padding', 'interactive'];
@@ -12,23 +12,40 @@ export class ElxCard extends HTMLElement {
     this.attachShadow({ mode: 'open' });
   }
 
-  connectedCallback() { this._buildDom(); this._update(); }
-  attributeChangedCallback() { this._update(); }
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+  attributeChangedCallback() {
+    this._update();
+  }
 
   get variant(): Variant {
     const val = this.getAttribute('variant');
-    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1 ? (val as Variant) : 'elevated';
+    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1
+      ? (val as Variant)
+      : 'elevated';
   }
-  set variant(val: string) { this.setAttribute('variant', val); }
+  set variant(val: string) {
+    this.setAttribute('variant', val);
+  }
 
   get padding(): Padding {
     const val = this.getAttribute('padding');
-    return (VALID_PADDINGS as readonly string[]).indexOf(val as string) !== -1 ? (val as Padding) : 'md';
+    return (VALID_PADDINGS as readonly string[]).indexOf(val as string) !== -1
+      ? (val as Padding)
+      : 'md';
   }
-  set padding(val: string) { this.setAttribute('padding', val); }
+  set padding(val: string) {
+    this.setAttribute('padding', val);
+  }
 
-  get interactive(): boolean { return this.hasAttribute('interactive'); }
-  set interactive(val: boolean) { val ? this.setAttribute('interactive', '') : this.removeAttribute('interactive'); }
+  get interactive(): boolean {
+    return this.hasAttribute('interactive');
+  }
+  set interactive(val: boolean) {
+    val ? this.setAttribute('interactive', '') : this.removeAttribute('interactive');
+  }
 
   private _buildDom() {
     const style = document.createElement('style');

--- a/src/components/checkbox/checkbox.stories.ts
+++ b/src/components/checkbox/checkbox.stories.ts
@@ -11,8 +11,8 @@ export default {
     size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
     label: { control: 'text' },
     name: { control: 'text' },
-    value: { control: 'text' }
-  }
+    value: { control: 'text' },
+  },
 };
 
 const Template = ({ checked, disabled, indeterminate, size, label, name, value }: any) => html`
@@ -28,19 +28,67 @@ const Template = ({ checked, disabled, indeterminate, size, label, name, value }
 `;
 
 export const Default = Template.bind({});
-(Default as any).args = { checked: false, disabled: false, indeterminate: false, size: 'md', label: 'Accept terms', name: 'terms', value: 'on' };
+(Default as any).args = {
+  checked: false,
+  disabled: false,
+  indeterminate: false,
+  size: 'md',
+  label: 'Accept terms',
+  name: 'terms',
+  value: 'on',
+};
 
 export const Checked = Template.bind({});
-(Checked as any).args = { checked: true, disabled: false, indeterminate: false, size: 'md', label: 'Checked', name: '', value: 'on' };
+(Checked as any).args = {
+  checked: true,
+  disabled: false,
+  indeterminate: false,
+  size: 'md',
+  label: 'Checked',
+  name: '',
+  value: 'on',
+};
 
 export const Indeterminate = Template.bind({});
-(Indeterminate as any).args = { checked: false, disabled: false, indeterminate: true, size: 'md', label: 'Indeterminate', name: '', value: 'on' };
+(Indeterminate as any).args = {
+  checked: false,
+  disabled: false,
+  indeterminate: true,
+  size: 'md',
+  label: 'Indeterminate',
+  name: '',
+  value: 'on',
+};
 
 export const Disabled = Template.bind({});
-(Disabled as any).args = { checked: false, disabled: true, indeterminate: false, size: 'md', label: 'Disabled', name: '', value: 'on' };
+(Disabled as any).args = {
+  checked: false,
+  disabled: true,
+  indeterminate: false,
+  size: 'md',
+  label: 'Disabled',
+  name: '',
+  value: 'on',
+};
 
 export const Small = Template.bind({});
-(Small as any).args = { checked: false, disabled: false, indeterminate: false, size: 'sm', label: 'Small', name: '', value: 'on' };
+(Small as any).args = {
+  checked: false,
+  disabled: false,
+  indeterminate: false,
+  size: 'sm',
+  label: 'Small',
+  name: '',
+  value: 'on',
+};
 
 export const Large = Template.bind({});
-(Large as any).args = { checked: false, disabled: false, indeterminate: false, size: 'lg', label: 'Large', name: '', value: 'on' };
+(Large as any).args = {
+  checked: false,
+  disabled: false,
+  indeterminate: false,
+  size: 'lg',
+  label: 'Large',
+  name: '',
+  value: 'on',
+};

--- a/src/components/checkbox/checkbox.test.ts
+++ b/src/components/checkbox/checkbox.test.ts
@@ -6,7 +6,9 @@ describe('elx-checkbox', () => {
     expect(customElements.get('elx-checkbox')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders with default props', () => {
     const el = document.createElement('elx-checkbox');
@@ -106,7 +108,9 @@ describe('elx-checkbox', () => {
     const el = document.createElement('elx-checkbox');
     document.body.appendChild(el);
     let detail: any = null;
-    el.addEventListener('change', (e: any) => { detail = e.detail; });
+    el.addEventListener('change', (e: any) => {
+      detail = e.detail;
+    });
     const input = el.shadowRoot!.querySelector('input')!;
     input.checked = true;
     input.dispatchEvent(new Event('change', { bubbles: true }));
@@ -119,7 +123,9 @@ describe('elx-checkbox', () => {
     el.setAttribute('disabled', '');
     document.body.appendChild(el);
     let fired = false;
-    el.addEventListener('change', () => { fired = true; });
+    el.addEventListener('change', () => {
+      fired = true;
+    });
     const input = el.shadowRoot!.querySelector('input')!;
     input.dispatchEvent(new Event('change', { bubbles: true }));
     expect(fired).toBe(false);
@@ -153,7 +159,9 @@ describe('elx-checkbox', () => {
     const el = document.createElement('elx-checkbox');
     el.setAttribute('disabled', '');
     document.body.appendChild(el);
-    expect(el.shadowRoot!.querySelector('.checkbox-box')!.classList.contains('disabled')).toBe(true);
+    expect(el.shadowRoot!.querySelector('.checkbox-box')!.classList.contains('disabled')).toBe(
+      true,
+    );
   });
 
   it('removes aria-checked when not indeterminate', () => {

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -1,10 +1,18 @@
 const VALID_SIZES = ['sm', 'md', 'lg'] as const;
-type Size = typeof VALID_SIZES[number];
+type Size = (typeof VALID_SIZES)[number];
 
 let uid = 0;
 
 export class ElxCheckbox extends HTMLElement {
-  static observedAttributes = ['checked', 'disabled', 'indeterminate', 'size', 'label', 'name', 'value'];
+  static observedAttributes = [
+    'checked',
+    'disabled',
+    'indeterminate',
+    'size',
+    'label',
+    'name',
+    'value',
+  ];
 
   private _input: HTMLInputElement | null = null;
   private _labelEl: HTMLLabelElement | null = null;
@@ -25,32 +33,62 @@ export class ElxCheckbox extends HTMLElement {
     this._update();
   }
 
-  get checked(): boolean { return this.hasAttribute('checked'); }
-  set checked(val: boolean) { val ? this.setAttribute('checked', '') : this.removeAttribute('checked'); }
+  get checked(): boolean {
+    return this.hasAttribute('checked');
+  }
+  set checked(val: boolean) {
+    val ? this.setAttribute('checked', '') : this.removeAttribute('checked');
+  }
 
-  get disabled(): boolean { return this.hasAttribute('disabled'); }
-  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
 
-  get indeterminate(): boolean { return this.hasAttribute('indeterminate'); }
-  set indeterminate(val: boolean) { val ? this.setAttribute('indeterminate', '') : this.removeAttribute('indeterminate'); }
+  get indeterminate(): boolean {
+    return this.hasAttribute('indeterminate');
+  }
+  set indeterminate(val: boolean) {
+    val ? this.setAttribute('indeterminate', '') : this.removeAttribute('indeterminate');
+  }
 
   get size(): Size {
     const val = this.getAttribute('size');
     return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
   }
-  set size(val: string) { this.setAttribute('size', val); }
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
 
-  get name(): string { return this.getAttribute('name') ?? ''; }
-  set name(val: string) { this.setAttribute('name', val); }
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+  set name(val: string) {
+    this.setAttribute('name', val);
+  }
 
-  get value(): string { return this.getAttribute('value') ?? 'on'; }
-  set value(val: string) { this.setAttribute('value', val); }
+  get value(): string {
+    return this.getAttribute('value') ?? 'on';
+  }
+  set value(val: string) {
+    this.setAttribute('value', val);
+  }
 
-  get label(): string { return this.getAttribute('label') ?? ''; }
-  set label(val: string) { this.setAttribute('label', val); }
+  get label(): string {
+    return this.getAttribute('label') ?? '';
+  }
+  set label(val: string) {
+    this.setAttribute('label', val);
+  }
 
-  focus() { this._input?.focus(); }
-  blur() { this._input?.blur(); }
+  focus() {
+    this._input?.focus();
+  }
+  blur() {
+    this._input?.blur();
+  }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -169,10 +207,13 @@ export class ElxCheckbox extends HTMLElement {
       } else {
         this.removeAttribute('checked');
       }
-      this.dispatchEvent(new CustomEvent('change', {
-        detail: { checked: this.checked, value: this.value },
-        bubbles: true, composed: true
-      }));
+      this.dispatchEvent(
+        new CustomEvent('change', {
+          detail: { checked: this.checked, value: this.value },
+          bubbles: true,
+          composed: true,
+        }),
+      );
     });
   }
 

--- a/src/components/dialog/dialog.stories.ts
+++ b/src/components/dialog/dialog.stories.ts
@@ -12,7 +12,9 @@ export const Default = () => html`
     <span slot="title">Dialog Title</span>
     <p>This is the dialog content. You can put anything here.</p>
     <div slot="footer">
-      <elx-button variant="ghost" onclick="document.querySelector('#dialog1').close()">Cancel</elx-button>
+      <elx-button variant="ghost" onclick="document.querySelector('#dialog1').close()"
+        >Cancel</elx-button
+      >
       <elx-button onclick="document.querySelector('#dialog1').close()">Confirm</elx-button>
     </div>
   </elx-dialog>

--- a/src/components/dialog/dialog.test.ts
+++ b/src/components/dialog/dialog.test.ts
@@ -6,7 +6,9 @@ describe('elx-dialog', () => {
     expect(customElements.get('elx-dialog')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders with overlay and dialog', () => {
     const el = document.createElement('elx-dialog');
@@ -50,7 +52,9 @@ describe('elx-dialog', () => {
     el.setAttribute('open', '');
     document.body.appendChild(el);
     let fired = false;
-    el.addEventListener('close', () => { fired = true; });
+    el.addEventListener('close', () => {
+      fired = true;
+    });
     (el as any).close();
     expect(fired).toBe(true);
   });

--- a/src/components/dialog/dialog.ts
+++ b/src/components/dialog/dialog.ts
@@ -2,22 +2,30 @@ export class ElxDialog extends HTMLElement {
   static observedAttributes = ['open'];
 
   private _previousActive: HTMLElement | null = null;
-  private _focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  private _focusableSelector =
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
   }
 
-  connectedCallback() { this._buildDom(); this._update(); }
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
   disconnectedCallback() {
     this._restoreFocus();
     document.removeEventListener('keydown', this._onKeydown);
   }
 
-  attributeChangedCallback() { this._update(); }
+  attributeChangedCallback() {
+    this._update();
+  }
 
-  get open(): boolean { return this.hasAttribute('open'); }
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
   set open(val: boolean) {
     val ? this.setAttribute('open', '') : this.removeAttribute('open');
   }
@@ -199,7 +207,9 @@ export class ElxDialog extends HTMLElement {
     }
   }
 
-  public show() { this.open = true; }
+  public show() {
+    this.open = true;
+  }
   public close() {
     this.open = false;
     this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));

--- a/src/components/input/input.stories.ts
+++ b/src/components/input/input.stories.ts
@@ -7,11 +7,11 @@ export default {
   argTypes: {
     type: {
       control: { type: 'select' },
-      options: ['text', 'password', 'email', 'number', 'tel', 'url', 'search']
+      options: ['text', 'password', 'email', 'number', 'tel', 'url', 'search'],
     },
     size: {
       control: { type: 'select' },
-      options: ['sm', 'md', 'lg']
+      options: ['sm', 'md', 'lg'],
     },
     disabled: { control: 'boolean' },
     readonly: { control: 'boolean' },
@@ -20,11 +20,22 @@ export default {
     placeholder: { control: 'text' },
     value: { control: 'text' },
     label: { control: 'text' },
-    name: { control: 'text' }
-  }
+    name: { control: 'text' },
+  },
 };
 
-const Template = ({ type, size, disabled, readonly, required, error, placeholder, value, label, name }: any) => html`
+const Template = ({
+  type,
+  size,
+  disabled,
+  readonly,
+  required,
+  error,
+  placeholder,
+  value,
+  label,
+  name,
+}: any) => html`
   <elx-input
     type=${type}
     size=${size}
@@ -40,25 +51,113 @@ const Template = ({ type, size, disabled, readonly, required, error, placeholder
 `;
 
 export const Default = Template.bind({});
-(Default as any).args = { type: 'text', size: 'md', disabled: false, readonly: false, required: false, error: false, placeholder: 'Enter text...', value: '', label: '', name: '' };
+(Default as any).args = {
+  type: 'text',
+  size: 'md',
+  disabled: false,
+  readonly: false,
+  required: false,
+  error: false,
+  placeholder: 'Enter text...',
+  value: '',
+  label: '',
+  name: '',
+};
 
 export const WithLabel = Template.bind({});
-(WithLabel as any).args = { type: 'text', size: 'md', disabled: false, readonly: false, required: false, error: false, placeholder: 'Enter your email', value: '', label: 'Email', name: 'email' };
+(WithLabel as any).args = {
+  type: 'text',
+  size: 'md',
+  disabled: false,
+  readonly: false,
+  required: false,
+  error: false,
+  placeholder: 'Enter your email',
+  value: '',
+  label: 'Email',
+  name: 'email',
+};
 
 export const Email = Template.bind({});
-(Email as any).args = { type: 'email', size: 'md', disabled: false, readonly: false, required: true, error: false, placeholder: 'you@example.com', value: '', label: 'Email Address', name: 'email' };
+(Email as any).args = {
+  type: 'email',
+  size: 'md',
+  disabled: false,
+  readonly: false,
+  required: true,
+  error: false,
+  placeholder: 'you@example.com',
+  value: '',
+  label: 'Email Address',
+  name: 'email',
+};
 
 export const Password = Template.bind({});
-(Password as any).args = { type: 'password', size: 'md', disabled: false, readonly: false, required: true, error: false, placeholder: 'Enter password', value: '', label: 'Password', name: 'password' };
+(Password as any).args = {
+  type: 'password',
+  size: 'md',
+  disabled: false,
+  readonly: false,
+  required: true,
+  error: false,
+  placeholder: 'Enter password',
+  value: '',
+  label: 'Password',
+  name: 'password',
+};
 
 export const Error = Template.bind({});
-(Error as any).args = { type: 'text', size: 'md', disabled: false, readonly: false, required: false, error: true, placeholder: 'Invalid input', value: 'bad value', label: 'Field with error', name: 'field' };
+(Error as any).args = {
+  type: 'text',
+  size: 'md',
+  disabled: false,
+  readonly: false,
+  required: false,
+  error: true,
+  placeholder: 'Invalid input',
+  value: 'bad value',
+  label: 'Field with error',
+  name: 'field',
+};
 
 export const Disabled = Template.bind({});
-(Disabled as any).args = { type: 'text', size: 'md', disabled: true, readonly: false, required: false, error: false, placeholder: 'Disabled input', value: '', label: 'Disabled', name: '' };
+(Disabled as any).args = {
+  type: 'text',
+  size: 'md',
+  disabled: true,
+  readonly: false,
+  required: false,
+  error: false,
+  placeholder: 'Disabled input',
+  value: '',
+  label: 'Disabled',
+  name: '',
+};
 
 export const Small = Template.bind({});
-(Small as any).args = { type: 'text', size: 'sm', disabled: false, readonly: false, required: false, error: false, placeholder: 'Small input', value: '', label: 'Small', name: '' };
+(Small as any).args = {
+  type: 'text',
+  size: 'sm',
+  disabled: false,
+  readonly: false,
+  required: false,
+  error: false,
+  placeholder: 'Small input',
+  value: '',
+  label: 'Small',
+  name: '',
+};
 
 export const Large = Template.bind({});
-(Large as any).args = { type: 'text', size: 'lg', disabled: false, readonly: false, required: false, error: false, placeholder: 'Large input', value: '', label: 'Large', name: '' };
+(Large as any).args = {
+  type: 'text',
+  size: 'lg',
+  disabled: false,
+  readonly: false,
+  required: false,
+  error: false,
+  placeholder: 'Large input',
+  value: '',
+  label: 'Large',
+  name: '',
+};

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -1,15 +1,23 @@
 const VALID_SIZES = ['sm', 'md', 'lg'] as const;
 const VALID_TYPES = ['text', 'password', 'email', 'number', 'tel', 'url', 'search'] as const;
 
-type Size = typeof VALID_SIZES[number];
-type InputType = typeof VALID_TYPES[number];
+type Size = (typeof VALID_SIZES)[number];
+type InputType = (typeof VALID_TYPES)[number];
 
 let uid = 0;
 
 export class ElxInput extends HTMLElement {
   static observedAttributes = [
-    'type', 'size', 'disabled', 'readonly', 'placeholder',
-    'value', 'name', 'required', 'error', 'label'
+    'type',
+    'size',
+    'disabled',
+    'readonly',
+    'placeholder',
+    'value',
+    'name',
+    'required',
+    'error',
+    'label',
   ];
 
   private _input: HTMLInputElement | null = null;
@@ -37,16 +45,18 @@ export class ElxInput extends HTMLElement {
       : 'text';
   }
 
-  set type(val: string) { this.setAttribute('type', val); }
+  set type(val: string) {
+    this.setAttribute('type', val);
+  }
 
   get size(): Size {
     const val = this.getAttribute('size');
-    return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1
-      ? (val as Size)
-      : 'md';
+    return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
   }
 
-  set size(val: string) { this.setAttribute('size', val); }
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
 
   get value(): string {
     return this._input?.value ?? this.getAttribute('value') ?? '';
@@ -57,26 +67,54 @@ export class ElxInput extends HTMLElement {
     this.setAttribute('value', val);
   }
 
-  get name(): string { return this.getAttribute('name') ?? ''; }
-  set name(val: string) { this.setAttribute('name', val); }
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+  set name(val: string) {
+    this.setAttribute('name', val);
+  }
 
-  get placeholder(): string { return this.getAttribute('placeholder') ?? ''; }
-  set placeholder(val: string) { this.setAttribute('placeholder', val); }
+  get placeholder(): string {
+    return this.getAttribute('placeholder') ?? '';
+  }
+  set placeholder(val: string) {
+    this.setAttribute('placeholder', val);
+  }
 
-  get disabled(): boolean { return this.hasAttribute('disabled'); }
-  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
 
-  get readonly(): boolean { return this.hasAttribute('readonly'); }
-  set readonly(val: boolean) { val ? this.setAttribute('readonly', '') : this.removeAttribute('readonly'); }
+  get readonly(): boolean {
+    return this.hasAttribute('readonly');
+  }
+  set readonly(val: boolean) {
+    val ? this.setAttribute('readonly', '') : this.removeAttribute('readonly');
+  }
 
-  get required(): boolean { return this.hasAttribute('required'); }
-  set required(val: boolean) { val ? this.setAttribute('required', '') : this.removeAttribute('required'); }
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+  set required(val: boolean) {
+    val ? this.setAttribute('required', '') : this.removeAttribute('required');
+  }
 
-  get error(): boolean { return this.hasAttribute('error'); }
-  set error(val: boolean) { val ? this.setAttribute('error', '') : this.removeAttribute('error'); }
+  get error(): boolean {
+    return this.hasAttribute('error');
+  }
+  set error(val: boolean) {
+    val ? this.setAttribute('error', '') : this.removeAttribute('error');
+  }
 
-  focus() { this._input?.focus(); }
-  blur() { this._input?.blur(); }
+  focus() {
+    this._input?.focus();
+  }
+  blur() {
+    this._input?.blur();
+  }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -125,17 +163,23 @@ export class ElxInput extends HTMLElement {
     this.shadowRoot!.appendChild(wrapper);
 
     this._input.addEventListener('input', () => {
-      this.dispatchEvent(new CustomEvent('input', {
-        detail: { value: this._input!.value },
-        bubbles: true, composed: true
-      }));
+      this.dispatchEvent(
+        new CustomEvent('input', {
+          detail: { value: this._input!.value },
+          bubbles: true,
+          composed: true,
+        }),
+      );
     });
 
     this._input.addEventListener('change', () => {
-      this.dispatchEvent(new CustomEvent('change', {
-        detail: { value: this._input!.value },
-        bubbles: true, composed: true
-      }));
+      this.dispatchEvent(
+        new CustomEvent('change', {
+          detail: { value: this._input!.value },
+          bubbles: true,
+          composed: true,
+        }),
+      );
     });
 
     this._input.addEventListener('focus', () => {

--- a/src/components/radio/radio.test.ts
+++ b/src/components/radio/radio.test.ts
@@ -7,7 +7,9 @@ describe('elx-radio', () => {
     expect(customElements.get('elx-radio-group')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders with default props', () => {
     const el = document.createElement('elx-radio');
@@ -77,7 +79,9 @@ describe('elx-radio', () => {
     const el = document.createElement('elx-radio');
     el.setAttribute('disabled', '');
     document.body.appendChild(el);
-    expect(el.shadowRoot!.querySelector('.radio-circle')!.classList.contains('disabled')).toBe(true);
+    expect(el.shadowRoot!.querySelector('.radio-circle')!.classList.contains('disabled')).toBe(
+      true,
+    );
   });
 
   it('sets name and value on input', () => {
@@ -109,7 +113,9 @@ describe('elx-radio', () => {
   it('label htmlFor matches input id', () => {
     const el = document.createElement('elx-radio');
     document.body.appendChild(el);
-    expect(el.shadowRoot!.querySelector('label')!.htmlFor).toBe(el.shadowRoot!.querySelector('input')!.id);
+    expect(el.shadowRoot!.querySelector('label')!.htmlFor).toBe(
+      el.shadowRoot!.querySelector('input')!.id,
+    );
   });
 
   it('dispatches change event on selection', () => {
@@ -118,7 +124,9 @@ describe('elx-radio', () => {
     el.setAttribute('name', 'fruit');
     document.body.appendChild(el);
     let detail: any = null;
-    el.addEventListener('change', (e: any) => { detail = e.detail; });
+    el.addEventListener('change', (e: any) => {
+      detail = e.detail;
+    });
     el.shadowRoot!.querySelector('input')!.dispatchEvent(new Event('change', { bubbles: true }));
     expect(detail).toBeTruthy();
     expect(detail.value).toBe('apple');
@@ -130,7 +138,9 @@ describe('elx-radio', () => {
     el.setAttribute('disabled', '');
     document.body.appendChild(el);
     let fired = false;
-    el.addEventListener('change', () => { fired = true; });
+    el.addEventListener('change', () => {
+      fired = true;
+    });
     el.shadowRoot!.querySelector('input')!.dispatchEvent(new Event('change', { bubbles: true }));
     expect(fired).toBe(false);
   });
@@ -153,7 +163,9 @@ describe('elx-radio', () => {
 });
 
 describe('elx-radio-group', () => {
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders with slot', () => {
     const group = document.createElement('elx-radio-group');

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -1,5 +1,5 @@
 const VALID_SIZES = ['sm', 'md', 'lg'] as const;
-type Size = typeof VALID_SIZES[number];
+type Size = (typeof VALID_SIZES)[number];
 
 let uid = 0;
 
@@ -16,32 +16,63 @@ export class ElxRadio extends HTMLElement {
     this.attachShadow({ mode: 'open' });
   }
 
-  connectedCallback() { this._buildDom(); this._update(); }
-  attributeChangedCallback() { this._update(); }
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+  attributeChangedCallback() {
+    this._update();
+  }
 
-  get checked(): boolean { return this.hasAttribute('checked'); }
-  set checked(val: boolean) { val ? this.setAttribute('checked', '') : this.removeAttribute('checked'); }
+  get checked(): boolean {
+    return this.hasAttribute('checked');
+  }
+  set checked(val: boolean) {
+    val ? this.setAttribute('checked', '') : this.removeAttribute('checked');
+  }
 
-  get disabled(): boolean { return this.hasAttribute('disabled'); }
-  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
 
   get size(): Size {
     const val = this.getAttribute('size');
     return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
   }
-  set size(val: string) { this.setAttribute('size', val); }
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
 
-  get name(): string { return this.getAttribute('name') ?? ''; }
-  set name(val: string) { this.setAttribute('name', val); }
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+  set name(val: string) {
+    this.setAttribute('name', val);
+  }
 
-  get value(): string { return this.getAttribute('value') ?? ''; }
-  set value(val: string) { this.setAttribute('value', val); }
+  get value(): string {
+    return this.getAttribute('value') ?? '';
+  }
+  set value(val: string) {
+    this.setAttribute('value', val);
+  }
 
-  get label(): string { return this.getAttribute('label') ?? ''; }
-  set label(val: string) { this.setAttribute('label', val); }
+  get label(): string {
+    return this.getAttribute('label') ?? '';
+  }
+  set label(val: string) {
+    this.setAttribute('label', val);
+  }
 
-  focus() { this._input?.focus(); }
-  blur() { this._input?.blur(); }
+  focus() {
+    this._input?.focus();
+  }
+  blur() {
+    this._input?.blur();
+  }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -137,10 +168,13 @@ export class ElxRadio extends HTMLElement {
       this.setAttribute('checked', '');
       // Uncheck siblings in same group
       this._uncheckSiblings();
-      this.dispatchEvent(new CustomEvent('change', {
-        detail: { value: this.value, name: this.name },
-        bubbles: true, composed: true
-      }));
+      this.dispatchEvent(
+        new CustomEvent('change', {
+          detail: { value: this.value, name: this.name },
+          bubbles: true,
+          composed: true,
+        }),
+      );
     });
   }
 
@@ -148,7 +182,7 @@ export class ElxRadio extends HTMLElement {
     const parent = this.parentElement;
     if (!parent) return;
     const siblings = parent.querySelectorAll(`elx-radio[name="${this.name}"]`);
-    siblings.forEach(sib => {
+    siblings.forEach((sib) => {
       if (sib !== this && sib.hasAttribute('checked')) {
         sib.removeAttribute('checked');
       }
@@ -201,19 +235,38 @@ export class ElxRadioGroup extends HTMLElement {
     this.addEventListener('change', this._handleChange.bind(this) as EventListener);
   }
 
-  attributeChangedCallback() { this._propagateAttrs(); }
+  attributeChangedCallback() {
+    this._propagateAttrs();
+  }
 
-  get name(): string { return this.getAttribute('name') ?? ''; }
-  set name(val: string) { this.setAttribute('name', val); }
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+  set name(val: string) {
+    this.setAttribute('name', val);
+  }
 
-  get value(): string { return this.getAttribute('value') ?? ''; }
-  set value(val: string) { this.setAttribute('value', val); this._syncChecked(); }
+  get value(): string {
+    return this.getAttribute('value') ?? '';
+  }
+  set value(val: string) {
+    this.setAttribute('value', val);
+    this._syncChecked();
+  }
 
-  get disabled(): boolean { return this.hasAttribute('disabled'); }
-  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
 
-  get orientation(): string { return this.getAttribute('orientation') ?? 'vertical'; }
-  set orientation(val: string) { this.setAttribute('orientation', val); }
+  get orientation(): string {
+    return this.getAttribute('orientation') ?? 'vertical';
+  }
+  set orientation(val: string) {
+    this.setAttribute('orientation', val);
+  }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -229,7 +282,7 @@ export class ElxRadioGroup extends HTMLElement {
 
   private _propagateAttrs() {
     const radios = this.querySelectorAll('elx-radio');
-    radios.forEach(radio => {
+    radios.forEach((radio) => {
       if (this.name) radio.setAttribute('name', this.name);
       if (this.disabled) radio.setAttribute('disabled', '');
     });
@@ -238,7 +291,7 @@ export class ElxRadioGroup extends HTMLElement {
 
   private _syncChecked() {
     const radios = this.querySelectorAll('elx-radio');
-    radios.forEach(radio => {
+    radios.forEach((radio) => {
       if (radio.getAttribute('value') === this.value) {
         radio.setAttribute('checked', '');
       } else {

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -43,24 +43,34 @@ export class ElxSelect extends HTMLElement {
     }
   }
 
-  get options(): SelectOption[] { return this._options; }
+  get options(): SelectOption[] {
+    return this._options;
+  }
   set options(val: SelectOption[]) {
     this._options = val;
     this._renderOptions();
     this._updateDisplay();
   }
 
-  get value(): string { return this._value; }
+  get value(): string {
+    return this._value;
+  }
   set value(val: string) {
     this._value = val;
     this.setAttribute('value', val);
     this._updateDisplay();
   }
 
-  get placeholder(): string { return this.getAttribute('placeholder') ?? 'Select...'; }
-  set placeholder(val: string) { this.setAttribute('placeholder', val); }
+  get placeholder(): string {
+    return this.getAttribute('placeholder') ?? 'Select...';
+  }
+  set placeholder(val: string) {
+    this.setAttribute('placeholder', val);
+  }
 
-  get disabled(): boolean { return this.hasAttribute('disabled'); }
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
   set disabled(val: boolean) {
     if (val) this.setAttribute('disabled', '');
     else this.removeAttribute('disabled');
@@ -194,7 +204,10 @@ export class ElxSelect extends HTMLElement {
     arrow.setAttribute('fill', 'currentColor');
     const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
     path.setAttribute('fill-rule', 'evenodd');
-    path.setAttribute('d', 'M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z');
+    path.setAttribute(
+      'd',
+      'M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z',
+    );
     path.setAttribute('clip-rule', 'evenodd');
     arrow.appendChild(path);
 
@@ -250,7 +263,7 @@ export class ElxSelect extends HTMLElement {
     const text = this._button.querySelector('.trigger-text');
     if (!text) return;
 
-    const selected = this._options.find(o => o.value === this._value);
+    const selected = this._options.find((o) => o.value === this._value);
     if (selected) {
       text.textContent = selected.label;
       text.classList.remove('placeholder');
@@ -260,7 +273,7 @@ export class ElxSelect extends HTMLElement {
     }
 
     // Update selected state in listbox
-    this._listbox?.querySelectorAll('.option').forEach(opt => {
+    this._listbox?.querySelectorAll('.option').forEach((opt) => {
       const val = opt.getAttribute('data-value');
       if (val === this._value) {
         opt.classList.add('selected');
@@ -284,7 +297,7 @@ export class ElxSelect extends HTMLElement {
     document.addEventListener('keydown', this._onDocumentKeydown);
 
     // Focus first selected or first option
-    const selectedIndex = this._options.findIndex(o => o.value === this._value);
+    const selectedIndex = this._options.findIndex((o) => o.value === this._value);
     this._focusOption(selectedIndex >= 0 ? selectedIndex : 0);
   }
 
@@ -294,7 +307,7 @@ export class ElxSelect extends HTMLElement {
     this._listbox?.classList.remove('open');
     document.removeEventListener('keydown', this._onDocumentKeydown);
     this._focusedIndex = -1;
-    this._listbox?.querySelectorAll('.option').forEach(o => o.classList.remove('focused'));
+    this._listbox?.querySelectorAll('.option').forEach((o) => o.classList.remove('focused'));
   }
 
   private _selectOption(opt: SelectOption) {

--- a/src/components/separator/separator.stories.ts
+++ b/src/components/separator/separator.stories.ts
@@ -5,9 +5,9 @@ export default {
   title: 'Components/Separator',
   tags: ['autodocs'],
   argTypes: {
-    orientation: { 
-      control: { type: 'select' }, 
-      options: ['horizontal', 'vertical'] 
+    orientation: {
+      control: { type: 'select' },
+      options: ['horizontal', 'vertical'],
     },
   },
 };

--- a/src/components/separator/separator.ts
+++ b/src/components/separator/separator.ts
@@ -1,5 +1,5 @@
 const VALID_ORIENTATIONS = ['horizontal', 'vertical'] as const;
-type Orientation = typeof VALID_ORIENTATIONS[number];
+type Orientation = (typeof VALID_ORIENTATIONS)[number];
 
 export class ElxSeparator extends HTMLElement {
   static observedAttributes = ['orientation'];
@@ -69,7 +69,7 @@ export class ElxSeparator extends HTMLElement {
   private _updateOrientation() {
     const separator = this.shadowRoot?.querySelector('.separator');
     if (!separator) return;
-    
+
     separator.className = `separator ${this.orientation}`;
     separator.setAttribute('aria-orientation', this.orientation);
   }

--- a/src/components/switch/switch.stories.ts
+++ b/src/components/switch/switch.stories.ts
@@ -10,8 +10,8 @@ export default {
     size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
     label: { control: 'text' },
     name: { control: 'text' },
-    value: { control: 'text' }
-  }
+    value: { control: 'text' },
+  },
 };
 
 const Template = ({ checked, disabled, size, label, name, value }: any) => html`
@@ -26,16 +26,51 @@ const Template = ({ checked, disabled, size, label, name, value }: any) => html`
 `;
 
 export const Default = Template.bind({});
-(Default as any).args = { checked: false, disabled: false, size: 'md', label: 'Dark mode', name: 'darkmode', value: 'on' };
+(Default as any).args = {
+  checked: false,
+  disabled: false,
+  size: 'md',
+  label: 'Dark mode',
+  name: 'darkmode',
+  value: 'on',
+};
 
 export const Checked = Template.bind({});
-(Checked as any).args = { checked: true, disabled: false, size: 'md', label: 'Enabled', name: '', value: 'on' };
+(Checked as any).args = {
+  checked: true,
+  disabled: false,
+  size: 'md',
+  label: 'Enabled',
+  name: '',
+  value: 'on',
+};
 
 export const Disabled = Template.bind({});
-(Disabled as any).args = { checked: false, disabled: true, size: 'md', label: 'Disabled', name: '', value: 'on' };
+(Disabled as any).args = {
+  checked: false,
+  disabled: true,
+  size: 'md',
+  label: 'Disabled',
+  name: '',
+  value: 'on',
+};
 
 export const Small = Template.bind({});
-(Small as any).args = { checked: true, disabled: false, size: 'sm', label: 'Small', name: '', value: 'on' };
+(Small as any).args = {
+  checked: true,
+  disabled: false,
+  size: 'sm',
+  label: 'Small',
+  name: '',
+  value: 'on',
+};
 
 export const Large = Template.bind({});
-(Large as any).args = { checked: true, disabled: false, size: 'lg', label: 'Large', name: '', value: 'on' };
+(Large as any).args = {
+  checked: true,
+  disabled: false,
+  size: 'lg',
+  label: 'Large',
+  name: '',
+  value: 'on',
+};

--- a/src/components/switch/switch.test.ts
+++ b/src/components/switch/switch.test.ts
@@ -6,7 +6,9 @@ describe('elx-switch', () => {
     expect(customElements.get('elx-switch')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders with default props', () => {
     const el = document.createElement('elx-switch');
@@ -106,7 +108,9 @@ describe('elx-switch', () => {
     const el = document.createElement('elx-switch');
     document.body.appendChild(el);
     let detail: any = null;
-    el.addEventListener('change', (e: any) => { detail = e.detail; });
+    el.addEventListener('change', (e: any) => {
+      detail = e.detail;
+    });
     const input = el.shadowRoot!.querySelector('input')!;
     input.checked = true;
     input.dispatchEvent(new Event('change', { bubbles: true }));
@@ -119,7 +123,9 @@ describe('elx-switch', () => {
     el.setAttribute('disabled', '');
     document.body.appendChild(el);
     let fired = false;
-    el.addEventListener('change', () => { fired = true; });
+    el.addEventListener('change', () => {
+      fired = true;
+    });
     const input = el.shadowRoot!.querySelector('input')!;
     input.dispatchEvent(new Event('change', { bubbles: true }));
     expect(fired).toBe(false);

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -1,5 +1,5 @@
 const VALID_SIZES = ['sm', 'md', 'lg'] as const;
-type Size = typeof VALID_SIZES[number];
+type Size = (typeof VALID_SIZES)[number];
 
 let uid = 0;
 
@@ -17,32 +17,63 @@ export class ElxSwitch extends HTMLElement {
     this.attachShadow({ mode: 'open' });
   }
 
-  connectedCallback() { this._buildDom(); this._update(); }
-  attributeChangedCallback() { this._update(); }
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+  attributeChangedCallback() {
+    this._update();
+  }
 
-  get checked(): boolean { return this.hasAttribute('checked'); }
-  set checked(val: boolean) { val ? this.setAttribute('checked', '') : this.removeAttribute('checked'); }
+  get checked(): boolean {
+    return this.hasAttribute('checked');
+  }
+  set checked(val: boolean) {
+    val ? this.setAttribute('checked', '') : this.removeAttribute('checked');
+  }
 
-  get disabled(): boolean { return this.hasAttribute('disabled'); }
-  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
 
   get size(): Size {
     const val = this.getAttribute('size');
     return (VALID_SIZES as readonly string[]).indexOf(val as string) !== -1 ? (val as Size) : 'md';
   }
-  set size(val: string) { this.setAttribute('size', val); }
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
 
-  get name(): string { return this.getAttribute('name') ?? ''; }
-  set name(val: string) { this.setAttribute('name', val); }
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+  set name(val: string) {
+    this.setAttribute('name', val);
+  }
 
-  get value(): string { return this.getAttribute('value') ?? 'on'; }
-  set value(val: string) { this.setAttribute('value', val); }
+  get value(): string {
+    return this.getAttribute('value') ?? 'on';
+  }
+  set value(val: string) {
+    this.setAttribute('value', val);
+  }
 
-  get label(): string { return this.getAttribute('label') ?? ''; }
-  set label(val: string) { this.setAttribute('label', val); }
+  get label(): string {
+    return this.getAttribute('label') ?? '';
+  }
+  set label(val: string) {
+    this.setAttribute('label', val);
+  }
 
-  focus() { this._input?.focus(); }
-  blur() { this._input?.blur(); }
+  focus() {
+    this._input?.focus();
+  }
+  blur() {
+    this._input?.blur();
+  }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -141,10 +172,13 @@ export class ElxSwitch extends HTMLElement {
       } else {
         this.removeAttribute('checked');
       }
-      this.dispatchEvent(new CustomEvent('change', {
-        detail: { checked: this.checked, value: this.value },
-        bubbles: true, composed: true
-      }));
+      this.dispatchEvent(
+        new CustomEvent('change', {
+          detail: { checked: this.checked, value: this.value },
+          bubbles: true,
+          composed: true,
+        }),
+      );
     });
   }
 

--- a/src/components/tabs/tabs.test.ts
+++ b/src/components/tabs/tabs.test.ts
@@ -7,7 +7,9 @@ describe('elx-tabs', () => {
     expect(customElements.get('elx-tab-panel')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('renders tab list and panels', () => {
     const el = document.createElement('elx-tabs');
@@ -81,7 +83,9 @@ describe('elx-tabs', () => {
     `;
     document.body.appendChild(el);
     let detail: any = null;
-    el.addEventListener('change', (e: any) => { detail = e.detail; });
+    el.addEventListener('change', (e: any) => {
+      detail = e.detail;
+    });
     const tabs = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.tab');
     tabs[1].click();
     expect(detail.value).toBe('b');
@@ -119,7 +123,7 @@ describe('elx-tabs', () => {
     const tabs = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.tab');
     tabs[0].focus();
     el.shadowRoot!.querySelector('.tab-list')!.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
     );
     expect((el as any).value).toBe('b');
   });
@@ -135,7 +139,7 @@ describe('elx-tabs', () => {
     const tabs = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.tab');
     tabs[1].focus();
     el.shadowRoot!.querySelector('.tab-list')!.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true })
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
     );
     expect((el as any).value).toBe('a');
   });
@@ -149,7 +153,7 @@ describe('elx-tabs', () => {
     `;
     document.body.appendChild(el);
     el.shadowRoot!.querySelector('.tab-list')!.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'Home', bubbles: true })
+      new KeyboardEvent('keydown', { key: 'Home', bubbles: true }),
     );
     expect((el as any).value).toBe('a');
   });
@@ -163,7 +167,7 @@ describe('elx-tabs', () => {
     `;
     document.body.appendChild(el);
     el.shadowRoot!.querySelector('.tab-list')!.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'End', bubbles: true })
+      new KeyboardEvent('keydown', { key: 'End', bubbles: true }),
     );
     expect((el as any).value).toBe('c');
   });
@@ -174,7 +178,9 @@ describe('elx-tab-panel', () => {
     expect(customElements.get('elx-tab-panel')).toBeDefined();
   });
 
-  afterEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('is hidden by default', () => {
     const el = document.createElement('elx-tab-panel');

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -6,14 +6,27 @@ export class ElxTabPanel extends HTMLElement {
     this.attachShadow({ mode: 'open' });
   }
 
-  connectedCallback() { this._buildDom(); this._update(); }
-  attributeChangedCallback() { this._update(); }
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+  attributeChangedCallback() {
+    this._update();
+  }
 
-  get name(): string { return this.getAttribute('name') ?? ''; }
-  set name(val: string) { this.setAttribute('name', val); }
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+  set name(val: string) {
+    this.setAttribute('name', val);
+  }
 
-  get active(): boolean { return this.hasAttribute('active'); }
-  set active(val: boolean) { val ? this.setAttribute('active', '') : this.removeAttribute('active'); }
+  get active(): boolean {
+    return this.hasAttribute('active');
+  }
+  set active(val: boolean) {
+    val ? this.setAttribute('active', '') : this.removeAttribute('active');
+  }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -55,10 +68,16 @@ export class ElxTabs extends HTMLElement {
     this._renderTabs();
   }
 
-  attributeChangedCallback() { this._renderTabs(); }
+  attributeChangedCallback() {
+    this._renderTabs();
+  }
 
-  get value(): string { return this.getAttribute('value') ?? ''; }
-  set value(val: string) { this.setAttribute('value', val); }
+  get value(): string {
+    return this.getAttribute('value') ?? '';
+  }
+  set value(val: string) {
+    this.setAttribute('value', val);
+  }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -115,7 +134,7 @@ export class ElxTabs extends HTMLElement {
     this._rendering = true;
 
     const panels: Element[] = [];
-    this.querySelectorAll('elx-tab-panel').forEach(p => panels.push(p));
+    this.querySelectorAll('elx-tab-panel').forEach((p) => panels.push(p));
     const currentValue = this.value || (panels[0]?.getAttribute('name') ?? '');
 
     while (this._tabList.firstChild) {
@@ -156,19 +175,24 @@ export class ElxTabs extends HTMLElement {
     this.value = name;
     this._rendering = false;
     this._renderTabs();
-    this.dispatchEvent(new CustomEvent('change', {
-      bubbles: true,
-      composed: true,
-      detail: { value: name }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('change', {
+        bubbles: true,
+        composed: true,
+        detail: { value: name },
+      }),
+    );
   }
 
   private _onKeydown = (e: KeyboardEvent) => {
     const tabs: HTMLButtonElement[] = [];
-    this._tabList!.querySelectorAll<HTMLButtonElement>('.tab').forEach(t => tabs.push(t));
+    this._tabList!.querySelectorAll<HTMLButtonElement>('.tab').forEach((t) => tabs.push(t));
     let current = -1;
     for (let i = 0; i < tabs.length; i++) {
-      if (tabs[i].getAttribute('aria-selected') === 'true') { current = i; break; }
+      if (tabs[i].getAttribute('aria-selected') === 'true') {
+        current = i;
+        break;
+      }
     }
     let next = current;
 
@@ -186,7 +210,7 @@ export class ElxTabs extends HTMLElement {
 
     e.preventDefault();
     const panels: Element[] = [];
-    this.querySelectorAll('elx-tab-panel').forEach(p => panels.push(p));
+    this.querySelectorAll('elx-tab-panel').forEach((p) => panels.push(p));
     const name = panels[next]?.getAttribute('name') ?? '';
     this._selectTab(name);
     tabs[next]?.focus();

--- a/src/components/text/text.stories.ts
+++ b/src/components/text/text.stories.ts
@@ -30,32 +30,75 @@ export default {
 };
 
 const Template = ({ as, size, weight, color, align, label }: any) => html`
-  <elx-text
-    as=${as}
-    size=${size}
-    weight=${weight}
-    color=${color}
-    align=${align}
-  >${label}</elx-text>
+  <elx-text as=${as} size=${size} weight=${weight} color=${color} align=${align}>${label}</elx-text>
 `;
 
 export const Paragraph = Template.bind({});
-(Paragraph as any).args = { as: 'p', size: 'base', weight: 'normal', color: 'default', align: 'left', label: 'This is a paragraph of text.' };
+(Paragraph as any).args = {
+  as: 'p',
+  size: 'base',
+  weight: 'normal',
+  color: 'default',
+  align: 'left',
+  label: 'This is a paragraph of text.',
+};
 
 export const Heading1 = Template.bind({});
-(Heading1 as any).args = { as: 'h1', size: '4xl', weight: 'semibold', color: 'default', align: 'left', label: 'Heading 1' };
+(Heading1 as any).args = {
+  as: 'h1',
+  size: '4xl',
+  weight: 'semibold',
+  color: 'default',
+  align: 'left',
+  label: 'Heading 1',
+};
 
 export const Heading2 = Template.bind({});
-(Heading2 as any).args = { as: 'h2', size: '3xl', weight: 'semibold', color: 'default', align: 'left', label: 'Heading 2' };
+(Heading2 as any).args = {
+  as: 'h2',
+  size: '3xl',
+  weight: 'semibold',
+  color: 'default',
+  align: 'left',
+  label: 'Heading 2',
+};
 
 export const Muted = Template.bind({});
-(Muted as any).args = { as: 'p', size: 'sm', weight: 'normal', color: 'muted', align: 'left', label: 'Muted helper text' };
+(Muted as any).args = {
+  as: 'p',
+  size: 'sm',
+  weight: 'normal',
+  color: 'muted',
+  align: 'left',
+  label: 'Muted helper text',
+};
 
 export const Primary = Template.bind({});
-(Primary as any).args = { as: 'span', size: 'base', weight: 'medium', color: 'primary', align: 'left', label: 'Primary colored text' };
+(Primary as any).args = {
+  as: 'span',
+  size: 'base',
+  weight: 'medium',
+  color: 'primary',
+  align: 'left',
+  label: 'Primary colored text',
+};
 
 export const Danger = Template.bind({});
-(Danger as any).args = { as: 'p', size: 'base', weight: 'medium', color: 'danger', align: 'left', label: 'Something went wrong.' };
+(Danger as any).args = {
+  as: 'p',
+  size: 'base',
+  weight: 'medium',
+  color: 'danger',
+  align: 'left',
+  label: 'Something went wrong.',
+};
 
 export const Centered = Template.bind({});
-(Centered as any).args = { as: 'p', size: 'lg', weight: 'normal', color: 'default', align: 'center', label: 'Centered text' };
+(Centered as any).args = {
+  as: 'p',
+  size: 'lg',
+  weight: 'normal',
+  color: 'default',
+  align: 'center',
+  label: 'Centered text',
+};

--- a/src/components/text/text.test.ts
+++ b/src/components/text/text.test.ts
@@ -96,7 +96,9 @@ describe('elx-text', () => {
       document.body.appendChild(el);
 
       const inner = el.shadowRoot!.querySelector(tag);
-      expect(inner!.style.fontWeight, `${tag} should default to semibold`).toBe('var(--elx-font-weight-semibold)');
+      expect(inner!.style.fontWeight, `${tag} should default to semibold`).toBe(
+        'var(--elx-font-weight-semibold)',
+      );
     }
   });
 
@@ -118,7 +120,9 @@ describe('elx-text', () => {
       document.body.appendChild(el);
 
       const inner = el.shadowRoot!.querySelector(tag) as HTMLElement;
-      expect(inner!.style.fontSize, `as="${tag}" should default to size ${size}`).toBe(`var(--elx-font-size-${size})`);
+      expect(inner!.style.fontSize, `as="${tag}" should default to size ${size}`).toBe(
+        `var(--elx-font-size-${size})`,
+      );
     }
   });
 

--- a/src/components/text/text.ts
+++ b/src/components/text/text.ts
@@ -4,11 +4,11 @@ const VALID_WEIGHTS = ['normal', 'medium', 'semibold', 'bold'] as const;
 const VALID_COLORS = ['default', 'muted', 'primary', 'danger', 'success'] as const;
 const VALID_ALIGNS = ['left', 'center', 'right'] as const;
 
-type Tag = typeof VALID_TAGS[number];
-type Size = typeof VALID_SIZES[number];
-type Weight = typeof VALID_WEIGHTS[number];
-type Color = typeof VALID_COLORS[number];
-type Align = typeof VALID_ALIGNS[number];
+type Tag = (typeof VALID_TAGS)[number];
+type Size = (typeof VALID_SIZES)[number];
+type Weight = (typeof VALID_WEIGHTS)[number];
+type Color = (typeof VALID_COLORS)[number];
+type Align = (typeof VALID_ALIGNS)[number];
 
 const DEFAULT_SIZES: Record<Tag, Size> = {
   h1: '4xl',

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -1,5 +1,5 @@
 const VALID_POSITIONS = ['top', 'right', 'bottom', 'left'] as const;
-type Position = typeof VALID_POSITIONS[number];
+type Position = (typeof VALID_POSITIONS)[number];
 
 export class ElxTooltip extends HTMLElement {
   static observedAttributes = ['content', 'position'];
@@ -16,7 +16,7 @@ export class ElxTooltip extends HTMLElement {
 
   connectedCallback() {
     this._buildDom();
-    
+
     // The tooltip wraps its target via a slot
     const slot = this.shadowRoot!.querySelector('slot');
     slot?.addEventListener('slotchange', () => {
@@ -37,19 +37,27 @@ export class ElxTooltip extends HTMLElement {
       if (this._tooltip) this._tooltip.textContent = newVal;
     } else if (name === 'position') {
       if (this._tooltip) {
-        this._tooltip.dataset.position = VALID_POSITIONS.includes(newVal as Position) ? newVal : 'top';
+        this._tooltip.dataset.position = VALID_POSITIONS.includes(newVal as Position)
+          ? newVal
+          : 'top';
       }
     }
   }
 
-  get content(): string { return this.getAttribute('content') ?? ''; }
-  set content(val: string) { this.setAttribute('content', val); }
+  get content(): string {
+    return this.getAttribute('content') ?? '';
+  }
+  set content(val: string) {
+    this.setAttribute('content', val);
+  }
 
-  get position(): Position { 
+  get position(): Position {
     const pos = this.getAttribute('position') as Position;
     return VALID_POSITIONS.includes(pos) ? pos : 'top';
   }
-  set position(val: Position) { this.setAttribute('position', val); }
+  set position(val: Position) {
+    this.setAttribute('position', val);
+  }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -129,7 +137,7 @@ export class ElxTooltip extends HTMLElement {
     this._tooltip.setAttribute('aria-hidden', 'true');
     this._tooltip.dataset.position = this.position;
     this._tooltip.textContent = this.content;
-    
+
     // Generate a unique ID for ARIA association
     this._tooltip.id = `tooltip-${Math.random().toString(36).substring(2, 9)}`;
 
@@ -158,14 +166,14 @@ export class ElxTooltip extends HTMLElement {
 
   private _teardownTarget() {
     if (!this._target) return;
-    
+
     this._target.removeAttribute('aria-describedby');
     this._target.removeEventListener('mouseenter', this._onShow);
     this._target.removeEventListener('mouseleave', this._onHide);
     this._target.removeEventListener('focus', this._onShow);
     this._target.removeEventListener('blur', this._onHide);
     this._target.removeEventListener('keydown', this._onKeydown);
-    
+
     this._target = null;
   }
 

--- a/src/stories/design-tokens.stories.ts
+++ b/src/stories/design-tokens.stories.ts
@@ -93,7 +93,9 @@ export const Colors: StoryObj = {
         ${extraColors.map(
           (cssVar) => html`
             <div>
-              <div style="${swatchBoxStyle(cssVar)} border: 1px solid var(--elx-color-neutral-200);"></div>
+              <div
+                style="${swatchBoxStyle(cssVar)} border: 1px solid var(--elx-color-neutral-200);"
+              ></div>
               <div style="${swatchLabelStyle}">var(${cssVar})</div>
             </div>
           `,
@@ -185,7 +187,9 @@ export const Typography: StoryObj = {
         ({ token, label }) => html`
           <div style="${rowStyle}">
             <span style="${tokenLabelStyle}">${token} — ${label}</span>
-            <span style="font-weight: var(${token}); font-size: var(--elx-font-size-lg); font-family: var(--elx-font-family-sans);">
+            <span
+              style="font-weight: var(${token}); font-size: var(--elx-font-size-lg); font-family: var(--elx-font-family-sans);"
+            >
               The quick brown fox
             </span>
           </div>
@@ -198,8 +202,10 @@ export const Typography: StoryObj = {
         ({ token, label }) => html`
           <div style="${rowStyle}">
             <span style="${tokenLabelStyle}">${token} — ${label}</span>
-            <span style="line-height: var(${token}); font-size: var(--elx-font-size-base); font-family: var(--elx-font-family-sans); background: var(--elx-color-primary-50); padding: 4px 8px; border-radius: var(--elx-radius-sm);">
-              Line height sample<br/>Second line of text
+            <span
+              style="line-height: var(${token}); font-size: var(--elx-font-size-base); font-family: var(--elx-font-family-sans); background: var(--elx-color-primary-50); padding: 4px 8px; border-radius: var(--elx-radius-sm);"
+            >
+              Line height sample<br />Second line of text
             </span>
           </div>
         `,
@@ -226,14 +232,18 @@ export const BorderRadius: StoryObj = {
         ${radii.map(
           ({ token, label }) => html`
             <div style="text-align: center;">
-              <div style="
+              <div
+                style="
                 width: 96px;
                 height: 96px;
                 background: var(--elx-color-primary-500);
                 border-radius: var(${token});
                 box-shadow: 0 1px 3px rgba(0,0,0,.12);
-              "></div>
-              <div style="font-size: var(--elx-font-size-sm); font-weight: var(--elx-font-weight-semibold); margin-top: 8px;">
+              "
+              ></div>
+              <div
+                style="font-size: var(--elx-font-size-sm); font-weight: var(--elx-font-weight-semibold); margin-top: 8px;"
+              >
                 ${label}
               </div>
               <div style="${swatchLabelStyle} max-width: 96px;">var(${token})</div>


### PR DESCRIPTION
## Summary
- Adds ESLint with typescript-eslint for linting
- Adds Prettier for code formatting
- Adds eslint-config-prettier to avoid conflicts
- Configures rules for Lit/web component patterns (allowTernary for setters)
- Formats all source files with Prettier
- Adds `lint`, `lint:fix`, `format`, `format:check` scripts

## Test Plan
- 240 tests passing
- 0 lint errors (95 warnings, mostly `no-explicit-any` in tests/stories)