### PR TITLE
feat: add Progress and Spinner components

### DIFF
--- a/src/components/progress/progress.stories.ts
+++ b/src/components/progress/progress.stories.ts
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './progress.js';
+
+const progressMeta: Meta = {
+  title: 'Components/Progress',
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: { type: 'range', min: 0, max: 100 } },
+    max: { control: 'number' },
+    variant: { control: 'select', options: ['primary', 'success', 'warning', 'danger'] },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    label: { control: 'text' },
+  },
+};
+export default progressMeta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: (args) => html`
+    <elx-progress
+      value=${args.value || 60}
+      max=${args.max || 100}
+      variant=${args.variant || 'primary'}
+      size=${args.size || 'md'}
+      label=${args.label || 'Upload progress'}
+    ></elx-progress>
+  `,
+};
+
+export const Variants: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <elx-progress value="25" variant="primary" label="Primary"></elx-progress>
+      <elx-progress value="50" variant="success" label="Success"></elx-progress>
+      <elx-progress value="75" variant="warning" label="Warning"></elx-progress>
+      <elx-progress value="90" variant="danger" label="Danger"></elx-progress>
+    </div>
+  `,
+};
+
+export const Sizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <elx-progress value="60" size="sm" label="Small"></elx-progress>
+      <elx-progress value="60" size="md" label="Medium"></elx-progress>
+      <elx-progress value="60" size="lg" label="Large"></elx-progress>
+    </div>
+  `,
+};
+
+export const Spinner: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 24px; align-items: center;">
+      <elx-spinner size="sm"></elx-spinner>
+      <elx-spinner size="md"></elx-spinner>
+      <elx-spinner size="lg"></elx-spinner>
+    </div>
+  `,
+};
+
+export const SpinnerVariants: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 24px; align-items: center;">
+      <elx-spinner variant="primary"></elx-spinner>
+      <elx-spinner variant="success"></elx-spinner>
+      <elx-spinner variant="warning"></elx-spinner>
+      <elx-spinner variant="danger"></elx-spinner>
+    </div>
+  `,
+};

--- a/src/components/progress/progress.test.ts
+++ b/src/components/progress/progress.test.ts
@@ -102,6 +102,16 @@ describe('elx-progress', () => {
     expect(labelDiv.style.display).toBe('none');
   });
 
+  it('handles max=0 by defaulting to 100', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.value = 50;
+    el.max = 0;
+    document.body.appendChild(el);
+    expect(el.max).toBe(100);
+    const bar = el.shadowRoot!.querySelector('.bar') as HTMLElement;
+    expect(bar.style.width).toBe('50%');
+  });
+
   it('updates bar when value changes', () => {
     const el = document.createElement('elx-progress') as any;
     el.value = 20;
@@ -164,6 +174,13 @@ describe('elx-spinner', () => {
     document.body.appendChild(el);
     const spinner = el.shadowRoot!.querySelector('.spinner');
     expect(spinner!.classList.contains('danger')).toBe(true);
+  });
+
+  it('has aria-busy=true', () => {
+    const el = document.createElement('elx-spinner');
+    document.body.appendChild(el);
+    const spinner = el.shadowRoot!.querySelector('.spinner');
+    expect(spinner!.getAttribute('aria-busy')).toBe('true');
   });
 
   it('defaults to md size and primary variant', () => {

--- a/src/components/progress/progress.test.ts
+++ b/src/components/progress/progress.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './progress';
+
+describe('elx-progress', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-progress')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with shadow DOM', () => {
+    const el = document.createElement('elx-progress');
+    document.body.appendChild(el);
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('defaults to 0 value and 100 max', () => {
+    const el = document.createElement('elx-progress') as any;
+    document.body.appendChild(el);
+    expect(el.value).toBe(0);
+    expect(el.max).toBe(100);
+  });
+
+  it('renders bar width based on value', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.value = 50;
+    document.body.appendChild(el);
+    const bar = el.shadowRoot!.querySelector('.bar') as HTMLElement;
+    expect(bar.style.width).toBe('50%');
+  });
+
+  it('clamps percentage between 0 and 100', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.value = 200;
+    document.body.appendChild(el);
+    const bar = el.shadowRoot!.querySelector('.bar') as HTMLElement;
+    expect(bar.style.width).toBe('100%');
+  });
+
+  it('supports custom max', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.max = 50;
+    el.value = 25;
+    document.body.appendChild(el);
+    const bar = el.shadowRoot!.querySelector('.bar') as HTMLElement;
+    expect(bar.style.width).toBe('50%');
+  });
+
+  it('applies variant class to bar', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.variant = 'success';
+    document.body.appendChild(el);
+    const bar = el.shadowRoot!.querySelector('.bar') as HTMLElement;
+    expect(bar.classList.contains('success')).toBe(true);
+  });
+
+  it('applies size class to track', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.size = 'lg';
+    document.body.appendChild(el);
+    const track = el.shadowRoot!.querySelector('.progress') as HTMLElement;
+    expect(track.classList.contains('lg')).toBe(true);
+  });
+
+  it('has correct ARIA attributes', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.value = 30;
+    el.max = 100;
+    document.body.appendChild(el);
+    const track = el.shadowRoot!.querySelector('.progress');
+    expect(track!.getAttribute('role')).toBe('progressbar');
+    expect(track!.getAttribute('aria-valuenow')).toBe('30');
+    expect(track!.getAttribute('aria-valuemin')).toBe('0');
+    expect(track!.getAttribute('aria-valuemax')).toBe('100');
+  });
+
+  it('uses label for aria-label when provided', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.value = 50;
+    el.label = 'Upload progress';
+    document.body.appendChild(el);
+    const track = el.shadowRoot!.querySelector('.progress');
+    expect(track!.getAttribute('aria-label')).toBe('Upload progress');
+  });
+
+  it('shows percentage in label area', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.value = 75;
+    el.label = 'Loading';
+    document.body.appendChild(el);
+    const percent = el.shadowRoot!.querySelector('.label-percent');
+    expect(percent!.textContent).toBe('75%');
+  });
+
+  it('hides label when not set', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.value = 50;
+    document.body.appendChild(el);
+    const labelDiv = el.shadowRoot!.querySelector('.progress-label') as HTMLElement;
+    expect(labelDiv.style.display).toBe('none');
+  });
+
+  it('updates bar when value changes', () => {
+    const el = document.createElement('elx-progress') as any;
+    el.value = 20;
+    document.body.appendChild(el);
+    const bar = el.shadowRoot!.querySelector('.bar') as HTMLElement;
+    expect(bar.style.width).toBe('20%');
+    el.value = 80;
+    expect(bar.style.width).toBe('80%');
+  });
+});
+
+describe('elx-spinner', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-spinner')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with shadow DOM', () => {
+    const el = document.createElement('elx-spinner');
+    document.body.appendChild(el);
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('has role=status', () => {
+    const el = document.createElement('elx-spinner');
+    document.body.appendChild(el);
+    const spinner = el.shadowRoot!.querySelector('.spinner');
+    expect(spinner!.getAttribute('role')).toBe('status');
+  });
+
+  it('defaults to Loading aria-label', () => {
+    const el = document.createElement('elx-spinner');
+    document.body.appendChild(el);
+    const spinner = el.shadowRoot!.querySelector('.spinner');
+    expect(spinner!.getAttribute('aria-label')).toBe('Loading');
+  });
+
+  it('applies custom label', () => {
+    const el = document.createElement('elx-spinner') as any;
+    el.label = 'Processing';
+    document.body.appendChild(el);
+    const spinner = el.shadowRoot!.querySelector('.spinner');
+    expect(spinner!.getAttribute('aria-label')).toBe('Processing');
+  });
+
+  it('applies size class', () => {
+    const el = document.createElement('elx-spinner') as any;
+    el.size = 'lg';
+    document.body.appendChild(el);
+    const spinner = el.shadowRoot!.querySelector('.spinner');
+    expect(spinner!.classList.contains('lg')).toBe(true);
+  });
+
+  it('applies variant class', () => {
+    const el = document.createElement('elx-spinner') as any;
+    el.variant = 'danger';
+    document.body.appendChild(el);
+    const spinner = el.shadowRoot!.querySelector('.spinner');
+    expect(spinner!.classList.contains('danger')).toBe(true);
+  });
+
+  it('defaults to md size and primary variant', () => {
+    const el = document.createElement('elx-spinner') as any;
+    document.body.appendChild(el);
+    expect(el.size).toBe('md');
+    expect(el.variant).toBe('primary');
+  });
+});

--- a/src/components/progress/progress.ts
+++ b/src/components/progress/progress.ts
@@ -1,0 +1,233 @@
+export class ElxProgress extends HTMLElement {
+  static observedAttributes = ['value', 'max', 'variant', 'size', 'label'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot?.querySelector('.progress')) this._buildDom();
+    this._update();
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    this._update();
+  }
+
+  get value(): number {
+    return Number(this.getAttribute('value')) || 0;
+  }
+  set value(val: number) {
+    this.setAttribute('value', String(val));
+  }
+
+  get max(): number {
+    return Number(this.getAttribute('max')) || 100;
+  }
+  set max(val: number) {
+    this.setAttribute('max', String(val));
+  }
+
+  get variant(): string {
+    return this.getAttribute('variant') || 'primary';
+  }
+  set variant(val: string) {
+    this.setAttribute('variant', val);
+  }
+
+  get size(): string {
+    return this.getAttribute('size') || 'md';
+  }
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
+
+  get label(): string {
+    return this.getAttribute('label') || '';
+  }
+  set label(val: string) {
+    this.setAttribute('label', val);
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: block;
+        width: 100%;
+      }
+
+      .progress-label {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 4px;
+        font-size: 14px;
+        color: var(--elx-color-neutral-700, #404040);
+      }
+
+      .progress {
+        width: 100%;
+        background: var(--elx-color-neutral-100, #f5f5f5);
+        border-radius: var(--elx-radius-full, 9999px);
+        overflow: hidden;
+      }
+
+      .progress.sm { height: 4px; }
+      .progress.md { height: 8px; }
+      .progress.lg { height: 12px; }
+
+      .bar {
+        height: 100%;
+        border-radius: var(--elx-radius-full, 9999px);
+        transition: width 300ms ease;
+      }
+
+      .bar.primary { background: var(--elx-color-primary-500, #6366f1); }
+      .bar.success { background: var(--elx-color-success-500, #22c55e); }
+      .bar.warning { background: var(--elx-color-warning-500, #f59e0b); }
+      .bar.danger { background: var(--elx-color-danger-500, #ef4444); }
+    `;
+
+    const labelDiv = document.createElement('div');
+    labelDiv.className = 'progress-label';
+    const labelText = document.createElement('span');
+    labelText.className = 'label-text';
+    const labelPercent = document.createElement('span');
+    labelPercent.className = 'label-percent';
+    labelDiv.appendChild(labelText);
+    labelDiv.appendChild(labelPercent);
+
+    const track = document.createElement('div');
+    track.className = 'progress';
+    track.setAttribute('role', 'progressbar');
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    track.appendChild(bar);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(labelDiv);
+    this.shadowRoot!.appendChild(track);
+  }
+
+  private _update() {
+    const track = this.shadowRoot?.querySelector('.progress') as HTMLElement;
+    const bar = this.shadowRoot?.querySelector('.bar') as HTMLElement;
+    const labelText = this.shadowRoot?.querySelector('.label-text') as HTMLElement;
+    const labelPercent = this.shadowRoot?.querySelector('.label-percent') as HTMLElement;
+    if (!track || !bar) return;
+
+    const percent = Math.min(100, Math.max(0, (this.value / this.max) * 100));
+
+    track.className = `progress ${this.size}`;
+    track.setAttribute('aria-valuenow', String(this.value));
+    track.setAttribute('aria-valuemin', '0');
+    track.setAttribute('aria-valuemax', String(this.max));
+    track.setAttribute('aria-label', this.label || `${Math.round(percent)}% complete`);
+
+    bar.className = `bar ${this.variant}`;
+    bar.style.width = `${percent}%`;
+
+    if (labelText) {
+      labelText.textContent = this.label;
+      const labelDiv = this.shadowRoot?.querySelector('.progress-label') as HTMLElement;
+      if (labelDiv) labelDiv.style.display = this.label ? 'flex' : 'none';
+    }
+    if (labelPercent) {
+      labelPercent.textContent = `${Math.round(percent)}%`;
+    }
+  }
+}
+
+export class ElxSpinner extends HTMLElement {
+  static observedAttributes = ['size', 'variant', 'label'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot?.querySelector('.spinner')) this._buildDom();
+    this._update();
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    this._update();
+  }
+
+  get size(): string {
+    return this.getAttribute('size') || 'md';
+  }
+  set size(val: string) {
+    this.setAttribute('size', val);
+  }
+
+  get variant(): string {
+    return this.getAttribute('variant') || 'primary';
+  }
+  set variant(val: string) {
+    this.setAttribute('variant', val);
+  }
+
+  get label(): string {
+    return this.getAttribute('label') || 'Loading';
+  }
+  set label(val: string) {
+    this.setAttribute('label', val);
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      @keyframes spin {
+        to { transform: rotate(360deg); }
+      }
+
+      .spinner {
+        border-radius: 50%;
+        border-style: solid;
+        border-color: var(--elx-color-neutral-200, #e5e5e5);
+        animation: spin 0.75s linear infinite;
+      }
+
+      .spinner.sm { width: 16px; height: 16px; border-width: 2px; }
+      .spinner.md { width: 24px; height: 24px; border-width: 3px; }
+      .spinner.lg { width: 36px; height: 36px; border-width: 4px; }
+
+      .spinner.primary { border-top-color: var(--elx-color-primary-500, #6366f1); }
+      .spinner.success { border-top-color: var(--elx-color-success-500, #22c55e); }
+      .spinner.warning { border-top-color: var(--elx-color-warning-500, #f59e0b); }
+      .spinner.danger { border-top-color: var(--elx-color-danger-500, #ef4444); }
+    `;
+
+    const spinner = document.createElement('div');
+    spinner.className = 'spinner';
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(spinner);
+  }
+
+  private _update() {
+    const spinner = this.shadowRoot?.querySelector('.spinner') as HTMLElement;
+    if (!spinner) return;
+    spinner.className = `spinner ${this.size} ${this.variant}`;
+    spinner.setAttribute('role', 'status');
+    spinner.setAttribute('aria-label', this.label);
+  }
+}
+
+if (!customElements.get('elx-progress')) {
+  customElements.define('elx-progress', ElxProgress);
+}
+if (!customElements.get('elx-spinner')) {
+  customElements.define('elx-spinner', ElxSpinner);
+}

--- a/src/components/progress/progress.ts
+++ b/src/components/progress/progress.ts
@@ -24,7 +24,8 @@ export class ElxProgress extends HTMLElement {
   }
 
   get max(): number {
-    return Number(this.getAttribute('max')) || 100;
+    const val = Number(this.getAttribute('max'));
+    return isNaN(val) || val <= 0 ? 100 : val;
   }
   set max(val: number) {
     this.setAttribute('max', String(val));
@@ -118,7 +119,7 @@ export class ElxProgress extends HTMLElement {
     const labelPercent = this.shadowRoot?.querySelector('.label-percent') as HTMLElement;
     if (!track || !bar) return;
 
-    const percent = Math.min(100, Math.max(0, (this.value / this.max) * 100));
+    const percent = this.max > 0 ? Math.min(100, Math.max(0, (this.value / this.max) * 100)) : 0;
 
     track.className = `progress ${this.size}`;
     track.setAttribute('aria-valuenow', String(this.value));
@@ -221,6 +222,7 @@ export class ElxSpinner extends HTMLElement {
     if (!spinner) return;
     spinner.className = `spinner ${this.size} ${this.variant}`;
     spinner.setAttribute('role', 'status');
+    spinner.setAttribute('aria-busy', 'true');
     spinner.setAttribute('aria-label', this.label);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,4 @@ export * from './components/text/text';
 export * from './components/toast/toast';
 export * from './components/dropdown/dropdown';
 export * from './components/popover/popover';
+export * from './components/progress/progress';


### PR DESCRIPTION
## Progress and Spinner Components

Adds elx-progress and elx-spinner for loading states.

### elx-progress
- Determinate progress bar with value/max attributes
- 4 variants: primary, success, warning, danger
- 3 sizes: sm, md, lg
- Optional label with percentage display
- ARIA: role=progressbar, aria-valuenow/min/max

### elx-spinner
- Animated CSS spinner
- Same variants and sizes as progress
- role=status with aria-label

### Tests
- 19 tests covering rendering, variants, sizes, ARIA, value updates
- 326 total tests passing