### PR TITLE
feat: add AvatarGroup component

### DIFF
--- a/src/components/avatar/avatar.test.ts
+++ b/src/components/avatar/avatar.test.ts
@@ -170,4 +170,50 @@ describe('ElxAvatarGroup', () => {
       expect(a.style.display).toBe('');
     });
   });
+
+  it('sets aria-label on overflow element', () => {
+    const group = document.createElement('elx-avatar-group') as any;
+    document.body.appendChild(group);
+    for (let i = 0; i < 5; i++) {
+      const avatar = document.createElement('elx-avatar');
+      group.appendChild(avatar);
+    }
+    group.max = 3;
+    const overflow = group.shadowRoot.querySelector('.overflow');
+    expect(overflow.getAttribute('aria-label')).toBe('2 more avatars');
+  });
+
+  it('removes aria-label when overflow hidden', () => {
+    const group = document.createElement('elx-avatar-group') as any;
+    document.body.appendChild(group);
+    for (let i = 0; i < 5; i++) {
+      const avatar = document.createElement('elx-avatar');
+      group.appendChild(avatar);
+    }
+    group.max = 3;
+    group.max = 0;
+    const overflow = group.shadowRoot.querySelector('.overflow');
+    expect(overflow.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('has role=group on overflow element', () => {
+    const group = document.createElement('elx-avatar-group') as any;
+    document.body.appendChild(group);
+    const overflow = group.shadowRoot.querySelector('.overflow');
+    expect(overflow.getAttribute('role')).toBe('group');
+  });
+
+  it('cleans up on disconnect and reconnect', () => {
+    const group = document.createElement('elx-avatar-group') as any;
+    document.body.appendChild(group);
+    for (let i = 0; i < 5; i++) {
+      const avatar = document.createElement('elx-avatar');
+      group.appendChild(avatar);
+    }
+    group.max = 3;
+    document.body.removeChild(group);
+    document.body.appendChild(group);
+    const overflow = group.shadowRoot.querySelector('.overflow');
+    expect(overflow.textContent).toBe('+2');
+  });
 });

--- a/src/components/avatar/avatar.test.ts
+++ b/src/components/avatar/avatar.test.ts
@@ -104,3 +104,70 @@ describe('elx-avatar', () => {
     expect(img.style.display).toBe('none');
   });
 });
+
+describe('ElxAvatarGroup', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('is defined', () => {
+    const group = document.createElement('elx-avatar-group');
+    document.body.appendChild(group);
+    expect(group.shadowRoot).toBeTruthy();
+  });
+
+  it('shows overflow count when max is set', () => {
+    const group = document.createElement('elx-avatar-group') as any;
+    document.body.appendChild(group);
+    for (let i = 0; i < 5; i++) {
+      const avatar = document.createElement('elx-avatar');
+      avatar.setAttribute('fallback', `U${i}`);
+      group.appendChild(avatar);
+    }
+    group.max = 3;
+    const overflow = group.shadowRoot.querySelector('.overflow');
+    expect(overflow.textContent).toBe('+2');
+    expect(overflow.style.display).toBe('inline-flex');
+  });
+
+  it('hides overflow when max is not set', () => {
+    const group = document.createElement('elx-avatar-group') as any;
+    document.body.appendChild(group);
+    for (let i = 0; i < 3; i++) {
+      const avatar = document.createElement('elx-avatar');
+      group.appendChild(avatar);
+    }
+    const overflow = group.shadowRoot.querySelector('.overflow');
+    expect(overflow.style.display).toBe('none');
+  });
+
+  it('hides extra avatars beyond max', () => {
+    const group = document.createElement('elx-avatar-group') as any;
+    document.body.appendChild(group);
+    for (let i = 0; i < 5; i++) {
+      const avatar = document.createElement('elx-avatar');
+      group.appendChild(avatar);
+    }
+    group.max = 3;
+    const avatars = group.querySelectorAll('elx-avatar');
+    expect((avatars[0] as HTMLElement).style.display).toBe('');
+    expect((avatars[2] as HTMLElement).style.display).toBe('');
+    expect((avatars[3] as HTMLElement).style.display).toBe('none');
+    expect((avatars[4] as HTMLElement).style.display).toBe('none');
+  });
+
+  it('shows all avatars when max removed', () => {
+    const group = document.createElement('elx-avatar-group') as any;
+    document.body.appendChild(group);
+    for (let i = 0; i < 5; i++) {
+      const avatar = document.createElement('elx-avatar');
+      group.appendChild(avatar);
+    }
+    group.max = 3;
+    group.max = 0;
+    const avatars = group.querySelectorAll('elx-avatar');
+    avatars.forEach((a: HTMLElement) => {
+      expect(a.style.display).toBe('');
+    });
+  });
+});

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -202,10 +202,12 @@ export class ElxAvatarGroup extends HTMLElement {
 
   private _rendered = false;
   private _overflowEl: HTMLSpanElement | null = null;
+  private _boundHandleSlotChange: () => void;
 
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
+    this._boundHandleSlotChange = this._handleSlotChange.bind(this);
   }
 
   connectedCallback() {
@@ -214,6 +216,13 @@ export class ElxAvatarGroup extends HTMLElement {
       this._rendered = true;
     }
     this._updateOverflow();
+  }
+
+  disconnectedCallback() {
+    const slot = this.shadowRoot?.querySelector('slot');
+    if (slot) {
+      slot.removeEventListener('slotchange', this._boundHandleSlotChange);
+    }
   }
 
   attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
@@ -235,9 +244,18 @@ export class ElxAvatarGroup extends HTMLElement {
     this.shadowRoot!.innerHTML = `
       <style>${avatarGroupStyles}</style>
       <slot></slot>
-      <span class="overflow" part="overflow" style="display: none;"></span>
+      <span class="overflow" part="overflow" role="group" style="display: none;"></span>
     `;
     this._overflowEl = this.shadowRoot!.querySelector('.overflow');
+    
+    const slot = this.shadowRoot!.querySelector('slot');
+    if (slot) {
+      slot.addEventListener('slotchange', this._boundHandleSlotChange);
+    }
+  }
+
+  private _handleSlotChange() {
+    this._updateOverflow();
   }
 
   private _updateOverflow() {
@@ -249,6 +267,7 @@ export class ElxAvatarGroup extends HTMLElement {
     if (max > 0 && avatars.length > max) {
       const overflow = avatars.length - max;
       this._overflowEl.textContent = `+${overflow}`;
+      this._overflowEl.setAttribute('aria-label', `${overflow} more avatars`);
       this._overflowEl.style.display = 'inline-flex';
 
       avatars.forEach((avatar, index) => {
@@ -260,6 +279,7 @@ export class ElxAvatarGroup extends HTMLElement {
       });
     } else {
       this._overflowEl.style.display = 'none';
+      this._overflowEl.removeAttribute('aria-label');
       avatars.forEach(avatar => {
         (avatar as HTMLElement).style.display = '';
       });

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -165,3 +165,108 @@ export class ElxAvatar extends HTMLElement {
 if (!customElements.get('elx-avatar')) {
   customElements.define('elx-avatar', ElxAvatar);
 }
+
+const avatarGroupStyles = `
+  :host {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  ::slotted(elx-avatar) {
+    margin-left: -0.5rem;
+    border: 2px solid var(--elx-color-surface, #ffffff);
+  }
+
+  ::slotted(elx-avatar:first-child) {
+    margin-left: 0;
+  }
+
+  .overflow {
+    margin-left: -0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: var(--elx-color-neutral-200, #e2e8f0);
+    color: var(--elx-color-neutral-500, #64748b);
+    font-weight: 600;
+    font-size: 14px;
+    border: 2px solid var(--elx-color-surface, #ffffff);
+  }
+`;
+
+export class ElxAvatarGroup extends HTMLElement {
+  static observedAttributes = ['max'];
+
+  private _rendered = false;
+  private _overflowEl: HTMLSpanElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this._rendered) {
+      this._render();
+      this._rendered = true;
+    }
+    this._updateOverflow();
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    this._updateOverflow();
+  }
+
+  get max(): number {
+    const val = parseInt(this.getAttribute('max') || '0', 10);
+    return isNaN(val) || val <= 0 ? 0 : val;
+  }
+
+  set max(value: number) {
+    if (value > 0) this.setAttribute('max', String(value));
+    else this.removeAttribute('max');
+  }
+
+  private _render() {
+    this.shadowRoot!.innerHTML = `
+      <style>${avatarGroupStyles}</style>
+      <slot></slot>
+      <span class="overflow" part="overflow" style="display: none;"></span>
+    `;
+    this._overflowEl = this.shadowRoot!.querySelector('.overflow');
+  }
+
+  private _updateOverflow() {
+    if (!this._overflowEl) return;
+
+    const avatars = this.querySelectorAll('elx-avatar');
+    const max = this.max;
+
+    if (max > 0 && avatars.length > max) {
+      const overflow = avatars.length - max;
+      this._overflowEl.textContent = `+${overflow}`;
+      this._overflowEl.style.display = 'inline-flex';
+
+      avatars.forEach((avatar, index) => {
+        if (index >= max) {
+          (avatar as HTMLElement).style.display = 'none';
+        } else {
+          (avatar as HTMLElement).style.display = '';
+        }
+      });
+    } else {
+      this._overflowEl.style.display = 'none';
+      avatars.forEach(avatar => {
+        (avatar as HTMLElement).style.display = '';
+      });
+    }
+  }
+}
+
+if (!customElements.get('elx-avatar-group')) {
+  customElements.define('elx-avatar-group', ElxAvatarGroup);
+}


### PR DESCRIPTION
## Summary
AvatarGroup component for displaying stacked avatars with overflow indicator.

## Features
- Stacked layout with negative margin overlap
- `max` attribute to limit visible avatars
- +N overflow badge when avatars exceed max
- Hides extra avatars beyond max count
- Reactive to max attribute changes

## Usage
```html
<elx-avatar-group max="3">
  <elx-avatar src="user1.jpg" alt="User 1"></elx-avatar>
  <elx-avatar src="user2.jpg" alt="User 2"></elx-avatar>
  <elx-avatar src="user3.jpg" alt="User 3"></elx-avatar>
  <elx-avatar fallback="JD"></elx-avatar>
  <elx-avatar fallback="AB"></elx-avatar>
</elx-avatar-group>
```

## Tests
- 5 new tests for AvatarGroup
- Total: 439 tests passing