### PR TITLE
feat: add changelog and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Extract changelog for version
+        id: changelog
+        run: |
+          # Extract the section for this version from CHANGELOG.md
+          awk '/^## \[${{ steps.version.outputs.version }}\]/{found=1; next} /^## \[/{if(found) exit} found{print}' CHANGELOG.md > release_notes.md
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          cat release_notes.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.changelog.outputs.notes }}
+          generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+#### Components
+- **Button** - Primary, secondary, outline, ghost, and danger variants with size options
+- **Input** - Text input with validation states and icons
+- **Checkbox** - Custom checkbox with indeterminate state
+- **Switch** - Toggle switch component
+- **Radio** - Radio button group component
+- **Badge** - Status badges with multiple variants
+- **Avatar** - User avatar with fallback initials and image support
+- **Card** - Container card with header, body, and footer slots
+- **Alert** - Dismissible alerts with success, warning, danger, and info variants
+- **Dialog** - Modal dialog with focus trap and keyboard navigation
+- **Tabs** - Tabbed interface with keyboard navigation
+- **Tooltip** - Accessible tooltip with positioning
+- **Select** - Custom dropdown select with search and multi-select
+- **Separator** - Horizontal and vertical dividers
+- **Accordion** - Collapsible content panels
+- **Text** - Typography component with variants
+- **Toast** - Notification toasts with auto-dismiss
+- **Dropdown Menu** - Context menus with keyboard navigation
+- **Popover** - Floating content containers
+- **Progress** - Progress bars with determinate and indeterminate states
+- **Spinner** - Loading spinners in multiple sizes
+- **Breadcrumb** - Navigation breadcrumbs
+- **Pagination** - Page navigation with ellipsis support
+
+#### Infrastructure
+- ESLint + Prettier setup for code quality
+- @storybook/addon-a11y for accessibility testing
+- Storybook deployed to GitHub Pages
+- Live demo page
+- Type declarations and package exports
+- Global theme file with CSS custom properties
+- Standalone theme.css export
+
+### Changed
+- Updated CI to use Node 20 and 22
+- Enhanced README with Storybook URL and full component list
+- Added warning and purple color palettes to theming documentation
+
+### Fixed
+- TypeScript compatibility issues with event listeners


### PR DESCRIPTION
## Summary
- Adds CHANGELOG.md documenting all v0.1.0 changes (23 components + infrastructure)
- Adds release.yml GitHub Actions workflow that creates releases from version tags
- Workflow extracts changelog section for the tagged version automatically
- Works with existing publish.yml (triggered by release → publishes to GitHub Packages)

## Flow
1. Tag a release: `git tag v0.1.0 && git push --tags`
2. release.yml creates a GitHub Release with changelog notes
3. publish.yml triggers on the release and publishes to npm