### PR TITLE
improvement: auto-generated changelog from PR titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,45 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Extract changelog for version
+      - name: Generate changelog from merged PRs
         id: changelog
         run: |
-          awk '/^## \[${{ steps.version.outputs.version }}\]/{found=1; next} /^## \[/{if(found) exit} found{print}' CHANGELOG.md > release_notes.md
+          chmod +x scripts/generate-changelog.sh
+          
+          # Get the previous tag (if any)
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          
+          # Generate new changelog entries
+          if [ -n "$PREV_TAG" ]; then
+            ./scripts/generate-changelog.sh "$PREV_TAG" > new_changes.md
+          else
+            ./scripts/generate-changelog.sh > new_changes.md
+          fi
+          
+          # Update CHANGELOG.md: insert new section after the header
+          if [ -s new_changes.md ]; then
+            # Create temp file with new changelog entry
+            head -n 7 CHANGELOG.md > changelog_header.md
+            cat changelog_header.md new_changes.md > CHANGELOG_new.md
+            tail -n +8 CHANGELOG.md >> CHANGELOG_new.md
+            mv CHANGELOG_new.md CHANGELOG.md
+            rm changelog_header.md new_changes.md
+          fi
+          
+          # Extract just this version's notes for the release
+          awk '/^## \[Unreleased\]/{found=1; next} /^## \[/{if(found) exit} found{print}' CHANGELOG.md > release_notes.md
+          
           echo "notes<<EOF" >> $GITHUB_OUTPUT
           cat release_notes.md >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Commit updated CHANGELOG.md
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet || git commit -m "chore: update CHANGELOG.md for v${{ steps.version.outputs.version }}"
+          git push origin HEAD:main
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,29 +42,30 @@ jobs:
         id: changelog
         run: |
           chmod +x scripts/generate-changelog.sh
+          VERSION="${{ steps.version.outputs.version }}"
           
-          # Get the previous tag (if any)
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          # Get the previous tag (if any) - use git tag to list tags sorted by version
+          PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]' | head -1 | sed 's/^v//' 2>/dev/null || echo "")
           
-          # Generate new changelog entries
+          # Generate new changelog entries with the version label
           if [ -n "$PREV_TAG" ]; then
-            ./scripts/generate-changelog.sh "$PREV_TAG" > new_changes.md
+            ./scripts/generate-changelog.sh "v${PREV_TAG}" "v${VERSION}" > new_changes.md
           else
-            ./scripts/generate-changelog.sh > new_changes.md
+            ./scripts/generate-changelog.sh "" "v${VERSION}" > new_changes.md
           fi
           
-          # Update CHANGELOG.md: insert new section after the header
+          # Update CHANGELOG.md: insert new section at the placeholder marker
           if [ -s new_changes.md ]; then
-            # Create temp file with new changelog entry
-            head -n 7 CHANGELOG.md > changelog_header.md
-            cat changelog_header.md new_changes.md > CHANGELOG_new.md
-            tail -n +8 CHANGELOG.md >> CHANGELOG_new.md
+            # Replace the placeholder comment with actual entries
+            sed '/CHANGELOG_ENTRIES_PLACEHOLDER/r new_changes.md' CHANGELOG.md > CHANGELOG_new.md
+            # Remove the marker comment line
+            sed -i '/CHANGELOG_ENTRIES_PLACEHOLDER/d' CHANGELOG_new.md
             mv CHANGELOG_new.md CHANGELOG.md
-            rm changelog_header.md new_changes.md
+            rm new_changes.md
           fi
           
-          # Extract just this version's notes for the release
-          awk '/^## \[Unreleased\]/{found=1; next} /^## \[/{if(found) exit} found{print}' CHANGELOG.md > release_notes.md
+          # Extract release notes for this version
+          awk "/^## \\[v${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md > release_notes.md
           
           echo "notes<<EOF" >> $GITHUB_OUTPUT
           cat release_notes.md >> $GITHUB_OUTPUT
@@ -76,7 +77,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
           git diff --cached --quiet || git commit -m "chore: update CHANGELOG.md for v${{ steps.version.outputs.version }}"
-          git push origin HEAD:main
+          git push origin HEAD:main || echo "Warning: Could not push CHANGELOG update (branch may be protected)"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- CHANGELOG_ENTRIES_PLACEHOLDER -->
 ## [Unreleased]
 
 ## [0.1.0] - 2026-04-25

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Generate changelog entries from merged PRs since the last tag.
-# Usage: ./scripts/generate-changelog.sh [since-tag]
+# Usage: ./scripts/generate-changelog.sh [since-tag] [version-label]
 # If no tag is given, uses the latest tag.
+# If no version-label is given, uses "Unreleased".
+# Squash-merged PRs are expected (reads commit subjects via --first-parent).
 
 set -euo pipefail
 
 SINCE_TAG="${1:-$(git describe --tags --abbrev=0 2>/dev/null || echo "")}"
+VERSION_LABEL="${2:-Unreleased}"
 DATE=$(date +%Y-%m-%d)
 
 if [ -z "$SINCE_TAG" ]; then
@@ -29,43 +32,47 @@ while IFS= read -r line; do
   # Categorize by conventional commit prefix
   if echo "$line" | grep -qiE '^feat(\(.+\))?:'; then
     entry=$(echo "$line" | sed -E 's/^feat(\([^)]+\))?: //')
-    FEATS="${FEATS}\n- ${entry}"
+    FEATS="${FEATS}
+- ${entry}"
   elif echo "$line" | grep -qiE '^fix(\(.+\))?:'; then
     entry=$(echo "$line" | sed -E 's/^fix(\([^)]+\))?: //')
-    FIXES="${FIXES}\n- ${entry}"
+    FIXES="${FIXES}
+- ${entry}"
   elif echo "$line" | grep -qiE '^(improvement|improve|chore|docs|refactor|perf|style|ci|build)(\(.+\))?:'; then
     entry=$(echo "$line" | sed -E 's/^(improvement|improve|chore|docs|refactor|perf|style|ci|build)(\([^)]+\))?: //')
-    IMPROVEMENTS="${IMPROVEMENTS}\n- ${entry}"
+    IMPROVEMENTS="${IMPROVEMENTS}
+- ${entry}"
   else
-    OTHER="${OTHER}\n- ${line}"
+    OTHER="${OTHER}
+- ${line}"
   fi
 done < <(git log --oneline --first-parent "$RANGE" 2>/dev/null | sed 's/^[a-f0-9]* //')
 
 # Output markdown
 echo ""
-echo "## [Unreleased] - ${DATE}"
+echo "## [${VERSION_LABEL}] - ${DATE}"
 echo ""
 
 if [ -n "$FEATS" ]; then
   echo "### Added"
-  echo -e "$FEATS"
+  printf '%s\n' "$FEATS"
   echo ""
 fi
 
 if [ -n "$FIXES" ]; then
   echo "### Fixed"
-  echo -e "$FIXES"
+  printf '%s\n' "$FIXES"
   echo ""
 fi
 
 if [ -n "$IMPROVEMENTS" ]; then
   echo "### Changed"
-  echo -e "$IMPROVEMENTS"
+  printf '%s\n' "$IMPROVEMENTS"
   echo ""
 fi
 
 if [ -n "$OTHER" ]; then
   echo "### Other"
-  echo -e "$OTHER"
+  printf '%s\n' "$OTHER"
   echo ""
 fi

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Generate changelog entries from merged PRs since the last tag.
+# Usage: ./scripts/generate-changelog.sh [since-tag]
+# If no tag is given, uses the latest tag.
+
+set -euo pipefail
+
+SINCE_TAG="${1:-$(git describe --tags --abbrev=0 2>/dev/null || echo "")}"
+DATE=$(date +%Y-%m-%d)
+
+if [ -z "$SINCE_TAG" ]; then
+  echo "No previous tag found. Listing all merged PRs on main." >&2
+  RANGE="main"
+else
+  echo "Generating changelog since $SINCE_TAG" >&2
+  RANGE="${SINCE_TAG}..HEAD"
+fi
+
+# Collect merge commit messages (PR titles from squash merges)
+FEATS=""
+FIXES=""
+IMPROVEMENTS=""
+OTHER=""
+
+while IFS= read -r line; do
+  # Skip empty lines
+  [ -z "$line" ] && continue
+
+  # Categorize by conventional commit prefix
+  if echo "$line" | grep -qiE '^feat(\(.+\))?:'; then
+    entry=$(echo "$line" | sed -E 's/^feat(\([^)]+\))?: //')
+    FEATS="${FEATS}\n- ${entry}"
+  elif echo "$line" | grep -qiE '^fix(\(.+\))?:'; then
+    entry=$(echo "$line" | sed -E 's/^fix(\([^)]+\))?: //')
+    FIXES="${FIXES}\n- ${entry}"
+  elif echo "$line" | grep -qiE '^(improvement|improve|chore|docs|refactor|perf|style|ci|build)(\(.+\))?:'; then
+    entry=$(echo "$line" | sed -E 's/^(improvement|improve|chore|docs|refactor|perf|style|ci|build)(\([^)]+\))?: //')
+    IMPROVEMENTS="${IMPROVEMENTS}\n- ${entry}"
+  else
+    OTHER="${OTHER}\n- ${line}"
+  fi
+done < <(git log --oneline --first-parent "$RANGE" 2>/dev/null | sed 's/^[a-f0-9]* //')
+
+# Output markdown
+echo ""
+echo "## [Unreleased] - ${DATE}"
+echo ""
+
+if [ -n "$FEATS" ]; then
+  echo "### Added"
+  echo -e "$FEATS"
+  echo ""
+fi
+
+if [ -n "$FIXES" ]; then
+  echo "### Fixed"
+  echo -e "$FIXES"
+  echo ""
+fi
+
+if [ -n "$IMPROVEMENTS" ]; then
+  echo "### Changed"
+  echo -e "$IMPROVEMENTS"
+  echo ""
+fi
+
+if [ -n "$OTHER" ]; then
+  echo "### Other"
+  echo -e "$OTHER"
+  echo ""
+fi


### PR DESCRIPTION
## Changes
- Added `scripts/generate-changelog.sh` — extracts merged PR titles and categorizes by conventional commit prefix (feat/fix/improvement/etc.)
- Updated `release.yml` to auto-generate changelog entries when a tag is pushed
- CHANGELOG.md is automatically updated and committed by the workflow
- Release notes on GitHub Releases are populated from the generated changelog

Closes #63