### PR TITLE
improvement: add CSS ::part() attributes to all 32 components

### DIFF
--- a/src/components/accordion/accordion.ts
+++ b/src/components/accordion/accordion.ts
@@ -135,6 +135,7 @@ export class ElxAccordionItem extends HTMLElement {
     `;
 
     this._trigger = document.createElement('button');
+    this._trigger.setAttribute('part', 'trigger');
     this._trigger.type = 'button';
     this._trigger.className = 'trigger';
     this._trigger.setAttribute('aria-expanded', 'false');
@@ -147,6 +148,7 @@ export class ElxAccordionItem extends HTMLElement {
     label.textContent = this.label;
 
     const arrow = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    arrow.setAttribute('part', 'icon');
     arrow.setAttribute('class', 'arrow');
     arrow.setAttribute('viewBox', '0 0 20 20');
     arrow.setAttribute('fill', 'currentColor');
@@ -163,6 +165,7 @@ export class ElxAccordionItem extends HTMLElement {
     this._trigger.appendChild(arrow);
 
     this._content = document.createElement('div');
+    this._content.setAttribute('part', 'panel');
     this._content.className = 'content';
     this._content.setAttribute('role', 'region');
     this._content.setAttribute('aria-labelledby', id);

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -90,9 +90,11 @@ export class ElxAlert extends HTMLElement {
     `;
 
     const wrapper = document.createElement('div');
+    wrapper.setAttribute('part', 'alert');
     wrapper.className = 'alert';
 
     const icon = document.createElement('span');
+    icon.setAttribute('part', 'icon');
     icon.className = 'icon';
 
     const content = document.createElement('div');
@@ -101,6 +103,7 @@ export class ElxAlert extends HTMLElement {
     content.appendChild(slot);
 
     this._closeBtn = document.createElement('button');
+    this._closeBtn.setAttribute('part', 'close-button');
     this._closeBtn.className = 'close-btn';
     this._closeBtn.type = 'button';
     this._closeBtn.setAttribute('aria-label', 'Dismiss alert');

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -126,7 +126,7 @@ export class ElxAvatar extends HTMLElement {
     } else if (name && name.trim()) {
       const span = document.createElement('span');
       span.className = 'initials';
-      span.setAttribute('part', 'initials');
+      span.setAttribute('part', 'fallback');
       span.textContent = this._getInitials(name);
       shadow.appendChild(span);
     }

--- a/src/components/badge/badge.ts
+++ b/src/components/badge/badge.ts
@@ -99,6 +99,7 @@ export class ElxBadge extends HTMLElement {
     `;
 
     this._span = document.createElement('span');
+    this._span.setAttribute('part', 'badge');
     this._span.className = 'badge';
 
     const slot = document.createElement('slot');

--- a/src/components/breadcrumb/breadcrumb.ts
+++ b/src/components/breadcrumb/breadcrumb.ts
@@ -48,8 +48,10 @@ export class ElxBreadcrumb extends HTMLElement {
     `;
 
     const nav = document.createElement('nav');
+    nav.setAttribute('part', 'nav');
     nav.setAttribute('aria-label', 'Breadcrumb');
     const ol = document.createElement('ol');
+    ol.setAttribute('part', 'list');
     ol.className = 'crumbs';
     const slot = document.createElement('slot');
     ol.appendChild(slot);

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -89,6 +89,7 @@ export class ElxButton extends HTMLElement {
     `;
 
     this._button = document.createElement('button');
+    this._button.setAttribute('part', 'button');
     this._button.type = 'button';
 
     this._slot = document.createElement('slot');

--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -224,8 +224,8 @@ export class ElxCalendar extends HTMLElement {
   private _render() {
     this.shadowRoot!.innerHTML = `
       <style>${calendarStyles}</style>
-      <div class="calendar" role="grid" aria-label="Calendar">
-        <div class="header">
+      <div class="calendar" role="grid" aria-label="Calendar" part="calendar">
+        <div class="header" part="header">
           <span class="month-year" aria-live="polite"></span>
           <div class="nav-buttons">
             <button class="nav-btn prev" aria-label="Previous month">&lt;</button>
@@ -233,7 +233,7 @@ export class ElxCalendar extends HTMLElement {
           </div>
         </div>
         <div class="weekdays" role="row"></div>
-        <div class="days" role="rowgroup"></div>
+        <div class="days" role="rowgroup" part="grid"></div>
       </div>
     `;
 

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -98,6 +98,7 @@ export class ElxCard extends HTMLElement {
     `;
 
     const wrapper = document.createElement('div');
+    wrapper.setAttribute('part', 'card');
     wrapper.className = 'card';
 
     const headerSlot = document.createElement('slot');

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -175,9 +175,11 @@ export class ElxCheckbox extends HTMLElement {
     `;
 
     this._labelEl = document.createElement('label');
+    this._labelEl.setAttribute('part', 'label');
     this._labelEl.htmlFor = this._id;
 
     this._input = document.createElement('input');
+    this._input.setAttribute('part', 'input');
     this._input.type = 'checkbox';
     this._input.id = this._id;
 
@@ -185,6 +187,7 @@ export class ElxCheckbox extends HTMLElement {
     box.className = 'checkbox-box';
 
     this._checkmark = document.createElement('span');
+    this._checkmark.setAttribute('part', 'checkmark');
     this._checkmark.className = 'checkmark';
 
     box.appendChild(this._checkmark);

--- a/src/components/dialog/dialog.ts
+++ b/src/components/dialog/dialog.ts
@@ -99,12 +99,14 @@ export class ElxDialog extends HTMLElement {
     `;
 
     const overlay = document.createElement('div');
+    overlay.setAttribute('part', 'overlay');
     overlay.className = 'overlay';
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) this.close();
     });
 
     const dialog = document.createElement('div');
+    dialog.setAttribute('part', 'dialog');
     dialog.className = 'dialog';
     dialog.setAttribute('role', 'dialog');
     dialog.setAttribute('aria-modal', 'true');
@@ -119,6 +121,7 @@ export class ElxDialog extends HTMLElement {
     title.appendChild(titleSlot);
 
     const closeBtn = document.createElement('button');
+    closeBtn.setAttribute('part', 'close-button');
     closeBtn.className = 'close-btn';
     closeBtn.type = 'button';
     closeBtn.setAttribute('aria-label', 'Close dialog');

--- a/src/components/drawer/drawer.ts
+++ b/src/components/drawer/drawer.ts
@@ -175,10 +175,12 @@ export class ElxDrawer extends HTMLElement {
     style.textContent = styles;
 
     const backdrop = document.createElement('div');
+    backdrop.setAttribute('part', 'overlay');
     backdrop.className = 'backdrop';
     backdrop.addEventListener('click', () => this.close());
 
     const drawer = document.createElement('div');
+    drawer.setAttribute('part', 'drawer');
     drawer.className = 'drawer';
     drawer.setAttribute('role', 'dialog');
     drawer.setAttribute('aria-modal', 'true');
@@ -193,6 +195,7 @@ export class ElxDrawer extends HTMLElement {
     title.appendChild(titleSlot);
 
     this._closeButton = document.createElement('button');
+    this._closeButton.setAttribute('part', 'close-button');
     this._closeButton.className = 'close-button';
     this._closeButton.setAttribute('aria-label', 'Close drawer');
     this._closeButton.innerHTML = `

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -186,12 +186,14 @@ export class ElxDropdown extends HTMLElement {
     `;
 
     const trigger = document.createElement('div');
+    trigger.setAttribute('part', 'trigger');
     trigger.className = 'trigger';
     const triggerSlot = document.createElement('slot');
     triggerSlot.name = 'trigger';
     trigger.appendChild(triggerSlot);
 
     const menu = document.createElement('div');
+    menu.setAttribute('part', 'menu');
     menu.className = 'menu';
     menu.setAttribute('role', 'menu');
     menu.setAttribute('aria-orientation', 'vertical');

--- a/src/components/file-upload/file-upload.ts
+++ b/src/components/file-upload/file-upload.ts
@@ -197,7 +197,7 @@ export class ElxFileUpload extends HTMLElement {
   private _render() {
     this.shadowRoot!.innerHTML = `
       <style>${fileUploadStyles}</style>
-      <div class="dropzone" role="button" tabindex="0" aria-label="Upload files">
+      <div class="dropzone" role="button" tabindex="0" aria-label="Upload files" part="dropzone">
         <span class="icon" aria-hidden="true">📁</span>
         <span class="label"><slot>Drop files here or click to browse</slot></span>
         <span class="hint"></span>

--- a/src/components/form-field/form-field.ts
+++ b/src/components/form-field/form-field.ts
@@ -140,6 +140,7 @@ export class ElxFormField extends HTMLElement {
     `;
 
     const wrapper = document.createElement('div');
+    wrapper.setAttribute('part', 'wrapper');
     wrapper.className = 'form-field';
     wrapper.setAttribute('role', 'group');
 
@@ -149,6 +150,7 @@ export class ElxFormField extends HTMLElement {
     // Use span instead of label — <label for> can't cross shadow DOM boundary.
     // Association is done via aria-labelledby in _handleSlotChange.
     const labelSpan = document.createElement('span');
+    labelSpan.setAttribute('part', 'label');
     labelSpan.className = 'label-text';
     labelSpan.id = labelId;
 
@@ -163,11 +165,13 @@ export class ElxFormField extends HTMLElement {
     const slot = document.createElement('slot');
 
     const helper = document.createElement('div');
+    helper.setAttribute('part', 'helper');
     helper.className = 'helper-text';
     helper.id = `${this._uniqueId}-helper`;
     helper.setAttribute('role', 'note');
 
     const error = document.createElement('div');
+    error.setAttribute('part', 'error');
     error.className = 'error-text';
     error.id = `${this._uniqueId}-error`;
     error.setAttribute('role', 'alert');

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -151,10 +151,12 @@ export class ElxInput extends HTMLElement {
     wrapper.className = 'input-wrapper';
 
     this._label = document.createElement('label');
+    this._label.setAttribute('part', 'label');
     this._label.style.display = 'none';
     this._label.htmlFor = this._inputId;
 
     this._input = document.createElement('input');
+    this._input.setAttribute('part', 'input');
     this._input.id = this._inputId;
 
     wrapper.appendChild(this._label);

--- a/src/components/label/label.ts
+++ b/src/components/label/label.ts
@@ -96,6 +96,7 @@ export class ElxLabel extends HTMLElement {
     // to properly cross the shadow DOM boundary
 
     const textSpan = document.createElement('span');
+    textSpan.setAttribute('part', 'label');
     textSpan.className = 'label-text';
 
     const slot = document.createElement('slot');

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -131,7 +131,7 @@ export class ElxMenu extends HTMLElement {
   private _render() {
     this.shadowRoot!.innerHTML = `
       <style>${menuStyles}</style>
-      <div class="menu" role="menu" tabindex="-1">
+      <div class="menu" role="menu" tabindex="-1" part="menu">
         <slot></slot>
       </div>
     `;

--- a/src/components/pagination/pagination.ts
+++ b/src/components/pagination/pagination.ts
@@ -103,6 +103,7 @@ export class ElxPagination extends HTMLElement {
     `;
 
     const nav = document.createElement('nav');
+    nav.setAttribute('part', 'nav');
     nav.setAttribute('aria-label', 'Pagination');
 
     this.shadowRoot!.appendChild(style);

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -161,12 +161,14 @@ export class ElxPopover extends HTMLElement {
     `;
 
     const trigger = document.createElement('div');
+    trigger.setAttribute('part', 'trigger');
     trigger.className = 'trigger';
     const triggerSlot = document.createElement('slot');
     triggerSlot.name = 'trigger';
     trigger.appendChild(triggerSlot);
 
     const content = document.createElement('div');
+    content.setAttribute('part', 'content');
     content.className = 'content';
     content.id = this._contentId;
     content.setAttribute('tabindex', '-1');

--- a/src/components/progress/progress.ts
+++ b/src/components/progress/progress.ts
@@ -101,9 +101,11 @@ export class ElxProgress extends HTMLElement {
     labelDiv.appendChild(labelPercent);
 
     const track = document.createElement('div');
+    track.setAttribute('part', 'track');
     track.className = 'progress';
     track.setAttribute('role', 'progressbar');
     const bar = document.createElement('div');
+    bar.setAttribute('part', 'bar');
     bar.className = 'bar';
     track.appendChild(bar);
 

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -140,9 +140,11 @@ export class ElxRadio extends HTMLElement {
     `;
 
     this._labelEl = document.createElement('label');
+    this._labelEl.setAttribute('part', 'label');
     this._labelEl.htmlFor = this._id;
 
     this._input = document.createElement('input');
+    this._input.setAttribute('part', 'input');
     this._input.type = 'radio';
     this._input.id = this._id;
 

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -186,6 +186,7 @@ export class ElxSelect extends HTMLElement {
     `;
 
     this._button = document.createElement('button');
+    this._button.setAttribute('part', 'trigger');
     this._button.type = 'button';
     this._button.className = 'trigger';
     this._button.setAttribute('role', 'combobox');
@@ -215,6 +216,7 @@ export class ElxSelect extends HTMLElement {
     this._button.appendChild(arrow);
 
     this._listbox = document.createElement('div');
+    this._listbox.setAttribute('part', 'listbox');
     this._listbox.className = 'listbox';
     this._listbox.setAttribute('role', 'listbox');
     this._listbox.setAttribute('id', this._id);

--- a/src/components/separator/separator.ts
+++ b/src/components/separator/separator.ts
@@ -58,6 +58,7 @@ export class ElxSeparator extends HTMLElement {
     `;
 
     const separator = document.createElement('div');
+    separator.setAttribute('part', 'separator');
     separator.className = `separator ${this.orientation}`;
     separator.setAttribute('role', 'separator');
     separator.setAttribute('aria-orientation', this.orientation);

--- a/src/components/skeleton/skeleton.ts
+++ b/src/components/skeleton/skeleton.ts
@@ -135,7 +135,7 @@ export class ElxSkeleton extends HTMLElement {
 
     this.shadowRoot!.innerHTML = `
       <style>${skeletonStyles}</style>
-      <div class="skeleton" style="${width ? `width:${width};` : ''}${height ? `height:${height};` : ''}" aria-hidden="true"></div>
+      <div class="skeleton" style="${width ? `width:${width};` : ''}${height ? `height:${height};` : ''}" aria-hidden="true" part="skeleton"></div>
     `;
   }
 }

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -172,6 +172,7 @@ export class ElxSlider extends HTMLElement {
     labelDiv.appendChild(labelValue);
 
     const track = document.createElement('div');
+    track.setAttribute('part', 'track');
     track.className = 'slider-track';
 
     const trackBg = document.createElement('div');
@@ -181,6 +182,7 @@ export class ElxSlider extends HTMLElement {
     trackFill.className = 'track-fill';
 
     const input = document.createElement('input');
+    input.setAttribute('part', 'input');
     input.type = 'range';
 
     track.appendChild(trackBg);

--- a/src/components/stepper/stepper.ts
+++ b/src/components/stepper/stepper.ts
@@ -226,7 +226,7 @@ export class ElxStepper extends HTMLElement {
   private _render() {
     this.shadowRoot!.innerHTML = `
       <style>${stepperStyles}</style>
-      <div class="stepper" role="list" aria-label="Progress steps">
+      <div class="stepper" role="list" aria-label="Progress steps" part="stepper">
         <slot></slot>
       </div>
     `;

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -141,14 +141,17 @@ export class ElxSwitch extends HTMLElement {
     `;
 
     this._labelEl = document.createElement('label');
+    this._labelEl.setAttribute('part', 'label');
     this._labelEl.htmlFor = this._id;
 
     this._input = document.createElement('input');
+    this._input.setAttribute('part', 'input');
     this._input.type = 'checkbox';
     this._input.id = this._id;
     this._input.setAttribute('role', 'switch');
 
     this._track = document.createElement('span');
+    this._track.setAttribute('part', 'track');
     this._track.className = 'track';
 
     this._thumb = document.createElement('span');

--- a/src/components/table/table.ts
+++ b/src/components/table/table.ts
@@ -90,6 +90,7 @@ export class ElxTable extends HTMLElement {
     `;
 
     this._table = document.createElement('table');
+    this._table.setAttribute('part', 'table');
     this._table.setAttribute('role', 'table');
 
     const slot = document.createElement('slot');

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -36,6 +36,7 @@ export class ElxTabPanel extends HTMLElement {
       .panel { padding: 16px 0; }
     `;
     const div = document.createElement('div');
+    div.setAttribute('part', 'panel');
     div.className = 'panel';
     div.setAttribute('role', 'tabpanel');
     const slot = document.createElement('slot');
@@ -118,6 +119,7 @@ export class ElxTabs extends HTMLElement {
     `;
 
     this._tabList = document.createElement('div');
+    this._tabList.setAttribute('part', 'tablist');
     this._tabList.className = 'tab-list';
     this._tabList.setAttribute('role', 'tablist');
     this._tabList.addEventListener('keydown', this._onKeydown);
@@ -147,6 +149,7 @@ export class ElxTabs extends HTMLElement {
       const isActive = name === currentValue;
 
       const btn = document.createElement('button');
+      btn.setAttribute('part', 'tab');
       btn.className = 'tab';
       btn.type = 'button';
       btn.setAttribute('role', 'tab');

--- a/src/components/text/text.ts
+++ b/src/components/text/text.ts
@@ -115,6 +115,7 @@ export class ElxText extends HTMLElement {
     `;
 
     this._element = document.createElement(this.as);
+    this._element.setAttribute('part', 'text');
     this._element.appendChild(document.createElement('slot'));
 
     this.shadowRoot!.appendChild(style);
@@ -127,6 +128,7 @@ export class ElxText extends HTMLElement {
     // Update tag if 'as' changed
     if (this._element.tagName.toLowerCase() !== this.as) {
       const newElement = document.createElement(this.as);
+      newElement.setAttribute('part', 'text');
       newElement.appendChild(document.createElement('slot'));
       this._element.replaceWith(newElement);
       this._element = newElement;

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -139,6 +139,7 @@ export class ElxToast extends HTMLElement {
     `;
 
     const container = document.createElement('div');
+    container.setAttribute('part', 'toast');
     container.className = 'toast';
     container.setAttribute('role', 'alert');
     container.setAttribute('aria-atomic', 'true');
@@ -152,6 +153,7 @@ export class ElxToast extends HTMLElement {
     content.appendChild(slot);
 
     const closeBtn = document.createElement('button');
+    closeBtn.setAttribute('part', 'close-button');
     closeBtn.type = 'button';
     closeBtn.className = 'close-btn';
     closeBtn.setAttribute('aria-label', 'Close');

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -132,6 +132,7 @@ export class ElxTooltip extends HTMLElement {
     `;
 
     this._tooltip = document.createElement('div');
+    this._tooltip.setAttribute('part', 'tooltip');
     this._tooltip.className = 'tooltip';
     this._tooltip.setAttribute('role', 'tooltip');
     this._tooltip.setAttribute('aria-hidden', 'true');
@@ -142,6 +143,7 @@ export class ElxTooltip extends HTMLElement {
     this._tooltip.id = `tooltip-${Math.random().toString(36).substring(2, 9)}`;
 
     const slot = document.createElement('slot');
+    slot.setAttribute('part', 'trigger');
 
     this.shadowRoot!.appendChild(style);
     this.shadowRoot!.appendChild(this._tooltip);


### PR DESCRIPTION
## Changes
Exposes shadow DOM elements for external styling via `::part()` selectors across all 32 components.

### Parts exposed per component:
- **button**: `button`
- **input**: `input`, `label`
- **checkbox**: `input`, `label`, `checkmark`
- **switch**: `input`, `label`, `track`
- **radio**: `input`, `label`
- **badge**: `badge`
- **avatar**: `image`, `fallback`
- **card**: `card`
- **alert**: `alert`, `icon`, `close-button`
- **dialog**: `overlay`, `dialog`, `close-button`
- **tabs**: `tablist`, `tab`, `panel`
- **tooltip**: `trigger`, `tooltip`
- **select**: `trigger`, `listbox`
- **separator**: `separator`
- **accordion**: `trigger`, `panel`, `icon`
- **text**: `text`
- **breadcrumb**: `nav`, `list`
- **dropdown**: `trigger`, `menu`
- **popover**: `trigger`, `content`
- **progress**: `track`, `bar`
- **table**: `table`
- **toast**: `toast`, `close-button`
- **pagination**: `nav`
- **drawer**: `overlay`, `drawer`, `close-button`
- **menu**: `menu`
- **skeleton**: `skeleton`
- **calendar**: `calendar`, `header`, `grid`
- **stepper**: `stepper`
- **file-upload**: `dropzone`
- **slider**: `track`, `input`
- **label**: `label`
- **form-field**: `wrapper`, `label`, `helper`, `error`

All 563 tests pass.

Closes #60