### PR TITLE
feat: add Toast/Notification component

### DIFF
--- a/src/components/toast/toast.stories.ts
+++ b/src/components/toast/toast.stories.ts
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import './toast.js';
+
+const meta: Meta = {
+  title: 'Components/Toast',
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Info: Story = {
+  render: () => {
+    const container = document.createElement('elx-toast-container');
+    const toast = document.createElement('elx-toast') as any;
+    toast.setAttribute('variant', 'info');
+    toast.textContent = 'This is an info message';
+    container.appendChild(toast);
+    setTimeout(() => toast.show(), 100);
+    return container;
+  },
+};
+
+export const Success: Story = {
+  render: () => {
+    const container = document.createElement('elx-toast-container');
+    const toast = document.createElement('elx-toast') as any;
+    toast.setAttribute('variant', 'success');
+    toast.textContent = 'Operation completed successfully!';
+    container.appendChild(toast);
+    setTimeout(() => toast.show(), 100);
+    return container;
+  },
+};
+
+export const Warning: Story = {
+  render: () => {
+    const container = document.createElement('elx-toast-container');
+    const toast = document.createElement('elx-toast') as any;
+    toast.setAttribute('variant', 'warning');
+    toast.textContent = 'Please review before continuing';
+    container.appendChild(toast);
+    setTimeout(() => toast.show(), 100);
+    return container;
+  },
+};
+
+export const Error: Story = {
+  render: () => {
+    const container = document.createElement('elx-toast-container');
+    const toast = document.createElement('elx-toast') as any;
+    toast.setAttribute('variant', 'error');
+    toast.textContent = 'Something went wrong. Please try again.';
+    container.appendChild(toast);
+    setTimeout(() => toast.show(), 100);
+    return container;
+  },
+};
+
+export const Dismissible: Story = {
+  render: () => {
+    const container = document.createElement('elx-toast-container');
+    const toast = document.createElement('elx-toast') as any;
+    toast.setAttribute('variant', 'info');
+    toast.setAttribute('dismissible', '');
+    toast.textContent = 'Click the X to dismiss';
+    container.appendChild(toast);
+    setTimeout(() => toast.show(), 100);
+    return container;
+  },
+};
+
+export const AutoDismiss: Story = {
+  render: () => {
+    const container = document.createElement('elx-toast-container');
+    const toast = document.createElement('elx-toast') as any;
+    toast.setAttribute('variant', 'success');
+    toast.setAttribute('duration', '3000');
+    toast.textContent = 'This will auto-dismiss in 3 seconds';
+    container.appendChild(toast);
+    setTimeout(() => toast.show(), 100);
+    return container;
+  },
+};
+
+export const ContainerPositions: Story = {
+  render: () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <p style="margin-bottom: 16px; font-family: sans-serif;">
+        Positions: top-right (default), top-left, top-center, bottom-right, bottom-left, bottom-center
+      </p>
+    `;
+    
+    const container = document.createElement('elx-toast-container') as any;
+    container.position = 'bottom-right';
+    const toast = document.createElement('elx-toast') as any;
+    toast.setAttribute('variant', 'info');
+    toast.setAttribute('dismissible', '');
+    toast.textContent = 'Bottom-right positioned toast';
+    container.appendChild(toast);
+    setTimeout(() => toast.show(), 100);
+    
+    div.appendChild(container);
+    return div;
+  },
+};
+
+export const ImperativeAPI: Story = {
+  render: () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <div style="display: flex; gap: 8px; margin-bottom: 16px; font-family: sans-serif;">
+        <button id="info-btn">Info</button>
+        <button id="success-btn">Success</button>
+        <button id="warning-btn">Warning</button>
+        <button id="error-btn">Error</button>
+      </div>
+    `;
+    
+    const container = document.createElement('elx-toast-container') as any;
+    div.appendChild(container);
+    
+    setTimeout(() => {
+      div.querySelector('#info-btn')?.addEventListener('click', () => {
+        container.toast('Info message', { variant: 'info' });
+      });
+      div.querySelector('#success-btn')?.addEventListener('click', () => {
+        container.toast('Success!', { variant: 'success' });
+      });
+      div.querySelector('#warning-btn')?.addEventListener('click', () => {
+        container.toast('Warning!', { variant: 'warning' });
+      });
+      div.querySelector('#error-btn')?.addEventListener('click', () => {
+        container.toast('Error!', { variant: 'error' });
+      });
+    }, 0);
+    
+    return div;
+  },
+};

--- a/src/components/toast/toast.test.ts
+++ b/src/components/toast/toast.test.ts
@@ -55,7 +55,32 @@ describe('elx-toast', () => {
     document.body.appendChild(el);
     const toast = el.shadowRoot!.querySelector('.toast');
     expect(toast!.getAttribute('role')).toBe('alert');
+    expect(toast!.getAttribute('aria-atomic')).toBe('true');
+    expect(toast!.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('uses assertive aria-live for error variant', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('variant', 'error');
+    document.body.appendChild(el);
+    const toast = el.shadowRoot!.querySelector('.toast');
     expect(toast!.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('uses assertive aria-live for warning variant', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('variant', 'warning');
+    document.body.appendChild(el);
+    const toast = el.shadowRoot!.querySelector('.toast');
+    expect(toast!.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('uses polite aria-live for success variant', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('variant', 'success');
+    document.body.appendChild(el);
+    const toast = el.shadowRoot!.querySelector('.toast');
+    expect(toast!.getAttribute('aria-live')).toBe('polite');
   });
 
   it('is hidden by default (no open attribute)', () => {

--- a/src/components/toast/toast.test.ts
+++ b/src/components/toast/toast.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import './toast';
+
+describe('elx-toast', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-toast')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('renders with default variant (info)', () => {
+    const el = document.createElement('elx-toast');
+    document.body.appendChild(el);
+    const toast = el.shadowRoot!.querySelector('.toast');
+    expect(toast!.classList.contains('info')).toBe(true);
+  });
+
+  it('applies success variant', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('variant', 'success');
+    document.body.appendChild(el);
+    const toast = el.shadowRoot!.querySelector('.toast');
+    expect(toast!.classList.contains('success')).toBe(true);
+  });
+
+  it('applies warning variant', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('variant', 'warning');
+    document.body.appendChild(el);
+    const toast = el.shadowRoot!.querySelector('.toast');
+    expect(toast!.classList.contains('warning')).toBe(true);
+  });
+
+  it('applies error variant', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('variant', 'error');
+    document.body.appendChild(el);
+    const toast = el.shadowRoot!.querySelector('.toast');
+    expect(toast!.classList.contains('error')).toBe(true);
+  });
+
+  it('falls back to info for invalid variant', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('variant', 'invalid');
+    document.body.appendChild(el);
+    const toast = el.shadowRoot!.querySelector('.toast');
+    expect(toast!.classList.contains('info')).toBe(true);
+  });
+
+  it('has correct ARIA attributes', () => {
+    const el = document.createElement('elx-toast');
+    document.body.appendChild(el);
+    const toast = el.shadowRoot!.querySelector('.toast');
+    expect(toast!.getAttribute('role')).toBe('alert');
+    expect(toast!.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('is hidden by default (no open attribute)', () => {
+    const el = document.createElement('elx-toast');
+    document.body.appendChild(el);
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('becomes visible when open attribute is set', () => {
+    const el = document.createElement('elx-toast');
+    document.body.appendChild(el);
+    el.setAttribute('open', '');
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  it('hides when open attribute is removed', () => {
+    const el = document.createElement('elx-toast');
+    document.body.appendChild(el);
+    el.setAttribute('open', '');
+    el.removeAttribute('open');
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('auto-hides after duration', () => {
+    vi.useFakeTimers();
+    const el = document.createElement('elx-toast');
+    el.setAttribute('duration', '3000');
+    document.body.appendChild(el);
+    el.setAttribute('open', '');
+    expect(el.hasAttribute('open')).toBe(true);
+    vi.advanceTimersByTime(3000);
+    expect(el.hasAttribute('open')).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('dispatches close event when hidden', () => {
+    const el = document.createElement('elx-toast');
+    document.body.appendChild(el);
+    const handler = vi.fn();
+    el.addEventListener('close', handler);
+    el.setAttribute('open', '');
+    el.removeAttribute('open');
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('shows close button when dismissible', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('dismissible', '');
+    document.body.appendChild(el);
+    const closeBtn = el.shadowRoot!.querySelector('.close-btn');
+    expect(closeBtn!.classList.contains('visible')).toBe(true);
+  });
+
+  it('hides close button when not dismissible', () => {
+    const el = document.createElement('elx-toast');
+    document.body.appendChild(el);
+    const closeBtn = el.shadowRoot!.querySelector('.close-btn');
+    expect(closeBtn!.classList.contains('visible')).toBe(false);
+  });
+
+  it('close button removes open attribute', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('dismissible', '');
+    document.body.appendChild(el);
+    el.setAttribute('open', '');
+    const closeBtn = el.shadowRoot!.querySelector('.close-btn') as HTMLButtonElement;
+    closeBtn.click();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('displays icon for variant', () => {
+    const el = document.createElement('elx-toast');
+    el.setAttribute('variant', 'success');
+    document.body.appendChild(el);
+    const icon = el.shadowRoot!.querySelector('.icon');
+    expect(icon!.textContent).toBe('✓');
+  });
+});
+
+describe('elx-toast-container', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-toast-container')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with shadow DOM', () => {
+    const el = document.createElement('elx-toast-container');
+    document.body.appendChild(el);
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('has default position top-right', () => {
+    const el = document.createElement('elx-toast-container');
+    document.body.appendChild(el);
+    expect(el.hasAttribute('position')).toBe(false);
+  });
+
+  it('accepts position attribute', () => {
+    const el = document.createElement('elx-toast-container');
+    el.setAttribute('position', 'bottom-left');
+    document.body.appendChild(el);
+    expect(el.getAttribute('position')).toBe('bottom-left');
+  });
+
+  it('toast() method creates a child toast element', () => {
+    const el = document.createElement('elx-toast-container') as any;
+    document.body.appendChild(el);
+    const toast = el.toast('Hello world', { variant: 'success' });
+    expect(toast).toBeTruthy();
+    expect(toast.getAttribute('variant')).toBe('success');
+    expect(toast.textContent).toBe('Hello world');
+    expect(el.contains(toast)).toBe(true);
+  });
+
+  it('toast() uses default options', () => {
+    const el = document.createElement('elx-toast-container') as any;
+    document.body.appendChild(el);
+    const toast = el.toast('Test');
+    expect(toast.getAttribute('variant')).toBe('info');
+    expect(toast.getAttribute('duration')).toBe('5000');
+    expect(toast.hasAttribute('dismissible')).toBe(true);
+  });
+
+  it('toast() respects custom options', () => {
+    const el = document.createElement('elx-toast-container') as any;
+    document.body.appendChild(el);
+    const toast = el.toast('Test', { variant: 'error', duration: 2000, dismissible: false });
+    expect(toast.getAttribute('variant')).toBe('error');
+    expect(toast.getAttribute('duration')).toBe('2000');
+    expect(toast.hasAttribute('dismissible')).toBe(false);
+  });
+
+  it('removes toast from container on close', () => {
+    const el = document.createElement('elx-toast-container') as any;
+    document.body.appendChild(el);
+    const toast = el.toast('Test');
+    expect(el.contains(toast)).toBe(true);
+    toast.dispatchEvent(new CustomEvent('close', { bubbles: true }));
+    expect(el.contains(toast)).toBe(false);
+  });
+});

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -1,0 +1,256 @@
+const VALID_VARIANTS = ['info', 'success', 'warning', 'error'] as const;
+
+type Variant = (typeof VALID_VARIANTS)[number];
+
+const ICONS: Record<Variant, string> = {
+  info: 'ℹ️',
+  success: '✓',
+  warning: '⚠',
+  error: '✕',
+};
+
+export class ElxToast extends HTMLElement {
+  static observedAttributes = ['variant', 'duration', 'dismissible', 'open'];
+
+  private _timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+
+  disconnectedCallback() {
+    this._clearTimer();
+  }
+
+  attributeChangedCallback(_name: string) {
+    if (_name === 'open') {
+      this._handleOpenChange();
+    }
+    this._update();
+  }
+
+  get variant(): Variant {
+    const val = this.getAttribute('variant');
+    return (VALID_VARIANTS as readonly string[]).indexOf(val as string) !== -1
+      ? (val as Variant)
+      : 'info';
+  }
+  set variant(val: string) {
+    this.setAttribute('variant', val);
+  }
+
+  get duration(): number {
+    const val = parseInt(this.getAttribute('duration') ?? '');
+    return isNaN(val) ? 5000 : val;
+  }
+  set duration(val: number) {
+    this.setAttribute('duration', String(val));
+  }
+
+  get dismissible(): boolean {
+    return this.hasAttribute('dismissible');
+  }
+  set dismissible(val: boolean) {
+    val ? this.setAttribute('dismissible', '') : this.removeAttribute('dismissible');
+  }
+
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+  set open(val: boolean) {
+    val ? this.setAttribute('open', '') : this.removeAttribute('open');
+  }
+
+  show() {
+    this.open = true;
+  }
+
+  hide() {
+    this.open = false;
+  }
+
+  private _handleOpenChange() {
+    this._clearTimer();
+    if (this.open && this.duration > 0) {
+      this._timer = setTimeout(() => this.hide(), this.duration);
+    }
+    if (!this.open) {
+      this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+    }
+  }
+
+  private _clearTimer() {
+    if (this._timer) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+  }
+
+  private _onClose = () => {
+    this.hide();
+  };
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: none; }
+      :host([open]) { display: block; }
+
+      .toast {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 12px 16px;
+        border-radius: var(--elx-radius-lg, 8px);
+        font-family: var(--elx-font-family-sans, sans-serif);
+        font-size: 14px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        pointer-events: auto;
+      }
+
+      .toast.info { background: var(--elx-color-primary-50); border: 1px solid var(--elx-color-primary-100); color: var(--elx-color-primary-700); }
+      .toast.success { background: var(--elx-color-success-50); border: 1px solid var(--elx-color-success-500, #a7f3d0); color: var(--elx-color-success-700); }
+      .toast.warning { background: var(--elx-color-warning-50); border: 1px solid var(--elx-color-warning-100); color: var(--elx-color-warning-700); }
+      .toast.error { background: var(--elx-color-danger-50); border: 1px solid var(--elx-color-danger-500, #fecaca); color: var(--elx-color-danger-700); }
+
+      .icon { flex-shrink: 0; font-size: 16px; line-height: 1; }
+      .content { flex: 1; min-width: 0; }
+      .close-btn {
+        flex-shrink: 0;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        font-size: 16px;
+        color: inherit;
+        padding: 0;
+        line-height: 1;
+        opacity: 0.7;
+      }
+      .close-btn:hover { opacity: 1; }
+      .close-btn:not(.visible) { display: none; }
+    `;
+
+    const container = document.createElement('div');
+    container.className = 'toast';
+    container.setAttribute('role', 'alert');
+    container.setAttribute('aria-live', 'assertive');
+
+    const icon = document.createElement('span');
+    icon.className = 'icon';
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    const slot = document.createElement('slot');
+    content.appendChild(slot);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'close-btn';
+    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.textContent = '✕';
+    closeBtn.addEventListener('click', this._onClose);
+
+    container.appendChild(icon);
+    container.appendChild(content);
+    container.appendChild(closeBtn);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(container);
+  }
+
+  private _update() {
+    const container = this.shadowRoot?.querySelector('.toast');
+    if (!container) return;
+
+    container.className = `toast ${this.variant}`;
+
+    const icon = container.querySelector('.icon');
+    if (icon) icon.textContent = ICONS[this.variant];
+
+    const closeBtn = container.querySelector('.close-btn');
+    if (closeBtn) {
+      closeBtn.classList.toggle('visible', this.dismissible);
+    }
+  }
+}
+
+export class ElxToastContainer extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this._buildDom();
+  }
+
+  get position(): string {
+    const val = this.getAttribute('position');
+    const valid = [
+      'top-right',
+      'top-left',
+      'top-center',
+      'bottom-right',
+      'bottom-left',
+      'bottom-center',
+    ];
+    return valid.includes(val ?? '') ? val! : 'top-right';
+  }
+  set position(val: string) {
+    this.setAttribute('position', val);
+  }
+
+  toast(message: string, options: { variant?: string; duration?: number; dismissible?: boolean } = {}) {
+    const toast = document.createElement('elx-toast') as ElxToast;
+    toast.variant = options.variant ?? 'info';
+    toast.duration = options.duration ?? 5000;
+    if (options.dismissible !== false) toast.dismissible = true;
+    toast.textContent = message;
+    toast.addEventListener('close', () => toast.remove(), { once: true });
+    this.appendChild(toast);
+    // Trigger show after append so connectedCallback runs first
+    requestAnimationFrame(() => toast.show());
+    return toast;
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        position: fixed;
+        z-index: 9999;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 16px;
+        pointer-events: none;
+        max-width: 420px;
+        width: 100%;
+      }
+
+      :host([position="top-right"]), :host(:not([position])) { top: 0; right: 0; }
+      :host([position="top-left"]) { top: 0; left: 0; }
+      :host([position="top-center"]) { top: 0; left: 50%; transform: translateX(-50%); }
+      :host([position="bottom-right"]) { bottom: 0; right: 0; }
+      :host([position="bottom-left"]) { bottom: 0; left: 0; }
+      :host([position="bottom-center"]) { bottom: 0; left: 50%; transform: translateX(-50%); }
+    `;
+
+    const slot = document.createElement('slot');
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(slot);
+  }
+}
+
+if (!customElements.get('elx-toast')) {
+  customElements.define('elx-toast', ElxToast);
+}
+if (!customElements.get('elx-toast-container')) {
+  customElements.define('elx-toast-container', ElxToastContainer);
+}

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -26,6 +26,8 @@ export class ElxToast extends HTMLElement {
 
   disconnectedCallback() {
     this._clearTimer();
+    const closeBtn = this.shadowRoot?.querySelector('.close-btn');
+    closeBtn?.removeEventListener('click', this._onClose);
   }
 
   attributeChangedCallback(_name: string) {
@@ -139,7 +141,7 @@ export class ElxToast extends HTMLElement {
     const container = document.createElement('div');
     container.className = 'toast';
     container.setAttribute('role', 'alert');
-    container.setAttribute('aria-live', 'assertive');
+    container.setAttribute('aria-atomic', 'true');
 
     const icon = document.createElement('span');
     icon.className = 'icon';
@@ -169,6 +171,8 @@ export class ElxToast extends HTMLElement {
     if (!container) return;
 
     container.className = `toast ${this.variant}`;
+    const liveValue = this.variant === 'error' || this.variant === 'warning' ? 'assertive' : 'polite';
+    container.setAttribute('aria-live', liveValue);
 
     const icon = container.querySelector('.icon');
     if (icon) icon.textContent = ICONS[this.variant];

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@ export * from './components/select/select';
 export * from './components/separator/separator';
 export * from './components/accordion/accordion';
 export * from './components/text/text';
+export * from './components/toast/toast';


### PR DESCRIPTION
## Summary
- Adds `elx-toast` component with 4 variants: info, success, warning, error
- Adds `elx-toast-container` with 6 position options (top/bottom × left/center/right)
- Imperative API: `container.toast('message', { variant, duration, dismissible })`
- Auto-dismiss with configurable duration (default 5000ms)
- Dismissible close button
- ARIA alert role with assertive live region for accessibility

## Test Plan
- 22 new tests, all passing
- Full suite: 262 tests passing