### PR TITLE
feat: add Drawer component

### DIFF
--- a/src/components/drawer/drawer.stories.ts
+++ b/src/components/drawer/drawer.stories.ts
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import './drawer.js';
+
+const meta: Meta = {
+  title: 'Components/Drawer',
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => {
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <button id="open-drawer">Open Drawer</button>
+      <elx-drawer id="demo-drawer">
+        <h3 slot="title">Drawer Title</h3>
+        <p>This is the drawer content. You can put any content here.</p>
+        <div slot="footer">
+          <button onclick="document.getElementById('demo-drawer').close()">Close</button>
+        </div>
+      </elx-drawer>
+    `;
+    setTimeout(() => {
+      container.querySelector('#open-drawer')?.addEventListener('click', () => {
+        (container.querySelector('#demo-drawer') as any).show();
+      });
+    }, 0);
+    return container;
+  },
+};
+
+export const LeftPlacement: Story = {
+  render: () => {
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <button id="open-left">Open Left Drawer</button>
+      <elx-drawer id="left-drawer" placement="left">
+        <h3 slot="title">Left Drawer</h3>
+        <p>This drawer slides in from the left.</p>
+      </elx-drawer>
+    `;
+    setTimeout(() => {
+      container.querySelector('#open-left')?.addEventListener('click', () => {
+        (container.querySelector('#left-drawer') as any).show();
+      });
+    }, 0);
+    return container;
+  },
+};
+
+export const WithForm: Story = {
+  render: () => {
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <button id="open-form">Open Form Drawer</button>
+      <elx-drawer id="form-drawer">
+        <h3 slot="title">Edit Profile</h3>
+        <form style="display: flex; flex-direction: column; gap: 1rem;">
+          <label>
+            Name
+            <input type="text" placeholder="Enter your name" style="width: 100%; margin-top: 0.25rem;" />
+          </label>
+          <label>
+            Email
+            <input type="email" placeholder="Enter your email" style="width: 100%; margin-top: 0.25rem;" />
+          </label>
+        </form>
+        <div slot="footer" style="display: flex; gap: 0.5rem;">
+          <button onclick="document.getElementById('form-drawer').close()">Cancel</button>
+          <button onclick="alert('Saved!')">Save</button>
+        </div>
+      </elx-drawer>
+    `;
+    setTimeout(() => {
+      container.querySelector('#open-form')?.addEventListener('click', () => {
+        (container.querySelector('#form-drawer') as any).show();
+      });
+    }, 0);
+    return container;
+  },
+};

--- a/src/components/drawer/drawer.test.ts
+++ b/src/components/drawer/drawer.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import './drawer';
+
+describe('ElxDrawer', () => {
+  let el: any;
+
+  beforeEach(() => {
+    el = document.createElement('elx-drawer');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders drawer structure', () => {
+    expect(el.shadowRoot.querySelector('.drawer')).toBeTruthy();
+    expect(el.shadowRoot.querySelector('.backdrop')).toBeTruthy();
+    expect(el.shadowRoot.querySelector('.header')).toBeTruthy();
+    expect(el.shadowRoot.querySelector('.content')).toBeTruthy();
+    expect(el.shadowRoot.querySelector('.footer')).toBeTruthy();
+  });
+
+  it('has dialog role and aria-modal', () => {
+    const drawer = el.shadowRoot.querySelector('.drawer');
+    expect(drawer.getAttribute('role')).toBe('dialog');
+    expect(drawer.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('defaults to right placement', () => {
+    expect(el.placement).toBe('right');
+    expect(el.getAttribute('placement')).toBe('right');
+  });
+
+  it('supports left placement', () => {
+    el.placement = 'left';
+    expect(el.getAttribute('placement')).toBe('left');
+  });
+
+  it('is closed by default', () => {
+    expect(el.open).toBe(false);
+    const drawer = el.shadowRoot.querySelector('.drawer');
+    expect(drawer.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('opens via show()', () => {
+    el.show();
+    expect(el.open).toBe(true);
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  it('closes via close()', () => {
+    el.show();
+    el.close();
+    expect(el.open).toBe(false);
+  });
+
+  it('toggles via toggle()', () => {
+    el.toggle();
+    expect(el.open).toBe(true);
+    el.toggle();
+    expect(el.open).toBe(false);
+  });
+
+  it('dispatches elx-drawer-close event on close', () => {
+    let fired = false;
+    el.addEventListener('elx-drawer-close', () => { fired = true; });
+    el.show();
+    el.close();
+    expect(fired).toBe(true);
+  });
+
+  it('does not dispatch close event when already closed', () => {
+    let fired = false;
+    el.addEventListener('elx-drawer-close', () => { fired = true; });
+    el.close();
+    expect(fired).toBe(false);
+  });
+
+  it('has close button with aria-label', () => {
+    const btn = el.shadowRoot.querySelector('.close-button');
+    expect(btn).toBeTruthy();
+    expect(btn.getAttribute('aria-label')).toBe('Close drawer');
+  });
+
+  it('closes when close button clicked', () => {
+    el.show();
+    const btn = el.shadowRoot.querySelector('.close-button');
+    btn.click();
+    expect(el.open).toBe(false);
+  });
+
+  it('closes when backdrop clicked', () => {
+    el.show();
+    const backdrop = el.shadowRoot.querySelector('.backdrop');
+    backdrop.click();
+    expect(el.open).toBe(false);
+  });
+
+  it('has title, default, and footer slots', () => {
+    const slots = el.shadowRoot.querySelectorAll('slot');
+    const names = Array.from(slots).map((s: any) => s.name || 'default');
+    expect(names).toContain('title');
+    expect(names).toContain('default');
+    expect(names).toContain('footer');
+  });
+
+  it('does not duplicate content on reconnect', () => {
+    const count = el.shadowRoot.querySelectorAll('.drawer').length;
+    document.body.removeChild(el);
+    document.body.appendChild(el);
+    expect(el.shadowRoot.querySelectorAll('.drawer').length).toBe(count);
+  });
+});

--- a/src/components/drawer/drawer.test.ts
+++ b/src/components/drawer/drawer.test.ts
@@ -99,7 +99,7 @@ describe('ElxDrawer', () => {
 
   it('has title, default, and footer slots', () => {
     const slots = el.shadowRoot.querySelectorAll('slot');
-    const names = Array.from(slots).map((s: any) => s.name || 'default');
+    const names = [...el.shadowRoot.querySelectorAll('slot')].map((s: any) => s.name || 'default');
     expect(names).toContain('title');
     expect(names).toContain('default');
     expect(names).toContain('footer');
@@ -110,5 +110,20 @@ describe('ElxDrawer', () => {
     document.body.removeChild(el);
     document.body.appendChild(el);
     expect(el.shadowRoot.querySelectorAll('.drawer').length).toBe(count);
+  });
+
+  it('closes on Escape key', () => {
+    el.show();
+    const event = new KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+    expect(el.open).toBe(false);
+  });
+
+  it('does not close on Escape when closed', () => {
+    let fired = false;
+    el.addEventListener('elx-drawer-close', () => { fired = true; });
+    const event = new KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+    expect(fired).toBe(false);
   });
 });

--- a/src/components/drawer/drawer.test.ts
+++ b/src/components/drawer/drawer.test.ts
@@ -98,7 +98,6 @@ describe('ElxDrawer', () => {
   });
 
   it('has title, default, and footer slots', () => {
-    const slots = el.shadowRoot.querySelectorAll('slot');
     const names = [...el.shadowRoot.querySelectorAll('slot')].map((s: any) => s.name || 'default');
     expect(names).toContain('title');
     expect(names).toContain('default');

--- a/src/components/drawer/drawer.ts
+++ b/src/components/drawer/drawer.ts
@@ -133,6 +133,7 @@ export class ElxDrawer extends HTMLElement {
 
   private _closeButton: HTMLButtonElement | null = null;
   private _previousActiveElement: HTMLElement | null = null;
+  private _boundHandleKeydown: (e: KeyboardEvent) => void;
 
   get open(): boolean {
     return this.hasAttribute('open');
@@ -157,6 +158,7 @@ export class ElxDrawer extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
+    this._boundHandleKeydown = this._handleKeydown.bind(this);
   }
 
   connectedCallback() {
@@ -239,13 +241,56 @@ export class ElxDrawer extends HTMLElement {
     if (this.open) {
       drawer?.setAttribute('aria-hidden', 'false');
       backdrop?.setAttribute('aria-hidden', 'false');
-      this._trapFocus();
       this._previousActiveElement = document.activeElement as HTMLElement;
+      this._trapFocus();
+      document.addEventListener('keydown', this._boundHandleKeydown);
     } else {
       drawer?.setAttribute('aria-hidden', 'true');
       backdrop?.setAttribute('aria-hidden', 'true');
+      document.removeEventListener('keydown', this._boundHandleKeydown);
       this._restoreFocus();
     }
+  }
+
+  private _handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      this.close();
+      return;
+    }
+
+    if (e.key === 'Tab') {
+      this._handleTab(e);
+    }
+  }
+
+  private _handleTab(e: KeyboardEvent) {
+    const drawer = this.shadowRoot?.querySelector('.drawer');
+    if (!drawer) return;
+
+    const focusables = drawer.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    if (focusables.length === 0) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('keydown', this._boundHandleKeydown);
+    this._restoreFocus();
   }
 
   private _trapFocus() {

--- a/src/components/drawer/drawer.ts
+++ b/src/components/drawer/drawer.ts
@@ -1,0 +1,289 @@
+const styles = `
+  :host {
+    --elx-drawer-bg: var(--elx-color-surface, #ffffff);
+    --elx-drawer-width: 320px;
+    --elx-drawer-shadow: var(--elx-shadow-lg, 0 25px 50px -12px rgba(0, 0, 0, 0.25));
+    --elx-drawer-z: var(--elx-z-modal, 1000);
+    --elx-drawer-border: var(--elx-color-border, #e2e8f0);
+  }
+
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: var(--elx-drawer-z);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+  }
+
+  :host([open]) .backdrop {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .drawer {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    z-index: var(--elx-drawer-z);
+    background: var(--elx-drawer-bg);
+    box-shadow: var(--elx-drawer-shadow);
+    display: flex;
+    flex-direction: column;
+    max-width: 90vw;
+    transition: transform 0.3s ease;
+  }
+
+  :host([placement='left']) .drawer {
+    left: 0;
+    border-right: 1px solid var(--elx-drawer-border);
+    transform: translateX(-100%);
+  }
+
+  :host([placement='right']) .drawer {
+    right: 0;
+    border-left: 1px solid var(--elx-drawer-border);
+    transform: translateX(100%);
+  }
+
+  :host([open]) .drawer {
+    transform: translateX(0);
+  }
+
+  :host([placement='left'][open]) .drawer {
+    animation: slideInLeft 0.3s ease;
+  }
+
+  :host([placement='right'][open]) .drawer {
+    animation: slideInRight 0.3s ease;
+  }
+
+  @keyframes slideInLeft {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(0); }
+  }
+
+  @keyframes slideInRight {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem;
+    border-bottom: 1px solid var(--elx-drawer-border);
+    flex-shrink: 0;
+  }
+
+  .title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .close-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.5rem;
+    border-radius: 0.375rem;
+    color: inherit;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .close-button:hover {
+    background: var(--elx-color-neutral-100, #f1f5f9);
+  }
+
+  .close-button:focus-visible {
+    outline: 2px solid var(--elx-color-primary, #3b82f6);
+    outline-offset: 2px;
+  }
+
+  .content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
+  }
+
+  .footer {
+    padding: 1rem;
+    border-top: 1px solid var(--elx-drawer-border);
+    flex-shrink: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .backdrop,
+    .drawer {
+      transition: none;
+    }
+    :host([open]) .drawer {
+      animation: none;
+    }
+  }
+`;
+
+export class ElxDrawer extends HTMLElement {
+  static observedAttributes = ['open', 'placement'];
+
+  private _closeButton: HTMLButtonElement | null = null;
+  private _previousActiveElement: HTMLElement | null = null;
+
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+
+  set open(val: boolean) {
+    if (val) {
+      this.setAttribute('open', '');
+    } else {
+      this.removeAttribute('open');
+    }
+  }
+
+  get placement(): 'left' | 'right' {
+    return (this.getAttribute('placement') as 'left' | 'right') || 'right';
+  }
+
+  set placement(val: 'left' | 'right') {
+    this.setAttribute('placement', val);
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this.hasAttribute('placement')) {
+      this.setAttribute('placement', 'right');
+    }
+    if (!this.shadowRoot?.querySelector('.drawer')) {
+      this._render();
+    }
+  }
+
+  private _render() {
+    const style = document.createElement('style');
+    style.textContent = styles;
+
+    const backdrop = document.createElement('div');
+    backdrop.className = 'backdrop';
+    backdrop.addEventListener('click', () => this.close());
+
+    const drawer = document.createElement('div');
+    drawer.className = 'drawer';
+    drawer.setAttribute('role', 'dialog');
+    drawer.setAttribute('aria-modal', 'true');
+
+    const header = document.createElement('div');
+    header.className = 'header';
+
+    const title = document.createElement('h2');
+    title.className = 'title';
+    const titleSlot = document.createElement('slot');
+    titleSlot.name = 'title';
+    title.appendChild(titleSlot);
+
+    this._closeButton = document.createElement('button');
+    this._closeButton.className = 'close-button';
+    this._closeButton.setAttribute('aria-label', 'Close drawer');
+    this._closeButton.innerHTML = `
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M18 6L6 18M6 6l12 12"/>
+      </svg>
+    `;
+    this._closeButton.addEventListener('click', () => this.close());
+
+    header.appendChild(title);
+    header.appendChild(this._closeButton);
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    const contentSlot = document.createElement('slot');
+    content.appendChild(contentSlot);
+
+    const footer = document.createElement('div');
+    footer.className = 'footer';
+    const footerSlot = document.createElement('slot');
+    footerSlot.name = 'footer';
+    footer.appendChild(footerSlot);
+
+    drawer.appendChild(header);
+    drawer.appendChild(content);
+    drawer.appendChild(footer);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(backdrop);
+    this.shadowRoot!.appendChild(drawer);
+
+    this._updateOpenState();
+  }
+
+  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    if (name === 'open') {
+      this._updateOpenState();
+    }
+  }
+
+  private _updateOpenState() {
+    const drawer = this.shadowRoot?.querySelector('.drawer');
+    const backdrop = this.shadowRoot?.querySelector('.backdrop');
+
+    if (this.open) {
+      drawer?.setAttribute('aria-hidden', 'false');
+      backdrop?.setAttribute('aria-hidden', 'false');
+      this._trapFocus();
+      this._previousActiveElement = document.activeElement as HTMLElement;
+    } else {
+      drawer?.setAttribute('aria-hidden', 'true');
+      backdrop?.setAttribute('aria-hidden', 'true');
+      this._restoreFocus();
+    }
+  }
+
+  private _trapFocus() {
+    const drawer = this.shadowRoot?.querySelector('.drawer');
+    if (!drawer) return;
+
+    const focusableElements = drawer.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    if (focusableElements.length > 0) {
+      focusableElements[0].focus();
+    }
+  }
+
+  private _restoreFocus() {
+    if (this._previousActiveElement) {
+      this._previousActiveElement.focus();
+    }
+  }
+
+  public show() {
+    this.open = true;
+  }
+
+  public close() {
+    const wasOpen = this.open;
+    this.open = false;
+    if (wasOpen) {
+      this.dispatchEvent(new CustomEvent('elx-drawer-close', { bubbles: true, composed: true }));
+    }
+  }
+
+  public toggle() {
+    this.open = !this.open;
+  }
+}
+
+if (!customElements.get('elx-drawer')) {
+  customElements.define('elx-drawer', ElxDrawer);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export * from './components/text/text';
 export * from './components/toast/toast';
 export * from './components/table/table';
 export * from './components/skeleton/skeleton';
+export * from './components/drawer/drawer';
 export * from './components/dropdown/dropdown';
 export * from './components/popover/popover';
 export * from './components/progress/progress';


### PR DESCRIPTION
## Summary
Slide-over panel component for side navigation, forms, etc.

## Features
- Left/right placement via `placement` attribute
- Backdrop click to close
- Title, content, and footer slots
- Focus trap and restore on close
- `show()`, `close()`, `toggle()` API
- `elx-drawer-close` event
- `prefers-reduced-motion` support
- Full ARIA support (role=dialog, aria-modal)

## Test plan
- [x] 412 tests pass locally
- [x] CI will verify