### PR TITLE
fix: skeleton review fixes

### DIFF
--- a/src/components/skeleton/skeleton.test.ts
+++ b/src/components/skeleton/skeleton.test.ts
@@ -44,6 +44,21 @@ describe('ElxSkeleton', () => {
     expect(el.hasAttribute('animate')).toBe(false);
   });
 
+  it('does not duplicate content on reconnect', () => {
+    const skeletonCount = el.shadowRoot.querySelectorAll('.skeleton').length;
+    document.body.removeChild(el);
+    document.body.appendChild(el);
+    expect(el.shadowRoot.querySelectorAll('.skeleton').length).toBe(skeletonCount);
+  });
+
+  it('clears width style when attribute removed', () => {
+    el.setAttribute('width', '200px');
+    const div = el.shadowRoot.querySelector('.skeleton');
+    expect(div.style.width).toBe('200px');
+    el.removeAttribute('width');
+    expect(div.style.width).toBe('');
+  });
+
   it('defaults to rectangular variant', () => {
     expect(el.variant).toBe('rectangular');
   });

--- a/src/components/skeleton/skeleton.ts
+++ b/src/components/skeleton/skeleton.ts
@@ -74,7 +74,9 @@ export class ElxSkeleton extends HTMLElement {
     if (!this.hasAttribute('animate')) {
       this.setAttribute('animate', '');
     }
-    this._render();
+    if (!this.shadowRoot?.querySelector('.skeleton')) {
+      this._render();
+    }
   }
 
   attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
@@ -128,4 +130,6 @@ export class ElxSkeleton extends HTMLElement {
   }
 }
 
-customElements.define('elx-skeleton', ElxSkeleton);
+if (!customElements.get('elx-skeleton')) {
+  customElements.define('elx-skeleton', ElxSkeleton);
+}


### PR DESCRIPTION
## Summary
Fixes from code review of the Skeleton component:

1. **Guard double-render on reconnect** —  now checks if  already exists before rendering
2. **Safe registration pattern** — uses  guard to prevent errors on multiple imports
3. **Added tests** — reconnection test, attribute removal test

## Test plan
- [x] All 397 tests pass locally
- [x] CI will verify