### PR TITLE
improvement: add bundle size tracking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,7 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Check bundle size
+        if: matrix.node-version == 22
+        run: npm run size

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@size-limit/file": "^12.1.0",
         "@storybook/addon-a11y": "^8.6.18",
         "@storybook/addon-essentials": "^8.0.0",
         "@storybook/addon-links": "^8.0.0",
@@ -20,6 +21,7 @@
         "jsdom": "^29.0.2",
         "lit": "^3.3.2",
         "prettier": "^3.8.3",
+        "size-limit": "^12.1.0",
         "typescript": "^5.4.0",
         "typescript-eslint": "^8.59.0",
         "vite": "^5.2.0",
@@ -1638,6 +1640,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
     "node_modules/@storybook/addon-a11y": {
       "version": "8.6.18",
       "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-8.6.18.tgz",
@@ -3244,6 +3259,16 @@
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
     },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4734,6 +4759,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lit": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
@@ -4980,6 +5018,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/natural-compare": {
@@ -5618,6 +5666,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,12 @@
     },
     {
       "path": "dist/theme.css",
-      "limit": "5 kB",
+      "limit": "2 kB",
+      "gzip": true
+    },
+    {
+      "path": "dist/style.css",
+      "limit": "2 kB",
       "gzip": true
     }
   ]

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write \"src/**/*.ts\"",
-    "format:check": "prettier --check \"src/**/*.ts\""
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "size": "size-limit",
+    "size:why": "size-limit --why"
   },
   "keywords": [
     "web-components",
@@ -31,6 +33,7 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@size-limit/file": "^12.1.0",
     "@storybook/addon-a11y": "^8.6.18",
     "@storybook/addon-essentials": "^8.0.0",
     "@storybook/addon-links": "^8.0.0",
@@ -41,6 +44,7 @@
     "jsdom": "^29.0.2",
     "lit": "^3.3.2",
     "prettier": "^3.8.3",
+    "size-limit": "^12.1.0",
     "typescript": "^5.4.0",
     "typescript-eslint": "^8.59.0",
     "vite": "^5.2.0",
@@ -56,5 +60,17 @@
       "types": "./dist/index.d.ts"
     },
     "./theme.css": "./dist/theme.css"
-  }
+  },
+  "size-limit": [
+    {
+      "path": "dist/index.js",
+      "limit": "40 kB",
+      "gzip": true
+    },
+    {
+      "path": "dist/theme.css",
+      "limit": "5 kB",
+      "gzip": true
+    }
+  ]
 }


### PR DESCRIPTION
## Changes
- Added `size-limit` with `@size-limit/file` for bundle size tracking
- Set budgets: 40kB for index.js (gzip), 5kB for theme.css (gzip)
- Added `npm run size` and `npm run size:why` scripts
- CI now checks bundle size on Node 22 after build
- Current sizes: 30.54kB JS, 781B CSS (well under budget)

Size checks will fail CI if the bundle exceeds the limit, preventing accidental size regressions.

Closes #62