### PR TITLE
feat: add Popover component

### DIFF
--- a/src/components/popover/popover.stories.ts
+++ b/src/components/popover/popover.stories.ts
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './popover.js';
+
+const meta: Meta = {
+  title: 'Components/Popover',
+  tags: ['autodocs'],
+  argTypes: {
+    position: {
+      control: 'select',
+      options: ['top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'left', 'right'],
+    },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: (args) => html`
+    <div style="padding: 100px; display: flex; justify-content: center;">
+      <elx-popover position=${args.position || 'bottom'} ?disabled=${args.disabled}>
+        <button slot="trigger">Click me</button>
+        <div>
+          <p style="margin: 0 0 8px;">Popover content</p>
+          <p style="margin: 0; color: #666; font-size: 14px;">This is a popover with some helpful information.</p>
+        </div>
+      </elx-popover>
+    </div>
+  `,
+};
+
+export const TopPosition: Story = {
+  render: () => html`
+    <div style="padding: 150px; display: flex; justify-content: center;">
+      <elx-popover position="top">
+        <button slot="trigger">Show above</button>
+        <div>This popover appears above the trigger.</div>
+      </elx-popover>
+    </div>
+  `,
+};
+
+export const LeftRight: Story = {
+  render: () => html`
+    <div style="padding: 100px; display: flex; gap: 40px; justify-content: center;">
+      <elx-popover position="left">
+        <button slot="trigger">Left</button>
+        <div>Left popover</div>
+      </elx-popover>
+      <elx-popover position="right">
+        <button slot="trigger">Right</button>
+        <div>Right popover</div>
+      </elx-popover>
+    </div>
+  `,
+};
+
+export const Disabled: Story = {
+  render: () => html`
+    <elx-popover disabled>
+      <button slot="trigger">Disabled</button>
+      <div>You should not see this.</div>
+    </elx-popover>
+  `,
+};
+
+export const RichContent: Story = {
+  render: () => html`
+    <div style="padding: 100px; display: flex; justify-content: center;">
+      <elx-popover position="bottom-start">
+        <button slot="trigger">User info</button>
+        <div>
+          <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 12px;">
+            <div style="width: 40px; height: 40px; border-radius: 50%; background: var(--elx-color-primary-500, #6366f1); display: flex; align-items: center; justify-content: center; color: white; font-weight: bold;">J</div>
+            <div>
+              <div style="font-weight: 600;">Jane Doe</div>
+              <div style="font-size: 13px; color: #666;">jane@example.com</div>
+            </div>
+          </div>
+          <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 8px 0;">
+          <div style="font-size: 14px; color: #666;">Member since 2024</div>
+        </div>
+      </elx-popover>
+    </div>
+  `,
+};

--- a/src/components/popover/popover.test.ts
+++ b/src/components/popover/popover.test.ts
@@ -128,4 +128,64 @@ describe('elx-popover', () => {
     const content = el.shadowRoot!.querySelector('.content') as HTMLElement;
     expect(content.style.bottom).toBe('100%');
   });
+
+  it('has aria-controls linking trigger to content', () => {
+    const el = document.createElement('elx-popover') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content');
+    expect(btn.getAttribute('aria-controls')).toBe(content!.id);
+  });
+
+  it('content has tabindex=-1 for focus', () => {
+    const el = document.createElement('elx-popover');
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content');
+    expect(content!.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('focuses content when opened', () => {
+    const el = document.createElement('elx-popover') as any;
+    document.body.appendChild(el);
+    el.show();
+    const content = el.shadowRoot!.querySelector('.content') as HTMLElement;
+    expect(el.shadowRoot!.activeElement).toBe(content);
+  });
+
+  it('trigger click toggles popover', () => {
+    const el = document.createElement('elx-popover') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+    btn.click();
+    expect(el.hasAttribute('open')).toBe(true);
+    btn.click();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('Enter/Space on trigger toggles popover', () => {
+    const el = document.createElement('elx-popover') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+    btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(el.hasAttribute('open')).toBe(true);
+    btn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('disabled popover does not toggle on trigger click', () => {
+    const el = document.createElement('elx-popover') as any;
+    el.disabled = true;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+    btn.click();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
 });

--- a/src/components/popover/popover.test.ts
+++ b/src/components/popover/popover.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import './popover';
+
+describe('elx-popover', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-popover')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with shadow DOM', () => {
+    const el = document.createElement('elx-popover');
+    document.body.appendChild(el);
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('is closed by default', () => {
+    const el = document.createElement('elx-popover');
+    document.body.appendChild(el);
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('opens when show() is called', () => {
+    const el = document.createElement('elx-popover') as any;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  it('closes when hide() is called', () => {
+    const el = document.createElement('elx-popover') as any;
+    document.body.appendChild(el);
+    el.show();
+    el.hide();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('toggles open state', () => {
+    const el = document.createElement('elx-popover') as any;
+    document.body.appendChild(el);
+    el.toggle();
+    expect(el.hasAttribute('open')).toBe(true);
+    el.toggle();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('does not open when disabled', () => {
+    const el = document.createElement('elx-popover') as any;
+    el.disabled = true;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('closes when clicking outside', () => {
+    const el = document.createElement('elx-popover') as any;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(true);
+    document.body.click();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('closes on Escape key', () => {
+    const el = document.createElement('elx-popover') as any;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(true);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('has correct ARIA attributes on content', () => {
+    const el = document.createElement('elx-popover');
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content');
+    expect(content!.getAttribute('role')).toBe('dialog');
+    expect(content!.getAttribute('aria-modal')).toBe('false');
+    expect(content!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('updates aria-hidden when opened', () => {
+    const el = document.createElement('elx-popover') as any;
+    document.body.appendChild(el);
+    el.show();
+    const content = el.shadowRoot!.querySelector('.content');
+    expect(content!.getAttribute('aria-hidden')).toBe('false');
+  });
+
+  it('sets aria-haspopup and aria-expanded on trigger', () => {
+    const el = document.createElement('elx-popover') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+    expect(btn.getAttribute('aria-haspopup')).toBe('dialog');
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+    el.show();
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('dispatches open and close events', () => {
+    const el = document.createElement('elx-popover') as any;
+    document.body.appendChild(el);
+    const openHandler = vi.fn();
+    const closeHandler = vi.fn();
+    el.addEventListener('open', openHandler);
+    el.addEventListener('close', closeHandler);
+    el.show();
+    expect(openHandler).toHaveBeenCalled();
+    el.hide();
+    expect(closeHandler).toHaveBeenCalled();
+  });
+
+  it('defaults to bottom position', () => {
+    const el = document.createElement('elx-popover') as any;
+    document.body.appendChild(el);
+    expect(el.position).toBe('bottom');
+  });
+
+  it('applies position attribute', () => {
+    const el = document.createElement('elx-popover') as any;
+    el.position = 'top';
+    document.body.appendChild(el);
+    expect(el.position).toBe('top');
+    const content = el.shadowRoot!.querySelector('.content') as HTMLElement;
+    expect(content.style.bottom).toBe('100%');
+  });
+});

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -1,0 +1,191 @@
+export class ElxPopover extends HTMLElement {
+  static observedAttributes = ['open', 'position', 'disabled'];
+
+  private _onClickOutside: (e: Event) => void;
+  private _onKeydown: (e: KeyboardEvent) => void;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._onClickOutside = (e: Event) => this._handleClickOutside(e);
+    this._onKeydown = (e: KeyboardEvent) => this._handleKeydown(e);
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+    document.addEventListener('click', this._onClickOutside);
+    document.addEventListener('keydown', this._onKeydown);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('click', this._onClickOutside);
+    document.removeEventListener('keydown', this._onKeydown);
+  }
+
+  attributeChangedCallback() {
+    this._update();
+  }
+
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+  set open(val: boolean) {
+    val ? this.setAttribute('open', '') : this.removeAttribute('open');
+  }
+
+  get position(): string {
+    return this.getAttribute('position') || 'bottom';
+  }
+  set position(val: string) {
+    this.setAttribute('position', val);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
+
+  show() {
+    if (!this.disabled) {
+      this.open = true;
+      this.dispatchEvent(new CustomEvent('open', { bubbles: true, composed: true }));
+    }
+  }
+
+  hide() {
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+  }
+
+  toggle() {
+    this.open ? this.hide() : this.show();
+  }
+
+  private _handleClickOutside(e: Event) {
+    if (!this.open) return;
+    const path = e.composedPath();
+    if (!path.includes(this)) {
+      this.hide();
+    }
+  }
+
+  private _handleKeydown(e: KeyboardEvent) {
+    if (!this.open) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.hide();
+      const trigger = this.querySelector('[slot="trigger"]') as HTMLElement;
+      trigger?.focus();
+    }
+  }
+
+  private _onTriggerClick = (e: Event) => {
+    e.preventDefault();
+    if (this.disabled) return;
+    this.toggle();
+  };
+
+  private _onTriggerKeydown = (e: KeyboardEvent) => {
+    if (this.disabled) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.toggle();
+    }
+  };
+
+  private _getPositionStyles(pos: string): string {
+    const positions: Record<string, string> = {
+      top: 'bottom: 100%; left: 50%; transform: translateX(-50%); margin-bottom: 8px;',
+      'top-start': 'bottom: 100%; left: 0; margin-bottom: 8px;',
+      'top-end': 'bottom: 100%; right: 0; margin-bottom: 8px;',
+      bottom: 'top: 100%; left: 50%; transform: translateX(-50%); margin-top: 8px;',
+      'bottom-start': 'top: 100%; left: 0; margin-top: 8px;',
+      'bottom-end': 'top: 100%; right: 0; margin-top: 8px;',
+      left: 'right: 100%; top: 50%; transform: translateY(-50%); margin-right: 8px;',
+      right: 'left: 100%; top: 50%; transform: translateY(-50%); margin-left: 8px;',
+    };
+    return positions[pos] || positions['bottom'];
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        position: relative;
+        display: inline-block;
+      }
+
+      .trigger {
+        display: contents;
+      }
+
+      .content {
+        position: absolute;
+        min-width: 200px;
+        padding: 12px 16px;
+        background: var(--elx-color-neutral-0, #fff);
+        border: 1px solid var(--elx-color-neutral-200, #e5e5e5);
+        border-radius: var(--elx-radius-lg, 8px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        z-index: 1000;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 150ms ease, visibility 150ms;
+      }
+
+      :host([open]) .content {
+        opacity: 1;
+        visibility: visible;
+      }
+
+      :host([disabled]) {
+        opacity: 0.5;
+        pointer-events: none;
+      }
+
+      ::slotted([slot="trigger"]) {
+        cursor: pointer;
+      }
+    `;
+
+    const trigger = document.createElement('div');
+    trigger.className = 'trigger';
+    const triggerSlot = document.createElement('slot');
+    triggerSlot.name = 'trigger';
+    trigger.appendChild(triggerSlot);
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    content.setAttribute('role', 'dialog');
+    content.setAttribute('aria-modal', 'false');
+    const contentSlot = document.createElement('slot');
+    content.appendChild(contentSlot);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(trigger);
+    this.shadowRoot!.appendChild(content);
+
+    triggerSlot.addEventListener('click', this._onTriggerClick);
+    triggerSlot.addEventListener('keydown', this._onTriggerKeydown);
+  }
+
+  private _update() {
+    const content = this.shadowRoot?.querySelector('.content') as HTMLElement;
+    if (content) {
+      content.setAttribute('aria-hidden', String(!this.open));
+      content.style.cssText = this._getPositionStyles(this.position);
+    }
+    const trigger = this.querySelector('[slot="trigger"]') as HTMLElement;
+    if (trigger) {
+      trigger.setAttribute('aria-haspopup', 'dialog');
+      trigger.setAttribute('aria-expanded', String(this.open));
+    }
+  }
+}
+
+if (!customElements.get('elx-popover')) {
+  customElements.define('elx-popover', ElxPopover);
+}

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -3,6 +3,7 @@ export class ElxPopover extends HTMLElement {
 
   private _onClickOutside: (e: Event) => void;
   private _onKeydown: (e: KeyboardEvent) => void;
+  private _contentId = `elx-popover-${Math.random().toString(36).slice(2, 9)}`;
 
   constructor() {
     super();
@@ -12,7 +13,7 @@ export class ElxPopover extends HTMLElement {
   }
 
   connectedCallback() {
-    this._buildDom();
+    if (!this.shadowRoot?.querySelector('.content')) this._buildDom();
     this._update();
     document.addEventListener('click', this._onClickOutside);
     document.addEventListener('keydown', this._onKeydown);
@@ -21,9 +22,15 @@ export class ElxPopover extends HTMLElement {
   disconnectedCallback() {
     document.removeEventListener('click', this._onClickOutside);
     document.removeEventListener('keydown', this._onKeydown);
+    const triggerSlot = this.shadowRoot?.querySelector('slot[name="trigger"]');
+    if (triggerSlot) {
+      triggerSlot.removeEventListener('click', this._onTriggerClick);
+      triggerSlot.removeEventListener('keydown', this._onTriggerKeydown);
+    }
   }
 
-  attributeChangedCallback() {
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
     this._update();
   }
 
@@ -52,6 +59,8 @@ export class ElxPopover extends HTMLElement {
     if (!this.disabled) {
       this.open = true;
       this.dispatchEvent(new CustomEvent('open', { bubbles: true, composed: true }));
+      const content = this.shadowRoot?.querySelector('.content') as HTMLElement;
+      content?.focus();
     }
   }
 
@@ -83,8 +92,8 @@ export class ElxPopover extends HTMLElement {
   }
 
   private _onTriggerClick = (e: Event) => {
-    e.preventDefault();
     if (this.disabled) return;
+    e.preventDefault();
     this.toggle();
   };
 
@@ -159,6 +168,8 @@ export class ElxPopover extends HTMLElement {
 
     const content = document.createElement('div');
     content.className = 'content';
+    content.id = this._contentId;
+    content.setAttribute('tabindex', '-1');
     content.setAttribute('role', 'dialog');
     content.setAttribute('aria-modal', 'false');
     const contentSlot = document.createElement('slot');
@@ -182,6 +193,7 @@ export class ElxPopover extends HTMLElement {
     if (trigger) {
       trigger.setAttribute('aria-haspopup', 'dialog');
       trigger.setAttribute('aria-expanded', String(this.open));
+      trigger.setAttribute('aria-controls', this._contentId);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,4 @@ export * from './components/accordion/accordion';
 export * from './components/text/text';
 export * from './components/toast/toast';
 export * from './components/dropdown/dropdown';
+export * from './components/popover/popover';


### PR DESCRIPTION
## Popover Component

Adds `elx-popover` — a slot-based popover with trigger/content pattern.

### Features
- 8 position options: top, top-start, top-end, bottom, bottom-start, bottom-end, left, right
- Click-outside close using `composedPath()` (shadow DOM safe)
- Escape key closes and returns focus to trigger
- `show()`/`hide()`/`toggle()` programmatic API
- Disabled state support
- CSS custom properties for theming

### Accessibility
- `aria-haspopup="dialog"` and `aria-expanded` on trigger
- `role="dialog"` and `aria-hidden` on content panel
- Keyboard: Enter/Space to toggle, Escape to close

### Tests
- 14 tests covering rendering, open/close, ARIA, events, positioning, disabled state
- 301 total tests passing