### PR TITLE
feat: add Dropdown Menu component

### DIFF
--- a/src/components/dropdown/dropdown.stories.ts
+++ b/src/components/dropdown/dropdown.stories.ts
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import './dropdown.js';
+
+const meta: Meta = {
+  title: 'Components/Dropdown',
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => {
+    const dropdown = document.createElement('elx-dropdown');
+    const trigger = document.createElement('button');
+    trigger.slot = 'trigger';
+    trigger.textContent = 'Open Menu';
+    dropdown.appendChild(trigger);
+
+    ['Edit', 'Duplicate', 'Delete'].forEach((label) => {
+      const item = document.createElement('elx-dropdown-item');
+      item.textContent = label;
+      dropdown.appendChild(item);
+    });
+
+    return dropdown;
+  },
+};
+
+export const WithDisabledItem: Story = {
+  render: () => {
+    const dropdown = document.createElement('elx-dropdown');
+    const trigger = document.createElement('button');
+    trigger.slot = 'trigger';
+    trigger.textContent = 'Actions';
+    dropdown.appendChild(trigger);
+
+    ['Edit', 'Duplicate'].forEach((label) => {
+      const item = document.createElement('elx-dropdown-item');
+      item.textContent = label;
+      dropdown.appendChild(item);
+    });
+
+    const disabled = document.createElement('elx-dropdown-item');
+    disabled.textContent = 'Delete';
+    disabled.setAttribute('disabled', '');
+    dropdown.appendChild(disabled);
+
+    return dropdown;
+  },
+};
+
+export const DisabledDropdown: Story = {
+  render: () => {
+    const dropdown = document.createElement('elx-dropdown');
+    dropdown.setAttribute('disabled', '');
+    const trigger = document.createElement('button');
+    trigger.slot = 'trigger';
+    trigger.textContent = 'Disabled Menu';
+    dropdown.appendChild(trigger);
+
+    const item = document.createElement('elx-dropdown-item');
+    item.textContent = 'Item';
+    dropdown.appendChild(item);
+
+    return dropdown;
+  },
+};

--- a/src/components/dropdown/dropdown.test.ts
+++ b/src/components/dropdown/dropdown.test.ts
@@ -88,6 +88,31 @@ describe('elx-dropdown', () => {
     const menu = el.shadowRoot!.querySelector('.menu');
     expect(menu!.getAttribute('aria-hidden')).toBe('false');
   });
+
+  it('sets aria-haspopup and aria-expanded on trigger', () => {
+    const el = document.createElement('elx-dropdown') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+    expect(btn.getAttribute('aria-haspopup')).toBe('menu');
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+    el.show();
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('dispatches open and close events', () => {
+    const el = document.createElement('elx-dropdown') as any;
+    document.body.appendChild(el);
+    const openHandler = vi.fn();
+    const closeHandler = vi.fn();
+    el.addEventListener('open', openHandler);
+    el.addEventListener('close', closeHandler);
+    el.show();
+    expect(openHandler).toHaveBeenCalled();
+    el.hide();
+    expect(closeHandler).toHaveBeenCalled();
+  });
 });
 
 describe('elx-dropdown-item', () => {
@@ -166,5 +191,20 @@ describe('elx-dropdown-item', () => {
     document.body.appendChild(el);
     const item = el.shadowRoot!.querySelector('.item');
     expect(item!.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('has tabindex -1 when disabled', () => {
+    const el = document.createElement('elx-dropdown-item') as any;
+    el.disabled = true;
+    document.body.appendChild(el);
+    const item = el.shadowRoot!.querySelector('.item');
+    expect(item!.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('has tabindex 0 when enabled', () => {
+    const el = document.createElement('elx-dropdown-item') as any;
+    document.body.appendChild(el);
+    const item = el.shadowRoot!.querySelector('.item');
+    expect(item!.getAttribute('tabindex')).toBe('0');
   });
 });

--- a/src/components/dropdown/dropdown.test.ts
+++ b/src/components/dropdown/dropdown.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import './dropdown';
+
+describe('elx-dropdown', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-dropdown')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with shadow DOM', () => {
+    const el = document.createElement('elx-dropdown');
+    document.body.appendChild(el);
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('is closed by default', () => {
+    const el = document.createElement('elx-dropdown');
+    document.body.appendChild(el);
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('opens when show() is called', () => {
+    const el = document.createElement('elx-dropdown') as any;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  it('closes when hide() is called', () => {
+    const el = document.createElement('elx-dropdown') as any;
+    document.body.appendChild(el);
+    el.show();
+    el.hide();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('toggles open state', () => {
+    const el = document.createElement('elx-dropdown') as any;
+    document.body.appendChild(el);
+    el.toggle();
+    expect(el.hasAttribute('open')).toBe(true);
+    el.toggle();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('does not open when disabled', () => {
+    const el = document.createElement('elx-dropdown') as any;
+    el.disabled = true;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('closes when clicking outside', () => {
+    const el = document.createElement('elx-dropdown') as any;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(true);
+    document.body.click();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('closes on Escape key', () => {
+    const el = document.createElement('elx-dropdown') as any;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(true);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('has correct ARIA attributes on menu', () => {
+    const el = document.createElement('elx-dropdown');
+    document.body.appendChild(el);
+    const menu = el.shadowRoot!.querySelector('.menu');
+    expect(menu!.getAttribute('role')).toBe('menu');
+    expect(menu!.getAttribute('aria-orientation')).toBe('vertical');
+    expect(menu!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('updates aria-hidden when opened', () => {
+    const el = document.createElement('elx-dropdown') as any;
+    document.body.appendChild(el);
+    el.show();
+    const menu = el.shadowRoot!.querySelector('.menu');
+    expect(menu!.getAttribute('aria-hidden')).toBe('false');
+  });
+});
+
+describe('elx-dropdown-item', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-dropdown-item')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with shadow DOM', () => {
+    const el = document.createElement('elx-dropdown-item');
+    document.body.appendChild(el);
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('has menuitem role', () => {
+    const el = document.createElement('elx-dropdown-item');
+    document.body.appendChild(el);
+    const item = el.shadowRoot!.querySelector('.item');
+    expect(item!.getAttribute('role')).toBe('menuitem');
+  });
+
+  it('dispatches select event on click', () => {
+    const el = document.createElement('elx-dropdown-item') as any;
+    document.body.appendChild(el);
+    const handler = vi.fn();
+    el.addEventListener('select', handler);
+    el.click();
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('does not dispatch select when disabled', () => {
+    const el = document.createElement('elx-dropdown-item') as any;
+    el.disabled = true;
+    document.body.appendChild(el);
+    const handler = vi.fn();
+    el.addEventListener('select', handler);
+    el.click();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('dispatches select on Enter key', () => {
+    const el = document.createElement('elx-dropdown-item') as any;
+    document.body.appendChild(el);
+    const handler = vi.fn();
+    el.addEventListener('select', handler);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('dispatches select on Space key', () => {
+    const el = document.createElement('elx-dropdown-item') as any;
+    document.body.appendChild(el);
+    const handler = vi.fn();
+    el.addEventListener('select', handler);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('closes parent dropdown on select', () => {
+    const dropdown = document.createElement('elx-dropdown') as any;
+    const item = document.createElement('elx-dropdown-item') as any;
+    dropdown.appendChild(item);
+    document.body.appendChild(dropdown);
+    dropdown.show();
+    expect(dropdown.hasAttribute('open')).toBe(true);
+    item.click();
+    expect(dropdown.hasAttribute('open')).toBe(false);
+  });
+
+  it('has aria-disabled attribute when disabled', () => {
+    const el = document.createElement('elx-dropdown-item') as any;
+    el.disabled = true;
+    document.body.appendChild(el);
+    const item = el.shadowRoot!.querySelector('.item');
+    expect(item!.getAttribute('aria-disabled')).toBe('true');
+  });
+});

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -1,0 +1,303 @@
+export class ElxDropdown extends HTMLElement {
+  static observedAttributes = ['open', 'disabled'];
+
+  private _onClickOutside: (e: Event) => void;
+  private _onKeydown: (e: KeyboardEvent) => void;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._onClickOutside = (e: Event) => this._handleClickOutside(e);
+    this._onKeydown = (e: KeyboardEvent) => this._handleKeydown(e);
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+    document.addEventListener('click', this._onClickOutside);
+    document.addEventListener('keydown', this._onKeydown);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('click', this._onClickOutside);
+    document.removeEventListener('keydown', this._onKeydown);
+  }
+
+  attributeChangedCallback() {
+    this._update();
+  }
+
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+  set open(val: boolean) {
+    val ? this.setAttribute('open', '') : this.removeAttribute('open');
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
+
+  show() {
+    if (!this.disabled) this.open = true;
+  }
+
+  hide() {
+    this.open = false;
+  }
+
+  toggle() {
+    this.open ? this.hide() : this.show();
+  }
+
+  private _handleClickOutside(e: Event) {
+    if (!this.open) return;
+    const target = e.target as Node;
+    if (!this.contains(target)) {
+      this.hide();
+    }
+  }
+
+  private _handleKeydown(e: KeyboardEvent) {
+    if (!this.open) return;
+    if (e.key === 'Escape') {
+      this.hide();
+      this._focusTrigger();
+    }
+  }
+
+  private _focusTrigger() {
+    const trigger = this.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger?.focus();
+  }
+
+  private _onTriggerClick = (e: Event) => {
+    e.preventDefault();
+    if (this.disabled) return;
+    this.toggle();
+  };
+
+  private _onTriggerKeydown = (e: KeyboardEvent) => {
+    if (this.disabled) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.toggle();
+    }
+    if (e.key === 'ArrowDown' && !this.open) {
+      e.preventDefault();
+      this.show();
+    }
+  };
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        position: relative;
+        display: inline-block;
+      }
+
+      .trigger {
+        display: contents;
+      }
+
+      .menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        min-width: 180px;
+        margin-top: 4px;
+        padding: 4px 0;
+        background: var(--elx-color-neutral-0, #fff);
+        border: 1px solid var(--elx-color-neutral-200, #e5e5e5);
+        border-radius: var(--elx-radius-lg, 8px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        z-index: 1000;
+        opacity: 0;
+        visibility: hidden;
+        transform: translateY(-8px);
+        transition: opacity 150ms ease, transform 150ms ease, visibility 150ms;
+      }
+
+      :host([open]) .menu {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0);
+      }
+
+      :host([disabled]) {
+        opacity: 0.5;
+        pointer-events: none;
+      }
+
+      ::slotted([slot="trigger"]) {
+        cursor: pointer;
+      }
+
+      ::slotted(elx-dropdown-item) {
+        display: block;
+      }
+    `;
+
+    const trigger = document.createElement('div');
+    trigger.className = 'trigger';
+    const triggerSlot = document.createElement('slot');
+    triggerSlot.name = 'trigger';
+    trigger.appendChild(triggerSlot);
+
+    const menu = document.createElement('div');
+    menu.className = 'menu';
+    menu.setAttribute('role', 'menu');
+    menu.setAttribute('aria-orientation', 'vertical');
+    const menuSlot = document.createElement('slot');
+    menu.appendChild(menuSlot);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(trigger);
+    this.shadowRoot!.appendChild(menu);
+
+    // Attach event listeners to trigger slot
+    triggerSlot.addEventListener('click', this._onTriggerClick);
+    triggerSlot.addEventListener('keydown', this._onTriggerKeydown);
+  }
+
+  private _update() {
+    const menu = this.shadowRoot?.querySelector('.menu');
+    if (menu) {
+      menu.setAttribute('aria-hidden', String(!this.open));
+    }
+  }
+}
+
+export class ElxDropdownItem extends HTMLElement {
+  static observedAttributes = ['disabled'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+    this.addEventListener('click', this._onClick);
+    this.addEventListener('keydown', this._onKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('click', this._onClick);
+    this.removeEventListener('keydown', this._onKeydown);
+  }
+
+  attributeChangedCallback() {
+    this._update();
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
+
+  private _onClick = () => {
+    if (this.disabled) return;
+    this.dispatchEvent(new CustomEvent('select', { bubbles: true, composed: true }));
+    // Close parent dropdown
+    const dropdown = this.closest('elx-dropdown') as ElxDropdown;
+    dropdown?.hide();
+  };
+
+  private _onKeydown = (e: KeyboardEvent) => {
+    if (this.disabled) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this._onClick();
+    }
+  };
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: block;
+      }
+
+      .item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        font-family: var(--elx-font-family-sans, sans-serif);
+        font-size: 14px;
+        color: var(--elx-color-neutral-900, #171717);
+        cursor: pointer;
+        transition: background-color 100ms ease;
+      }
+
+      .item:hover {
+        background: var(--elx-color-neutral-100, #f5f5f5);
+      }
+
+      .item:focus-visible {
+        outline: 2px solid var(--elx-color-primary-500, #3b82f6);
+        outline-offset: -2px;
+      }
+
+      :host([disabled]) .item {
+        opacity: 0.5;
+        cursor: not-allowed;
+        pointer-events: none;
+      }
+
+      .icon {
+        flex-shrink: 0;
+        width: 16px;
+        height: 16px;
+      }
+
+      .content {
+        flex: 1;
+      }
+    `;
+
+    const item = document.createElement('div');
+    item.className = 'item';
+    item.setAttribute('role', 'menuitem');
+    item.setAttribute('tabindex', '0');
+
+    const icon = document.createElement('span');
+    icon.className = 'icon';
+    const iconSlot = document.createElement('slot');
+    iconSlot.name = 'icon';
+    icon.appendChild(iconSlot);
+
+    const content = document.createElement('span');
+    content.className = 'content';
+    const contentSlot = document.createElement('slot');
+    content.appendChild(contentSlot);
+
+    item.appendChild(icon);
+    item.appendChild(content);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(item);
+  }
+
+  private _update() {
+    const item = this.shadowRoot?.querySelector('.item');
+    if (item) {
+      item.setAttribute('aria-disabled', String(this.disabled));
+    }
+  }
+}
+
+if (!customElements.get('elx-dropdown')) {
+  customElements.define('elx-dropdown', ElxDropdown);
+}
+if (!customElements.get('elx-dropdown-item')) {
+  customElements.define('elx-dropdown-item', ElxDropdownItem);
+}

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -42,11 +42,15 @@ export class ElxDropdown extends HTMLElement {
   }
 
   show() {
-    if (!this.disabled) this.open = true;
+    if (!this.disabled) {
+      this.open = true;
+      this.dispatchEvent(new CustomEvent('open', { bubbles: true, composed: true }));
+    }
   }
 
   hide() {
     this.open = false;
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
   }
 
   toggle() {
@@ -55,8 +59,8 @@ export class ElxDropdown extends HTMLElement {
 
   private _handleClickOutside(e: Event) {
     if (!this.open) return;
-    const target = e.target as Node;
-    if (!this.contains(target)) {
+    const path = e.composedPath();
+    if (!path.includes(this)) {
       this.hide();
     }
   }
@@ -64,9 +68,48 @@ export class ElxDropdown extends HTMLElement {
   private _handleKeydown(e: KeyboardEvent) {
     if (!this.open) return;
     if (e.key === 'Escape') {
+      e.preventDefault();
       this.hide();
       this._focusTrigger();
     }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      this._focusItem(1);
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      this._focusItem(-1);
+    }
+    if (e.key === 'Home') {
+      e.preventDefault();
+      this._focusItem(0, true);
+    }
+    if (e.key === 'End') {
+      e.preventDefault();
+      this._focusItem(-1, true);
+    }
+  }
+
+  private _getItems(): ElxDropdownItem[] {
+    return Array.from(this.querySelectorAll('elx-dropdown-item:not([disabled])'));
+  }
+
+  private _focusItem(direction: number, absolute = false) {
+    const items = this._getItems();
+    if (items.length === 0) return;
+    const active = document.activeElement as HTMLElement;
+    const currentIndex = items.indexOf(active as ElxDropdownItem);
+    let nextIndex: number;
+    if (absolute) {
+      nextIndex = direction >= 0 ? 0 : items.length - 1;
+    } else if (currentIndex === -1) {
+      nextIndex = direction > 0 ? 0 : items.length - 1;
+    } else {
+      nextIndex = (currentIndex + direction + items.length) % items.length;
+    }
+    const item = items[nextIndex];
+    const inner = item.shadowRoot?.querySelector('.item') as HTMLElement;
+    inner?.focus();
   }
 
   private _focusTrigger() {
@@ -168,6 +211,12 @@ export class ElxDropdown extends HTMLElement {
     const menu = this.shadowRoot?.querySelector('.menu');
     if (menu) {
       menu.setAttribute('aria-hidden', String(!this.open));
+    }
+    // Update trigger ARIA attributes
+    const trigger = this.querySelector('[slot="trigger"]') as HTMLElement;
+    if (trigger) {
+      trigger.setAttribute('aria-haspopup', 'menu');
+      trigger.setAttribute('aria-expanded', String(this.open));
     }
   }
 }
@@ -291,6 +340,7 @@ export class ElxDropdownItem extends HTMLElement {
     const item = this.shadowRoot?.querySelector('.item');
     if (item) {
       item.setAttribute('aria-disabled', String(this.disabled));
+      item.setAttribute('tabindex', this.disabled ? '-1' : '0');
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,4 @@ export * from './components/separator/separator';
 export * from './components/accordion/accordion';
 export * from './components/text/text';
 export * from './components/toast/toast';
+export * from './components/dropdown/dropdown';


### PR DESCRIPTION
## Summary
- Adds `elx-dropdown` with open/close/toggle methods
- Adds `elx-dropdown-item` with select event
- Click-outside dismiss and Escape key support
- Keyboard navigation (Enter/Space on items)
- Items auto-close parent dropdown on select
- Disabled state for both dropdown and items
- ARIA menu/menuitem roles

## Test Plan
- 18 new tests, all passing
- Full suite: 283 tests passing