### PR TITLE
fix: add workflow_dispatch to publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to GitHub Packages
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
GitHub Actions workflows triggered by GITHUB_TOKEN don't fire other workflow events (prevents infinite loops). This adds workflow_dispatch so we can manually trigger publish after a release.