### PR TITLE
feat: add Breadcrumb component

### DIFF
--- a/src/components/breadcrumb/breadcrumb.stories.ts
+++ b/src/components/breadcrumb/breadcrumb.stories.ts
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './breadcrumb.js';
+
+const meta: Meta = {
+  title: 'Components/Breadcrumb',
+  tags: ['autodocs'],
+  argTypes: {
+    separator: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`
+    <elx-breadcrumb>
+      <elx-breadcrumb-item href="/">Home</elx-breadcrumb-item>
+      <elx-breadcrumb-item href="/products">Products</elx-breadcrumb-item>
+      <elx-breadcrumb-item>Current Page</elx-breadcrumb-item>
+    </elx-breadcrumb>
+  `,
+};
+
+export const CustomSeparator: Story = {
+  render: () => html`
+    <elx-breadcrumb separator=">">
+      <elx-breadcrumb-item href="/">Home</elx-breadcrumb-item>
+      <elx-breadcrumb-item href="/docs">Docs</elx-breadcrumb-item>
+      <elx-breadcrumb-item>API Reference</elx-breadcrumb-item>
+    </elx-breadcrumb>
+  `,
+};
+
+export const ArrowSeparator: Story = {
+  render: () => html`
+    <elx-breadcrumb separator="→">
+      <elx-breadcrumb-item href="/">Home</elx-breadcrumb-item>
+      <elx-breadcrumb-item href="/settings">Settings</elx-breadcrumb-item>
+      <elx-breadcrumb-item href="/settings/profile">Profile</elx-breadcrumb-item>
+      <elx-breadcrumb-item>Edit</elx-breadcrumb-item>
+    </elx-breadcrumb>
+  `,
+};

--- a/src/components/breadcrumb/breadcrumb.test.ts
+++ b/src/components/breadcrumb/breadcrumb.test.ts
@@ -125,4 +125,19 @@ describe('elx-breadcrumb-item', () => {
     const sep = el.shadowRoot!.querySelector('.separator');
     expect(sep!.getAttribute('aria-hidden')).toBe('true');
   });
+
+  it('has role=listitem', () => {
+    const el = document.createElement('elx-breadcrumb-item');
+    document.body.appendChild(el);
+    expect(el.getAttribute('role')).toBe('listitem');
+  });
+
+  it('sanitizes javascript: href', () => {
+    const el = document.createElement('elx-breadcrumb-item') as any;
+    el.href = 'javascript:alert(1)';
+    document.body.appendChild(el);
+    const a = el.shadowRoot!.querySelector('a');
+    expect(a).toBeTruthy();
+    expect(a!.href).not.toContain('javascript:');
+  });
 });

--- a/src/components/breadcrumb/breadcrumb.test.ts
+++ b/src/components/breadcrumb/breadcrumb.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './breadcrumb';
+
+describe('elx-breadcrumb', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-breadcrumb')).toBeDefined();
+    expect(customElements.get('elx-breadcrumb-item')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with shadow DOM', () => {
+    const el = document.createElement('elx-breadcrumb');
+    document.body.appendChild(el);
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('has nav with aria-label', () => {
+    const el = document.createElement('elx-breadcrumb');
+    document.body.appendChild(el);
+    const nav = el.shadowRoot!.querySelector('nav');
+    expect(nav!.getAttribute('aria-label')).toBe('Breadcrumb');
+  });
+
+  it('defaults separator to /', () => {
+    const el = document.createElement('elx-breadcrumb') as any;
+    document.body.appendChild(el);
+    expect(el.separator).toBe('/');
+  });
+
+  it('supports custom separator', () => {
+    const el = document.createElement('elx-breadcrumb') as any;
+    el.separator = '>';
+    document.body.appendChild(el);
+    expect(el.separator).toBe('>');
+  });
+
+  it('sets aria-current=page on last item', () => {
+    const el = document.createElement('elx-breadcrumb') as any;
+    const item1 = document.createElement('elx-breadcrumb-item');
+    item1.textContent = 'Home';
+    const item2 = document.createElement('elx-breadcrumb-item');
+    item2.textContent = 'Page';
+    el.appendChild(item1);
+    el.appendChild(item2);
+    document.body.appendChild(el);
+    expect(item1.hasAttribute('aria-current')).toBe(false);
+    expect(item2.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('sets data-separator on non-last items', () => {
+    const el = document.createElement('elx-breadcrumb') as any;
+    const item1 = document.createElement('elx-breadcrumb-item');
+    const item2 = document.createElement('elx-breadcrumb-item');
+    el.appendChild(item1);
+    el.appendChild(item2);
+    document.body.appendChild(el);
+    expect(item1.getAttribute('data-separator')).toBe('/');
+    expect(item2.getAttribute('data-separator')).toBe('');
+  });
+});
+
+describe('elx-breadcrumb-item', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with shadow DOM', () => {
+    const el = document.createElement('elx-breadcrumb-item');
+    document.body.appendChild(el);
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('renders link when href is set', () => {
+    const el = document.createElement('elx-breadcrumb-item') as any;
+    el.href = '/home';
+    document.body.appendChild(el);
+    const a = el.shadowRoot!.querySelector('a');
+    expect(a).toBeTruthy();
+    expect(a!.href).toContain('/home');
+  });
+
+  it('renders span when no href', () => {
+    const el = document.createElement('elx-breadcrumb-item');
+    document.body.appendChild(el);
+    const a = el.shadowRoot!.querySelector('a');
+    expect(a).toBeNull();
+    const span = el.shadowRoot!.querySelector('.item span');
+    expect(span).toBeTruthy();
+  });
+
+  it('renders span with current class when aria-current is set', () => {
+    const el = document.createElement('elx-breadcrumb-item') as any;
+    el.href = '/page';
+    el.setAttribute('aria-current', 'page');
+    document.body.appendChild(el);
+    const a = el.shadowRoot!.querySelector('a');
+    expect(a).toBeNull();
+    const current = el.shadowRoot!.querySelector('.current');
+    expect(current).toBeTruthy();
+  });
+
+  it('shows separator when data-separator is set', () => {
+    const el = document.createElement('elx-breadcrumb-item') as any;
+    el.setAttribute('data-separator', '/');
+    document.body.appendChild(el);
+    const sep = el.shadowRoot!.querySelector('.separator') as HTMLElement;
+    expect(sep.textContent).toBe('/');
+    expect(sep.style.display).not.toBe('none');
+  });
+
+  it('hides separator when data-separator is empty', () => {
+    const el = document.createElement('elx-breadcrumb-item') as any;
+    el.setAttribute('data-separator', '');
+    document.body.appendChild(el);
+    const sep = el.shadowRoot!.querySelector('.separator') as HTMLElement;
+    expect(sep.style.display).toBe('none');
+  });
+
+  it('separator is aria-hidden', () => {
+    const el = document.createElement('elx-breadcrumb-item');
+    document.body.appendChild(el);
+    const sep = el.shadowRoot!.querySelector('.separator');
+    expect(sep!.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/src/components/breadcrumb/breadcrumb.ts
+++ b/src/components/breadcrumb/breadcrumb.ts
@@ -1,0 +1,183 @@
+export class ElxBreadcrumb extends HTMLElement {
+  static observedAttributes = ['separator'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot?.querySelector('nav')) this._buildDom();
+    this._update();
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    this._update();
+  }
+
+  get separator(): string {
+    return this.getAttribute('separator') || '/';
+  }
+  set separator(val: string) {
+    this.setAttribute('separator', val);
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: block;
+      }
+
+      nav {
+        font-size: 14px;
+      }
+
+      .crumbs {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        gap: 4px;
+      }
+
+      ::slotted(elx-breadcrumb-item) {
+        display: inline-flex;
+        align-items: center;
+      }
+    `;
+
+    const nav = document.createElement('nav');
+    nav.setAttribute('aria-label', 'Breadcrumb');
+    const ol = document.createElement('ol');
+    ol.className = 'crumbs';
+    const slot = document.createElement('slot');
+    ol.appendChild(slot);
+    nav.appendChild(ol);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(nav);
+  }
+
+  private _update() {
+    const items = Array.from(this.querySelectorAll('elx-breadcrumb-item'));
+    items.forEach((item, i) => {
+      const isLast = i === items.length - 1;
+      item.setAttribute('data-separator', isLast ? '' : this.separator);
+      if (isLast) {
+        item.setAttribute('aria-current', 'page');
+      } else {
+        item.removeAttribute('aria-current');
+      }
+    });
+  }
+}
+
+export class ElxBreadcrumbItem extends HTMLElement {
+  static observedAttributes = ['href', 'data-separator'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot?.querySelector('.item')) this._buildDom();
+    this._update();
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    this._update();
+  }
+
+  get href(): string {
+    return this.getAttribute('href') || '';
+  }
+  set href(val: string) {
+    this.setAttribute('href', val);
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .item {
+        display: inline-flex;
+        align-items: center;
+      }
+
+      a {
+        color: var(--elx-color-primary-500, #6366f1);
+        text-decoration: none;
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+
+      .current {
+        color: var(--elx-color-neutral-700, #404040);
+      }
+
+      .separator {
+        color: var(--elx-color-neutral-400, #a3a3a3);
+        user-select: none;
+        margin: 0 2px;
+      }
+    `;
+
+    const span = document.createElement('span');
+    span.className = 'item';
+    const sep = document.createElement('span');
+    sep.className = 'separator';
+    sep.setAttribute('aria-hidden', 'true');
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(span);
+    this.shadowRoot!.appendChild(sep);
+  }
+
+  private _update() {
+    const container = this.shadowRoot?.querySelector('.item') as HTMLElement;
+    const sep = this.shadowRoot?.querySelector('.separator') as HTMLElement;
+    if (!container) return;
+
+    container.innerHTML = '';
+
+    const isCurrent = this.hasAttribute('aria-current');
+
+    if (this.href && !isCurrent) {
+      const a = document.createElement('a');
+      a.href = this.href;
+      a.appendChild(document.createElement('slot'));
+      container.appendChild(a);
+    } else {
+      const span = document.createElement('span');
+      span.className = isCurrent ? 'current' : '';
+      span.appendChild(document.createElement('slot'));
+      container.appendChild(span);
+    }
+
+    if (sep) {
+      const sepText = this.getAttribute('data-separator') || '';
+      sep.textContent = sepText;
+      sep.style.display = sepText ? '' : 'none';
+    }
+  }
+}
+
+if (!customElements.get('elx-breadcrumb')) {
+  customElements.define('elx-breadcrumb', ElxBreadcrumb);
+}
+if (!customElements.get('elx-breadcrumb-item')) {
+  customElements.define('elx-breadcrumb-item', ElxBreadcrumbItem);
+}

--- a/src/components/breadcrumb/breadcrumb.ts
+++ b/src/components/breadcrumb/breadcrumb.ts
@@ -44,10 +44,7 @@ export class ElxBreadcrumb extends HTMLElement {
         gap: 4px;
       }
 
-      ::slotted(elx-breadcrumb-item) {
-        display: inline-flex;
-        align-items: center;
-      }
+
     `;
 
     const nav = document.createElement('nav');
@@ -86,6 +83,7 @@ export class ElxBreadcrumbItem extends HTMLElement {
 
   connectedCallback() {
     if (!this.shadowRoot?.querySelector('.item')) this._buildDom();
+    this.setAttribute('role', 'listitem');
     this._update();
   }
 
@@ -157,7 +155,11 @@ export class ElxBreadcrumbItem extends HTMLElement {
 
     if (this.href && !isCurrent) {
       const a = document.createElement('a');
-      a.href = this.href;
+      // Sanitize href to prevent javascript: URLs
+      const href = this.href;
+      if (!/^javascript:/i.test(href)) {
+        a.href = href;
+      }
       a.appendChild(document.createElement('slot'));
       container.appendChild(a);
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,4 @@ export * from './components/toast/toast';
 export * from './components/dropdown/dropdown';
 export * from './components/popover/popover';
 export * from './components/progress/progress';
+export * from './components/breadcrumb/breadcrumb';


### PR DESCRIPTION
## Breadcrumb Component

Adds elx-breadcrumb and elx-breadcrumb-item for navigation trails.

### Features
- nav/ol semantic structure with aria-label=Breadcrumb
- elx-breadcrumb-item renders link (with href) or span (current page)
- Custom separator attribute (default: /)
- aria-current=page auto-set on last item
- aria-hidden separators
- CSS custom properties for theming

### Tests
- 13 tests covering rendering, ARIA, separators, links, current page
- 341 total tests passing