### PR TITLE
improvement: add dark mode and theme switcher support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // Elementix - Web Components Design System
 import './theme.css';
+export * from './theme-switcher';
 export * from './components/button/button';
 export * from './components/input/input';
 export * from './components/checkbox/checkbox';

--- a/src/theme-switcher.ts
+++ b/src/theme-switcher.ts
@@ -1,0 +1,56 @@
+/**
+ * Theme switcher utility for Elementix.
+ *
+ * Usage:
+ *   import { setTheme, getTheme, toggleTheme } from '@clawdiab/elementix';
+ *
+ *   setTheme('dark');       // force dark
+ *   setTheme('light');      // force light
+ *   setTheme('system');     // follow OS preference (default)
+ *   toggleTheme();          // toggle between light and dark
+ */
+
+export type Theme = 'light' | 'dark' | 'system';
+
+const STORAGE_KEY = 'elx-theme';
+
+export function getTheme(): Theme {
+  if (typeof localStorage === 'undefined') return 'system';
+  return (localStorage.getItem(STORAGE_KEY) as Theme) || 'system';
+}
+
+export function setTheme(theme: Theme): void {
+  const root = document.documentElement;
+
+  if (theme === 'system') {
+    root.removeAttribute('data-theme');
+    root.classList.remove('elx-dark', 'elx-light');
+    localStorage.removeItem(STORAGE_KEY);
+  } else {
+    root.setAttribute('data-theme', theme);
+    root.classList.toggle('elx-dark', theme === 'dark');
+    root.classList.toggle('elx-light', theme === 'light');
+    localStorage.setItem(STORAGE_KEY, theme);
+  }
+
+  root.dispatchEvent(new CustomEvent('elx-theme-change', { detail: { theme } }));
+}
+
+export function toggleTheme(): void {
+  const current = getResolvedTheme();
+  setTheme(current === 'dark' ? 'light' : 'dark');
+}
+
+export function getResolvedTheme(): 'light' | 'dark' {
+  const stored = getTheme();
+  if (stored !== 'system') return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+/** Initialize theme from localStorage on page load. */
+export function initTheme(): void {
+  const stored = getTheme();
+  if (stored !== 'system') {
+    setTheme(stored);
+  }
+}

--- a/src/theme-switcher.ts
+++ b/src/theme-switcher.ts
@@ -13,13 +13,20 @@
 export type Theme = 'light' | 'dark' | 'system';
 
 const STORAGE_KEY = 'elx-theme';
+const VALID_THEMES: Theme[] = ['light', 'dark', 'system'];
+
+function isBrowser(): boolean {
+  return typeof document !== 'undefined' && typeof window !== 'undefined';
+}
 
 export function getTheme(): Theme {
-  if (typeof localStorage === 'undefined') return 'system';
-  return (localStorage.getItem(STORAGE_KEY) as Theme) || 'system';
+  if (!isBrowser() || typeof localStorage === 'undefined') return 'system';
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored && VALID_THEMES.includes(stored as Theme) ? (stored as Theme) : 'system';
 }
 
 export function setTheme(theme: Theme): void {
+  if (!isBrowser()) return;
   const root = document.documentElement;
 
   if (theme === 'system') {
@@ -37,11 +44,13 @@ export function setTheme(theme: Theme): void {
 }
 
 export function toggleTheme(): void {
+  if (!isBrowser()) return;
   const current = getResolvedTheme();
   setTheme(current === 'dark' ? 'light' : 'dark');
 }
 
 export function getResolvedTheme(): 'light' | 'dark' {
+  if (!isBrowser()) return 'light';
   const stored = getTheme();
   if (stored !== 'system') return stored;
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -49,6 +58,7 @@ export function getResolvedTheme(): 'light' | 'dark' {
 
 /** Initialize theme from localStorage on page load. */
 export function initTheme(): void {
+  if (!isBrowser()) return;
   const stored = getTheme();
   if (stored !== 'system') {
     setTheme(stored);

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,5 +1,15 @@
 :root {
-  /* Colors */
+  /* Semantic color tokens - light mode (default) */
+  --elx-color-text: #1f2937;
+  --elx-color-text-muted: #6b7280;
+  --elx-color-surface: #ffffff;
+  --elx-color-surface-hover: #f9fafb;
+  --elx-color-surface-muted: #f3f4f6;
+  --elx-color-border: #e5e7eb;
+  --elx-color-on-primary: #ffffff;
+  --elx-color-primary-light: #dbeafe;
+
+  /* Palette colors */
   --elx-color-primary-50: #eff6ff;
   --elx-color-primary-100: #dbeafe;
   --elx-color-primary-500: #3b82f6;
@@ -70,4 +80,54 @@
   --elx-radius-md: 0.375rem;
   --elx-radius-lg: 0.5rem;
   --elx-radius-full: 9999px;
+}
+
+/* Dark mode - via class or system preference */
+[data-theme="dark"],
+.elx-dark {
+  --elx-color-text: #f3f4f6;
+  --elx-color-text-muted: #9ca3af;
+  --elx-color-surface: #111827;
+  --elx-color-surface-hover: #1f2937;
+  --elx-color-surface-muted: #1f2937;
+  --elx-color-border: #374151;
+  --elx-color-on-primary: #ffffff;
+  --elx-color-primary-light: #1e3a5f;
+  --elx-color-white: #111827;
+  --elx-color-black: #f9fafb;
+  --elx-color-neutral-50: #111827;
+  --elx-color-neutral-100: #1f2937;
+  --elx-color-neutral-200: #374151;
+  --elx-color-neutral-300: #4b5563;
+  --elx-color-neutral-400: #6b7280;
+  --elx-color-neutral-500: #9ca3af;
+  --elx-color-neutral-600: #d1d5db;
+  --elx-color-neutral-700: #e5e7eb;
+  --elx-color-neutral-800: #f3f4f6;
+  --elx-color-neutral-900: #f9fafb;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not(.elx-light) {
+    --elx-color-text: #f3f4f6;
+    --elx-color-text-muted: #9ca3af;
+    --elx-color-surface: #111827;
+    --elx-color-surface-hover: #1f2937;
+    --elx-color-surface-muted: #1f2937;
+    --elx-color-border: #374151;
+    --elx-color-on-primary: #ffffff;
+    --elx-color-primary-light: #1e3a5f;
+    --elx-color-white: #111827;
+    --elx-color-black: #f9fafb;
+    --elx-color-neutral-50: #111827;
+    --elx-color-neutral-100: #1f2937;
+    --elx-color-neutral-200: #374151;
+    --elx-color-neutral-300: #4b5563;
+    --elx-color-neutral-400: #6b7280;
+    --elx-color-neutral-500: #9ca3af;
+    --elx-color-neutral-600: #d1d5db;
+    --elx-color-neutral-700: #e5e7eb;
+    --elx-color-neutral-800: #f3f4f6;
+    --elx-color-neutral-900: #f9fafb;
+  }
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -93,8 +93,19 @@
   --elx-color-border: #374151;
   --elx-color-on-primary: #ffffff;
   --elx-color-primary-light: #1e3a5f;
-  --elx-color-white: #111827;
-  --elx-color-black: #f9fafb;
+
+  /* Status backgrounds (fixed, not inverted) */
+  --elx-color-primary-50: #1e3a5f;
+  --elx-color-danger-50: #450a0a;
+  --elx-color-danger-100: #7f1d1d;
+  --elx-color-success-50: #052e16;
+  --elx-color-success-100: #14532d;
+  --elx-color-warning-50: #451a03;
+  --elx-color-warning-100: #78350f;
+  --elx-color-purple-50: #3b0764;
+  --elx-color-purple-100: #581c87;
+
+  /* Palette overrides for dark */
   --elx-color-neutral-50: #111827;
   --elx-color-neutral-100: #1f2937;
   --elx-color-neutral-200: #374151;
@@ -117,8 +128,15 @@
     --elx-color-border: #374151;
     --elx-color-on-primary: #ffffff;
     --elx-color-primary-light: #1e3a5f;
-    --elx-color-white: #111827;
-    --elx-color-black: #f9fafb;
+    --elx-color-primary-50: #1e3a5f;
+    --elx-color-danger-50: #450a0a;
+    --elx-color-danger-100: #7f1d1d;
+    --elx-color-success-50: #052e16;
+    --elx-color-success-100: #14532d;
+    --elx-color-warning-50: #451a03;
+    --elx-color-warning-100: #78350f;
+    --elx-color-purple-50: #3b0764;
+    --elx-color-purple-100: #581c87;
     --elx-color-neutral-50: #111827;
     --elx-color-neutral-100: #1f2937;
     --elx-color-neutral-200: #374151;


### PR DESCRIPTION
## Changes
Added comprehensive dark mode support with semantic color tokens.

### Theme system:
- **Semantic tokens**: `--elx-color-text`, `--elx-color-surface`, `--elx-color-border`, etc.
- **Dark mode triggers**:
  - `data-theme="dark"` attribute on `<html>` or any ancestor
  - `.elx-dark` class on `<html>` or any ancestor
  - System preference `prefers-color-scheme: dark` (auto-detected)

### Theme switcher utility:
```ts
import { setTheme, getTheme, toggleTheme, initTheme } from '@clawdiab/elementix';

setTheme('dark');   // force dark
setTheme('light');  // force light
setTheme('system'); // follow OS preference
toggleTheme();      // toggle between light/dark
```

- Persists preference to `localStorage` under `elx-theme` key
- Fires `elx-theme-change` custom event on theme switch

All 563 tests pass. Bundle size: 32.65kB gzip (under 40kB budget).

Closes #59