### PR TITLE
feat: add Table component

### DIFF
--- a/src/components/table/table.stories.ts
+++ b/src/components/table/table.stories.ts
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import './table.js';
+
+const meta: Meta = {
+  title: 'Components/Table',
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => {
+    const table = document.createElement('elx-table');
+
+    const header = document.createElement('elx-table-header');
+    const headerRow = document.createElement('elx-table-row');
+    ['Name', 'Email', 'Role'].forEach((text) => {
+      const cell = document.createElement('elx-table-header-cell');
+      cell.textContent = text;
+      headerRow.appendChild(cell);
+    });
+    header.appendChild(headerRow);
+
+    const body = document.createElement('elx-table-body');
+    const data = [
+      ['Alice', 'alice@example.com', 'Admin'],
+      ['Bob', 'bob@example.com', 'Editor'],
+      ['Charlie', 'charlie@example.com', 'Viewer'],
+    ];
+    data.forEach((row) => {
+      const tr = document.createElement('elx-table-row');
+      row.forEach((text) => {
+        const td = document.createElement('elx-table-cell');
+        td.textContent = text;
+        tr.appendChild(td);
+      });
+      body.appendChild(tr);
+    });
+
+    table.appendChild(header);
+    table.appendChild(body);
+    return table;
+  },
+};
+
+export const Striped: Story = {
+  render: () => {
+    const table = document.createElement('elx-table');
+    table.setAttribute('striped', '');
+
+    const header = document.createElement('elx-table-header');
+    const headerRow = document.createElement('elx-table-row');
+    ['Name', 'Status', 'Amount'].forEach((text) => {
+      const cell = document.createElement('elx-table-header-cell');
+      cell.textContent = text;
+      headerRow.appendChild(cell);
+    });
+    header.appendChild(headerRow);
+
+    const body = document.createElement('elx-table-body');
+    const data = [
+      ['Invoice #001', 'Paid', '$250.00'],
+      ['Invoice #002', 'Pending', '$150.00'],
+      ['Invoice #003', 'Paid', '$350.00'],
+      ['Invoice #004', 'Overdue', '$450.00'],
+    ];
+    data.forEach((row) => {
+      const tr = document.createElement('elx-table-row');
+      row.forEach((text) => {
+        const td = document.createElement('elx-table-cell');
+        td.textContent = text;
+        tr.appendChild(td);
+      });
+      body.appendChild(tr);
+    });
+
+    table.appendChild(header);
+    table.appendChild(body);
+    return table;
+  },
+};
+
+export const Sortable: Story = {
+  render: () => {
+    const table = document.createElement('elx-table');
+    table.setAttribute('hoverable', '');
+
+    const header = document.createElement('elx-table-header');
+    const headerRow = document.createElement('elx-table-row');
+    ['Name', 'Age', 'City'].forEach((text) => {
+      const cell = document.createElement('elx-table-header-cell');
+      cell.setAttribute('sortable', '');
+      cell.textContent = text;
+      headerRow.appendChild(cell);
+    });
+    header.appendChild(headerRow);
+
+    const body = document.createElement('elx-table-body');
+    const data = [
+      ['Alice', '28', 'Jakarta'],
+      ['Bob', '34', 'Bandung'],
+      ['Charlie', '22', 'Surabaya'],
+    ];
+    data.forEach((row) => {
+      const tr = document.createElement('elx-table-row');
+      row.forEach((text) => {
+        const td = document.createElement('elx-table-cell');
+        td.textContent = text;
+        tr.appendChild(td);
+      });
+      body.appendChild(tr);
+    });
+
+    table.appendChild(header);
+    table.appendChild(body);
+    return table;
+  },
+};
+
+export const WithSelection: Story = {
+  render: () => {
+    const table = document.createElement('elx-table');
+    table.setAttribute('bordered', '');
+
+    const header = document.createElement('elx-table-header');
+    const headerRow = document.createElement('elx-table-row');
+    ['Product', 'Price', 'Stock'].forEach((text) => {
+      const cell = document.createElement('elx-table-header-cell');
+      cell.textContent = text;
+      headerRow.appendChild(cell);
+    });
+    header.appendChild(headerRow);
+
+    const body = document.createElement('elx-table-body');
+    const data = [
+      ['Widget A', '$10.00', '100', false, false],
+      ['Widget B', '$20.00', '50', true, false],
+      ['Widget C', '$15.00', '0', false, true],
+    ];
+    data.forEach(([name, price, stock, selected, disabled]) => {
+      const tr = document.createElement('elx-table-row');
+      if (selected) tr.setAttribute('selected', '');
+      if (disabled) tr.setAttribute('disabled', '');
+      [name, price, stock].forEach((text) => {
+        const td = document.createElement('elx-table-cell');
+        td.textContent = text as string;
+        tr.appendChild(td);
+      });
+      body.appendChild(tr);
+    });
+
+    table.appendChild(header);
+    table.appendChild(body);
+    return table;
+  },
+};

--- a/src/components/table/table.test.ts
+++ b/src/components/table/table.test.ts
@@ -1,0 +1,257 @@
+import './table';
+
+describe('ElxTable', () => {
+  let el: any;
+
+  beforeEach(() => {
+    el = document.createElement('elx-table');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders with table role', () => {
+    const table = el.shadowRoot.querySelector('table');
+    expect(table).toBeTruthy();
+    expect(table.getAttribute('role')).toBe('table');
+  });
+
+  it('renders slot for content', () => {
+    const slot = el.shadowRoot.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('has striped attribute', () => {
+    el.striped = true;
+    expect(el.hasAttribute('striped')).toBe(true);
+    expect(el.striped).toBe(true);
+  });
+
+  it('has hoverable attribute', () => {
+    el.hoverable = true;
+    expect(el.hasAttribute('hoverable')).toBe(true);
+    expect(el.hoverable).toBe(true);
+  });
+
+  it('has bordered attribute', () => {
+    el.bordered = true;
+    expect(el.hasAttribute('bordered')).toBe(true);
+    expect(el.bordered).toBe(true);
+  });
+});
+
+describe('ElxTableHeader', () => {
+  let el: any;
+
+  beforeEach(() => {
+    el = document.createElement('elx-table-header');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders slot', () => {
+    const slot = el.shadowRoot.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('has rowgroup role', () => {
+    expect(el.getAttribute('role')).toBe('rowgroup');
+  });
+});
+
+describe('ElxTableBody', () => {
+  let el: any;
+
+  beforeEach(() => {
+    el = document.createElement('elx-table-body');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders slot', () => {
+    const slot = el.shadowRoot.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('has rowgroup role', () => {
+    expect(el.getAttribute('role')).toBe('rowgroup');
+  });
+});
+
+describe('ElxTableRow', () => {
+  let el: any;
+
+  beforeEach(() => {
+    el = document.createElement('elx-table-row');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders slot', () => {
+    const slot = el.shadowRoot.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('has row role', () => {
+    expect(el.getAttribute('role')).toBe('row');
+  });
+
+  it('has selected attribute', () => {
+    el.selected = true;
+    expect(el.hasAttribute('selected')).toBe(true);
+    expect(el.selected).toBe(true);
+    expect(el.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('has disabled attribute', () => {
+    el.disabled = true;
+    expect(el.hasAttribute('disabled')).toBe(true);
+    expect(el.disabled).toBe(true);
+    expect(el.getAttribute('aria-disabled')).toBe('true');
+  });
+});
+
+describe('ElxTableCell', () => {
+  let el: any;
+
+  beforeEach(() => {
+    el = document.createElement('elx-table-cell');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders slot', () => {
+    const slot = el.shadowRoot.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('has cell role', () => {
+    expect(el.getAttribute('role')).toBe('cell');
+  });
+});
+
+describe('ElxTableHeaderCell', () => {
+  let el: any;
+
+  beforeEach(() => {
+    el = document.createElement('elx-table-header-cell');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders slot', () => {
+    const slot = el.shadowRoot.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('has columnheader role', () => {
+    expect(el.getAttribute('role')).toBe('columnheader');
+  });
+
+  it('has sortable attribute', () => {
+    el.sortable = true;
+    expect(el.hasAttribute('sortable')).toBe(true);
+    expect(el.sortable).toBe(true);
+  });
+
+  it('has sortDirection attribute', () => {
+    el.sortDirection = 'asc';
+    expect(el.sortDirection).toBe('asc');
+    el.sortDirection = 'desc';
+    expect(el.sortDirection).toBe('desc');
+    el.sortDirection = 'none';
+    expect(el.sortDirection).toBe('none');
+  });
+
+  it('renders sort button when sortable', () => {
+    el.sortable = true;
+    document.body.innerHTML = '';
+    el = document.createElement('elx-table-header-cell');
+    el.sortable = true;
+    document.body.appendChild(el);
+    const button = el.shadowRoot.querySelector('button');
+    expect(button).toBeTruthy();
+  });
+
+  it('does not render sort button when not sortable', () => {
+    const button = el.shadowRoot.querySelector('button');
+    expect(button).toBeNull();
+  });
+
+  it('dispatches sort event on button click', async () => {
+    el.sortable = true;
+    document.body.innerHTML = '';
+    el = document.createElement('elx-table-header-cell');
+    el.sortable = true;
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot.querySelector('button');
+    let eventDetail: any = null;
+    el.addEventListener('sort', (e: CustomEvent) => {
+      eventDetail = e.detail;
+    });
+
+    button.click();
+    expect(eventDetail).toBeTruthy();
+    expect(eventDetail.direction).toBe('asc');
+  });
+
+  it('cycles sort direction on repeated clicks', async () => {
+    el.sortable = true;
+    document.body.innerHTML = '';
+    el = document.createElement('elx-table-header-cell');
+    el.sortable = true;
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot.querySelector('button');
+    const directions: string[] = [];
+
+    el.addEventListener('sort', (e: CustomEvent) => {
+      directions.push(e.detail.direction);
+    });
+
+    button.click();
+    el.sortDirection = 'asc';
+    button.click();
+    el.sortDirection = 'desc';
+    button.click();
+
+    expect(directions).toEqual(['asc', 'desc', 'asc']);
+  });
+
+  it('updates aria-sort based on sortDirection', () => {
+    el.sortable = true;
+    document.body.innerHTML = '';
+    el = document.createElement('elx-table-header-cell');
+    el.sortable = true;
+    document.body.appendChild(el);
+
+    const button = el.shadowRoot.querySelector('button');
+
+    el.sortDirection = 'asc';
+    expect(button.getAttribute('aria-sort')).toBe('ascending');
+
+    el.sortDirection = 'desc';
+    expect(button.getAttribute('aria-sort')).toBe('descending');
+
+    el.sortDirection = 'none';
+    expect(button.hasAttribute('aria-sort')).toBe(false);
+  });
+});

--- a/src/components/table/table.ts
+++ b/src/components/table/table.ts
@@ -1,0 +1,389 @@
+export class ElxTable extends HTMLElement {
+  static observedAttributes = ['striped', 'hoverable', 'bordered'];
+
+  private _table: HTMLTableElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this._buildDom();
+  }
+
+  get striped(): boolean {
+    return this.hasAttribute('striped');
+  }
+  set striped(val: boolean) {
+    if (val) this.setAttribute('striped', '');
+    else this.removeAttribute('striped');
+  }
+
+  get hoverable(): boolean {
+    return this.hasAttribute('hoverable');
+  }
+  set hoverable(val: boolean) {
+    if (val) this.setAttribute('hoverable', '');
+    else this.removeAttribute('hoverable');
+  }
+
+  get bordered(): boolean {
+    return this.hasAttribute('bordered');
+  }
+  set bordered(val: boolean) {
+    if (val) this.setAttribute('bordered', '');
+    else this.removeAttribute('bordered');
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: block;
+        width: 100%;
+        overflow-x: auto;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: var(--elx-font-size-sm, 14px);
+        font-family: var(--elx-font-family-sans, inherit);
+      }
+
+      :host([bordered]) table {
+        border: 1px solid var(--elx-color-neutral-200, #e5e7eb);
+      }
+
+      :host([bordered]) th,
+      :host([bordered]) td {
+        border: 1px solid var(--elx-color-neutral-200, #e5e7eb);
+      }
+
+      th {
+        padding: 12px 16px;
+        text-align: left;
+        font-weight: var(--elx-font-weight-semibold, 600);
+        color: var(--elx-color-neutral-700, #374151);
+        background: var(--elx-color-neutral-50, #f9fafb);
+        border-bottom: 2px solid var(--elx-color-neutral-200, #e5e7eb);
+      }
+
+      td {
+        padding: 12px 16px;
+        color: var(--elx-color-neutral-900, #111827);
+        border-bottom: 1px solid var(--elx-color-neutral-200, #e5e7eb);
+      }
+
+      :host([striped]) tbody tr:nth-child(even) {
+        background: var(--elx-color-neutral-50, #f9fafb);
+      }
+
+      :host([hoverable]) tbody tr:hover {
+        background: var(--elx-color-neutral-100, #f3f4f6);
+      }
+
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+    `;
+
+    this._table = document.createElement('table');
+    this._table.setAttribute('role', 'table');
+
+    const slot = document.createElement('slot');
+    this._table.appendChild(slot);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(this._table);
+  }
+}
+
+export class ElxTableHeader extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.setAttribute('role', 'rowgroup');
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: table-header-group;
+      }
+    `;
+    const slot = document.createElement('slot');
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(slot);
+  }
+}
+
+export class ElxTableBody extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.setAttribute('role', 'rowgroup');
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: table-row-group;
+      }
+    `;
+    const slot = document.createElement('slot');
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(slot);
+  }
+}
+
+export class ElxTableRow extends HTMLElement {
+  static observedAttributes = ['selected', 'disabled'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.setAttribute('role', 'row');
+    this._buildDom();
+  }
+
+  attributeChangedCallback(name: string, oldVal: string, newVal: string) {
+    if (oldVal === newVal) return;
+    if (name === 'selected' || name === 'disabled') {
+      this._updateState();
+    }
+  }
+
+  get selected(): boolean {
+    return this.hasAttribute('selected');
+  }
+  set selected(val: boolean) {
+    if (val) this.setAttribute('selected', '');
+    else this.removeAttribute('selected');
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    if (val) this.setAttribute('disabled', '');
+    else this.removeAttribute('disabled');
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: table-row;
+      }
+
+      :host([selected]) {
+        background: var(--elx-color-primary-50, #eff6ff) !important;
+      }
+
+      :host([disabled]) {
+        opacity: 0.5;
+        pointer-events: none;
+      }
+    `;
+    const slot = document.createElement('slot');
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(slot);
+  }
+
+  private _updateState() {
+    this.setAttribute('aria-selected', String(this.selected));
+    this.setAttribute('aria-disabled', String(this.disabled));
+  }
+}
+
+export class ElxTableCell extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.setAttribute('role', 'cell');
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: table-cell;
+      }
+    `;
+    const slot = document.createElement('slot');
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(slot);
+  }
+}
+
+export class ElxTableHeaderCell extends HTMLElement {
+  static observedAttributes = ['sortable', 'sort-direction'];
+
+  private _button: HTMLButtonElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.setAttribute('role', 'columnheader');
+    this._buildDom();
+  }
+
+  attributeChangedCallback(name: string, oldVal: string, newVal: string) {
+    if (oldVal === newVal) return;
+    if (name === 'sortable' || name === 'sort-direction') {
+      this._updateSortState();
+    }
+  }
+
+  get sortable(): boolean {
+    return this.hasAttribute('sortable');
+  }
+  set sortable(val: boolean) {
+    if (val) this.setAttribute('sortable', '');
+    else this.removeAttribute('sortable');
+  }
+
+  get sortDirection(): 'asc' | 'desc' | 'none' {
+    const val = this.getAttribute('sort-direction');
+    if (val === 'asc' || val === 'desc') return val;
+    return 'none';
+  }
+  set sortDirection(val: 'asc' | 'desc' | 'none') {
+    if (val === 'none') this.removeAttribute('sort-direction');
+    else this.setAttribute('sort-direction', val);
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: table-cell;
+      }
+
+      .header-content {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      button {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        background: none;
+        border: none;
+        padding: 0;
+        font: inherit;
+        color: inherit;
+        cursor: pointer;
+      }
+
+      button:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 2px var(--elx-color-primary-500, #3b82f6);
+        border-radius: var(--elx-radius-sm, 4px);
+      }
+
+      .sort-icon {
+        width: 14px;
+        height: 14px;
+        opacity: 0.3;
+        transition: opacity 0.15s, transform 0.15s;
+      }
+
+      button:hover .sort-icon {
+        opacity: 0.7;
+      }
+
+      button[aria-sort="ascending"] .sort-icon,
+      button[aria-sort="descending"] .sort-icon {
+        opacity: 1;
+      }
+
+      button[aria-sort="descending"] .sort-icon {
+        transform: rotate(180deg);
+      }
+    `;
+
+    const slot = document.createElement('slot');
+
+    if (this.sortable) {
+      this._button = document.createElement('button');
+      this._button.type = 'button';
+      this._button.className = 'header-content';
+      const textSpan = document.createElement('span');
+      textSpan.appendChild(slot);
+
+      const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      icon.setAttribute('class', 'sort-icon');
+      icon.setAttribute('viewBox', '0 0 20 20');
+      icon.setAttribute('fill', 'currentColor');
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('fill-rule', 'evenodd');
+      path.setAttribute('d', 'M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z');
+      path.setAttribute('clip-rule', 'evenodd');
+      icon.appendChild(path);
+
+      this._button.appendChild(textSpan);
+      this._button.appendChild(icon);
+
+      this._button.addEventListener('click', () => this._handleSortClick());
+
+      this.shadowRoot!.appendChild(style);
+      this.shadowRoot!.appendChild(this._button);
+    } else {
+      this.shadowRoot!.appendChild(style);
+      this.shadowRoot!.appendChild(slot);
+    }
+  }
+
+  private _updateSortState() {
+    if (!this._button) return;
+    const direction = this.sortDirection;
+    if (direction === 'none') {
+      this._button.removeAttribute('aria-sort');
+    } else {
+      this._button.setAttribute('aria-sort', direction === 'asc' ? 'ascending' : 'descending');
+    }
+  }
+
+  private _handleSortClick() {
+    const nextDirection = this.sortDirection === 'none' ? 'asc' : this.sortDirection === 'asc' ? 'desc' : 'asc';
+    this.dispatchEvent(
+      new CustomEvent('sort', {
+        detail: { direction: nextDirection },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+}
+
+if (!customElements.get('elx-table')) {
+  customElements.define('elx-table', ElxTable);
+}
+if (!customElements.get('elx-table-header')) {
+  customElements.define('elx-table-header', ElxTableHeader);
+}
+if (!customElements.get('elx-table-body')) {
+  customElements.define('elx-table-body', ElxTableBody);
+}
+if (!customElements.get('elx-table-row')) {
+  customElements.define('elx-table-row', ElxTableRow);
+}
+if (!customElements.get('elx-table-cell')) {
+  customElements.define('elx-table-cell', ElxTableCell);
+}
+if (!customElements.get('elx-table-header-cell')) {
+  customElements.define('elx-table-header-cell', ElxTableHeaderCell);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from './components/separator/separator';
 export * from './components/accordion/accordion';
 export * from './components/text/text';
 export * from './components/toast/toast';
+export * from './components/table/table';
 export * from './components/dropdown/dropdown';
 export * from './components/popover/popover';
 export * from './components/progress/progress';


### PR DESCRIPTION
## Summary
6 sub-components for composable tables:
- `elx-table` — wrapper with striped, hoverable, bordered variants
- `elx-table-header` / `elx-table-body` — semantic grouping
- `elx-table-row` — with selected/disabled states
- `elx-table-cell` — body cells
- `elx-table-header-cell` — sortable headers with sort events and aria-sort

19 tests, 4 Storybook stories.