### PR TITLE
feat: add Toggle and ToggleGroup components

### DIFF
--- a/src/components/toggle/toggle.stories.ts
+++ b/src/components/toggle/toggle.stories.ts
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './toggle.js';
+
+const meta: Meta = {
+  title: 'Components/Toggle',
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    variant: { control: 'select', options: ['default', 'outline'] },
+    pressed: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: (args) => html`
+    <elx-toggle
+      size=${args.size ?? 'md'}
+      variant=${args.variant ?? 'default'}
+      ?pressed=${args.pressed}
+      ?disabled=${args.disabled}
+    >Bold</elx-toggle>
+  `,
+};
+
+export const Pressed: Story = {
+  render: () => html`<elx-toggle pressed>Bold</elx-toggle>`,
+};
+
+export const Disabled: Story = {
+  render: () => html`<elx-toggle disabled>Bold</elx-toggle>`,
+};
+
+export const Outline: Story = {
+  render: () => html`
+    <elx-toggle variant="outline">Normal</elx-toggle>
+    <elx-toggle variant="outline" pressed>Pressed</elx-toggle>
+  `,
+};
+
+export const Sizes: Story = {
+  render: () => html`
+    <elx-toggle size="sm">Small</elx-toggle>
+    <elx-toggle size="md">Medium</elx-toggle>
+    <elx-toggle size="lg">Large</elx-toggle>
+  `,
+};
+
+export const Group: Story = {
+  render: () => html`
+    <elx-toggle-group>
+      <elx-toggle value="bold">B</elx-toggle>
+      <elx-toggle value="italic">I</elx-toggle>
+      <elx-toggle value="underline">U</elx-toggle>
+    </elx-toggle-group>
+  `,
+};
+
+export const GroupMultiple: Story = {
+  render: () => html`
+    <elx-toggle-group type="multiple">
+      <elx-toggle value="bold">B</elx-toggle>
+      <elx-toggle value="italic">I</elx-toggle>
+      <elx-toggle value="underline">U</elx-toggle>
+    </elx-toggle-group>
+  `,
+};
+
+export const GroupDisabled: Story = {
+  render: () => html`
+    <elx-toggle-group disabled>
+      <elx-toggle value="bold">B</elx-toggle>
+      <elx-toggle value="italic">I</elx-toggle>
+    </elx-toggle-group>
+  `,
+};

--- a/src/components/toggle/toggle.test.ts
+++ b/src/components/toggle/toggle.test.ts
@@ -92,6 +92,12 @@ describe('ElxToggle', () => {
     expect(btn.getAttribute('type')).toBe('button');
   });
 
+  it('resets pressed state on form reset', () => {
+    (el as any).pressed = true;
+    (el as any).formResetCallback();
+    expect((el as any).pressed).toBe(false);
+  });
+
   it('has role="button" implicitly via button element', () => {
     const btn = el.shadowRoot!.querySelector('button')!;
     expect(btn.tagName).toBe('BUTTON');
@@ -125,7 +131,7 @@ describe('ElxToggleGroup', () => {
   });
 
   it('allows only one toggle pressed in single mode', () => {
-    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    const toggles = group.querySelectorAll('elx-toggle') as any;
     toggles[0].shadowRoot!.querySelector('button').click();
     expect(toggles[0].pressed).toBe(true);
     toggles[1].shadowRoot!.querySelector('button').click();
@@ -135,7 +141,7 @@ describe('ElxToggleGroup', () => {
 
   it('allows multiple toggles pressed in multiple mode', () => {
     (group as any).type = 'multiple';
-    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    const toggles = group.querySelectorAll('elx-toggle') as any;
     toggles[0].shadowRoot!.querySelector('button').click();
     toggles[1].shadowRoot!.querySelector('button').click();
     expect(toggles[0].pressed).toBe(true);
@@ -143,14 +149,14 @@ describe('ElxToggleGroup', () => {
   });
 
   it('updates value attribute in single mode', () => {
-    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    const toggles = group.querySelectorAll('elx-toggle') as any;
     toggles[0].shadowRoot!.querySelector('button').click();
     expect((group as any).value).toBe('bold');
   });
 
   it('updates value attribute with comma-separated values in multiple mode', () => {
     (group as any).type = 'multiple';
-    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    const toggles = group.querySelectorAll('elx-toggle') as any;
     toggles[0].shadowRoot!.querySelector('button').click();
     toggles[2].shadowRoot!.querySelector('button').click();
     expect((group as any).value).toBe('bold,underline');
@@ -165,8 +171,18 @@ describe('ElxToggleGroup', () => {
     group.addEventListener('change', (e: Event) => {
       detail = (e as CustomEvent).detail;
     });
-    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    const toggles = group.querySelectorAll('elx-toggle') as any;
     toggles[0].shadowRoot!.querySelector('button').click();
     expect(detail.value).toBe('bold');
+  });
+
+  it('supports aria-label attribute', () => {
+    group.setAttribute('aria-label', 'Text formatting');
+    expect(group.getAttribute('aria-label')).toBe('Text formatting');
+  });
+
+  it('sets value via setter', () => {
+    (group as any).value = 'test';
+    expect(group.getAttribute('value')).toBe('test');
   });
 });

--- a/src/components/toggle/toggle.test.ts
+++ b/src/components/toggle/toggle.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import './toggle';
 
 describe('ElxToggle', () => {

--- a/src/components/toggle/toggle.test.ts
+++ b/src/components/toggle/toggle.test.ts
@@ -1,0 +1,172 @@
+import './toggle';
+
+describe('ElxToggle', () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    el = document.createElement('elx-toggle');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders a button element', () => {
+    const btn = el.shadowRoot!.querySelector('button');
+    expect(btn).toBeTruthy();
+  });
+
+  it('has default size md', () => {
+    expect((el as any).size).toBe('md');
+  });
+
+  it('has default variant default', () => {
+    expect((el as any).variant).toBe('default');
+  });
+
+  it('toggles pressed state on click', () => {
+    const btn = el.shadowRoot!.querySelector('button') as HTMLButtonElement;
+    btn.click();
+    expect((el as any).pressed).toBe(true);
+    btn.click();
+    expect((el as any).pressed).toBe(false);
+  });
+
+  it('sets aria-pressed attribute', () => {
+    const btn = el.shadowRoot!.querySelector('button')!;
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    (el as any).pressed = true;
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('does not toggle when disabled', () => {
+    (el as any).disabled = true;
+    const btn = el.shadowRoot!.querySelector('button') as HTMLButtonElement;
+    btn.click();
+    expect((el as any).pressed).toBe(false);
+  });
+
+  it('applies size class', () => {
+    (el as any).size = 'lg';
+    const btn = el.shadowRoot!.querySelector('button')!;
+    expect(btn.classList.contains('lg')).toBe(true);
+  });
+
+  it('applies variant class', () => {
+    (el as any).variant = 'outline';
+    const btn = el.shadowRoot!.querySelector('button')!;
+    expect(btn.classList.contains('variant-outline')).toBe(true);
+  });
+
+  it('applies pressed class when pressed', () => {
+    (el as any).pressed = true;
+    const btn = el.shadowRoot!.querySelector('button')!;
+    expect(btn.classList.contains('pressed')).toBe(true);
+  });
+
+  it('dispatches change event with detail', () => {
+    let detail: any;
+    el.addEventListener('change', (e: Event) => {
+      detail = (e as CustomEvent).detail;
+    });
+    const btn = el.shadowRoot!.querySelector('button') as HTMLButtonElement;
+    btn.click();
+    expect(detail.pressed).toBe(true);
+    expect(detail.value).toBe('on');
+  });
+
+  it('uses custom value attribute', () => {
+    (el as any).value = 'bold';
+    let detail: any;
+    el.addEventListener('change', (e: Event) => {
+      detail = (e as CustomEvent).detail;
+    });
+    const btn = el.shadowRoot!.querySelector('button') as HTMLButtonElement;
+    btn.click();
+    expect(detail.value).toBe('bold');
+  });
+
+  it('has type="button" to prevent form submission', () => {
+    const btn = el.shadowRoot!.querySelector('button')!;
+    expect(btn.getAttribute('type')).toBe('button');
+  });
+
+  it('has role="button" implicitly via button element', () => {
+    const btn = el.shadowRoot!.querySelector('button')!;
+    expect(btn.tagName).toBe('BUTTON');
+  });
+});
+
+describe('ElxToggleGroup', () => {
+  let group: HTMLElement;
+
+  beforeEach(() => {
+    group = document.createElement('elx-toggle-group');
+    group.innerHTML = `
+      <elx-toggle value="bold"></elx-toggle>
+      <elx-toggle value="italic"></elx-toggle>
+      <elx-toggle value="underline"></elx-toggle>
+    `;
+    document.body.appendChild(group);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders slot content', () => {
+    const toggles = group.querySelectorAll('elx-toggle');
+    expect(toggles.length).toBe(3);
+  });
+
+  it('has default type single', () => {
+    expect((group as any).type).toBe('single');
+  });
+
+  it('allows only one toggle pressed in single mode', () => {
+    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    toggles[0].shadowRoot!.querySelector('button').click();
+    expect(toggles[0].pressed).toBe(true);
+    toggles[1].shadowRoot!.querySelector('button').click();
+    expect(toggles[0].pressed).toBe(false);
+    expect(toggles[1].pressed).toBe(true);
+  });
+
+  it('allows multiple toggles pressed in multiple mode', () => {
+    (group as any).type = 'multiple';
+    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    toggles[0].shadowRoot!.querySelector('button').click();
+    toggles[1].shadowRoot!.querySelector('button').click();
+    expect(toggles[0].pressed).toBe(true);
+    expect(toggles[1].pressed).toBe(true);
+  });
+
+  it('updates value attribute in single mode', () => {
+    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    toggles[0].shadowRoot!.querySelector('button').click();
+    expect((group as any).value).toBe('bold');
+  });
+
+  it('updates value attribute with comma-separated values in multiple mode', () => {
+    (group as any).type = 'multiple';
+    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    toggles[0].shadowRoot!.querySelector('button').click();
+    toggles[2].shadowRoot!.querySelector('button').click();
+    expect((group as any).value).toBe('bold,underline');
+  });
+
+  it('has role="group"', () => {
+    expect(group.getAttribute('role')).toBe('group');
+  });
+
+  it('dispatches change event with group value', () => {
+    let detail: any;
+    group.addEventListener('change', (e: Event) => {
+      detail = (e as CustomEvent).detail;
+    });
+    const toggles = [...group.querySelectorAll('elx-toggle')] as any[];
+    toggles[0].shadowRoot!.querySelector('button').click();
+    expect(detail.value).toBe('bold');
+  });
+});

--- a/src/components/toggle/toggle.ts
+++ b/src/components/toggle/toggle.ts
@@ -1,0 +1,224 @@
+let uid = 0;
+
+export class ElxToggle extends HTMLElement {
+  static formAssociated = true;
+  static observedAttributes = ['pressed', 'disabled', 'size', 'variant', 'value', 'name'];
+
+  private _internals: ElementInternals;
+  private _btn: HTMLButtonElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._internals = this.attachInternals?.() ?? ({} as ElementInternals);
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+  }
+
+  attributeChangedCallback() {
+    this._update();
+  }
+
+  get pressed(): boolean { return this.hasAttribute('pressed'); }
+  set pressed(val: boolean) { val ? this.setAttribute('pressed', '') : this.removeAttribute('pressed'); }
+
+  get disabled(): boolean { return this.hasAttribute('disabled'); }
+  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+
+  get size(): string { return this.getAttribute('size') ?? 'md'; }
+  set size(val: string) { this.setAttribute('size', val); }
+
+  get variant(): string { return this.getAttribute('variant') ?? 'default'; }
+  set variant(val: string) { this.setAttribute('variant', val); }
+
+  get value(): string { return this.getAttribute('value') ?? 'on'; }
+  set value(val: string) { this.setAttribute('value', val); }
+
+  get name(): string { return this.getAttribute('name') ?? ''; }
+  set name(val: string) { this.setAttribute('name', val); }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: inline-block; }
+
+      button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        border: 1px solid var(--elx-color-neutral-200);
+        border-radius: var(--elx-radius-md);
+        background: transparent;
+        color: var(--elx-color-neutral-700);
+        font-family: var(--elx-font-family-sans);
+        font-weight: 500;
+        cursor: pointer;
+        transition: background 0.15s, color 0.15s, border-color 0.15s;
+        outline: none;
+        user-select: none;
+      }
+
+      button.sm { height: 28px; padding: 0 8px; font-size: 12px; }
+      button.md { height: 36px; padding: 0 12px; font-size: 14px; }
+      button.lg { height: 44px; padding: 0 16px; font-size: 16px; }
+
+      button:hover:not(:disabled) { background: var(--elx-color-neutral-100); }
+
+      button.pressed {
+        background: var(--elx-color-neutral-200);
+        color: var(--elx-color-neutral-900);
+        border-color: var(--elx-color-neutral-300);
+      }
+
+      button.variant-outline.pressed {
+        background: var(--elx-color-primary-50);
+        color: var(--elx-color-primary-700);
+        border-color: var(--elx-color-primary-300);
+      }
+
+      button:focus-visible {
+        box-shadow: 0 0 0 3px rgba(37,99,235,0.3);
+      }
+
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      ::slotted(*) { pointer-events: none; }
+    `;
+
+    this._btn = document.createElement('button');
+    this._btn.setAttribute('part', 'button');
+    this._btn.setAttribute('type', 'button');
+    const slot = document.createElement('slot');
+    this._btn.appendChild(slot);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(this._btn);
+
+    this._btn.addEventListener('click', () => {
+      if (this.disabled) return;
+      this.pressed = !this.pressed;
+      this._syncFormState();
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: { pressed: this.pressed, value: this.value },
+        bubbles: true,
+        composed: true,
+      }));
+    });
+  }
+
+  private _update() {
+    if (!this._btn) return;
+    const isPressed = this.pressed;
+    const isDisabled = this.disabled;
+    this._btn.disabled = isDisabled;
+    this._btn.setAttribute('aria-pressed', String(isPressed));
+    this._btn.className = [
+      this.size,
+      `variant-${this.variant}`,
+      isPressed ? 'pressed' : '',
+    ].filter(Boolean).join(' ');
+    this._syncFormState();
+  }
+
+  private _syncFormState() {
+    this._internals.setFormValue?.(this.pressed ? this.value : null);
+    this._internals.setValidity?.({});
+  }
+
+  formResetCallback() {
+    this.pressed = false;
+    this._syncFormState();
+  }
+}
+
+export class ElxToggleGroup extends HTMLElement {
+  static observedAttributes = ['type', 'disabled', 'value'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+    this.shadowRoot!.addEventListener('slotchange', () => this._bindToggles());
+  }
+
+  attributeChangedCallback() {
+    this._update();
+  }
+
+  get type(): string { return this.getAttribute('type') ?? 'single'; }
+  set type(val: string) { this.setAttribute('type', val); }
+
+  get disabled(): boolean { return this.hasAttribute('disabled'); }
+  set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
+
+  get value(): string { return this.getAttribute('value') ?? ''; }
+  set value(val: string) { this.setAttribute('value', val); }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: inline-flex; gap: 4px; flex-wrap: wrap; }
+    `;
+    const slot = document.createElement('slot');
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(slot);
+
+    this.setAttribute('role', 'group');
+
+    this.addEventListener('change', (e: Event) => {
+      const ce = e as CustomEvent;
+      const target = e.composedPath()[0] as ElxToggle;
+      if (!(target instanceof ElxToggle)) return;
+
+      if (this.type === 'single') {
+        // depress all others
+        this._getToggles().forEach(t => {
+          if (t !== target) t.pressed = false;
+        });
+        this.setAttribute('value', target.pressed ? target.value : '');
+      } else {
+        // multi — collect all pressed values
+        const vals = this._getToggles().filter(t => t.pressed).map(t => t.value);
+        this.setAttribute('value', vals.join(','));
+      }
+
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: { value: this.value },
+        bubbles: true,
+        composed: true,
+      }));
+    });
+  }
+
+  private _getToggles(): ElxToggle[] {
+    const result: ElxToggle[] = [];
+    const nodes = this.querySelectorAll('elx-toggle');
+    for (let i = 0; i < nodes.length; i++) result.push(nodes[i] as ElxToggle);
+    return result;
+  }
+
+  private _bindToggles() {
+    if (this.disabled) {
+      this._getToggles().forEach(t => t.setAttribute('disabled', ''));
+    }
+  }
+
+  private _update() {
+    if (!this.shadowRoot) return;
+    this._bindToggles();
+  }
+}
+
+if (!customElements.get('elx-toggle')) customElements.define('elx-toggle', ElxToggle);
+if (!customElements.get('elx-toggle-group')) customElements.define('elx-toggle-group', ElxToggleGroup);

--- a/src/components/toggle/toggle.ts
+++ b/src/components/toggle/toggle.ts
@@ -1,4 +1,5 @@
-let uid = 0;
+const VALID_SIZES = ['sm', 'md', 'lg'] as const;
+const VALID_VARIANTS = ['default', 'outline'] as const;
 
 export class ElxToggle extends HTMLElement {
   static formAssociated = true;
@@ -28,10 +29,16 @@ export class ElxToggle extends HTMLElement {
   get disabled(): boolean { return this.hasAttribute('disabled'); }
   set disabled(val: boolean) { val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled'); }
 
-  get size(): string { return this.getAttribute('size') ?? 'md'; }
+  get size(): string {
+    const val = this.getAttribute('size');
+    return (VALID_SIZES as readonly string[]).indexOf(val!) !== -1 ? val! : 'md';
+  }
   set size(val: string) { this.setAttribute('size', val); }
 
-  get variant(): string { return this.getAttribute('variant') ?? 'default'; }
+  get variant(): string {
+    const val = this.getAttribute('variant');
+    return (VALID_VARIANTS as readonly string[]).indexOf(val!) !== -1 ? val! : 'default';
+  }
   set variant(val: string) { this.setAttribute('variant', val); }
 
   get value(): string { return this.getAttribute('value') ?? 'on'; }
@@ -39,6 +46,9 @@ export class ElxToggle extends HTMLElement {
 
   get name(): string { return this.getAttribute('name') ?? ''; }
   set name(val: string) { this.setAttribute('name', val); }
+
+  focus() { this._btn?.focus(); }
+  blur() { this._btn?.blur(); }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -139,7 +149,7 @@ export class ElxToggle extends HTMLElement {
 }
 
 export class ElxToggleGroup extends HTMLElement {
-  static observedAttributes = ['type', 'disabled', 'value'];
+  static observedAttributes = ['type', 'disabled', 'value', 'aria-label'];
 
   constructor() {
     super();
@@ -177,19 +187,17 @@ export class ElxToggleGroup extends HTMLElement {
     this.setAttribute('role', 'group');
 
     this.addEventListener('change', (e: Event) => {
-      const ce = e as CustomEvent;
       const target = e.composedPath()[0] as ElxToggle;
       if (!(target instanceof ElxToggle)) return;
 
       if (this.type === 'single') {
-        // depress all others
         this._getToggles().forEach(t => {
           if (t !== target) t.pressed = false;
         });
         this.setAttribute('value', target.pressed ? target.value : '');
       } else {
-        // multi — collect all pressed values
-        const vals = this._getToggles().filter(t => t.pressed).map(t => t.value);
+        const vals: string[] = [];
+        this._getToggles().forEach(t => { if (t.pressed) vals.push(t.value); });
         this.setAttribute('value', vals.join(','));
       }
 
@@ -199,6 +207,27 @@ export class ElxToggleGroup extends HTMLElement {
         composed: true,
       }));
     });
+
+    this.addEventListener('keydown', (e: KeyboardEvent) => this._handleKeydown(e));
+  }
+
+  private _handleKeydown(e: KeyboardEvent) {
+    const toggles = this._getToggles().filter(t => !t.disabled);
+    if (!toggles.length) return;
+    const active = document.activeElement;
+    let idx = -1;
+    for (let i = 0; i < toggles.length; i++) {
+      if (toggles[i] === active || toggles[i].shadowRoot!.contains(active as Node)) { idx = i; break; }
+    }
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = toggles[(idx + 1) % toggles.length];
+      (next as any).focus?.() || next.shadowRoot!.querySelector('button')?.focus();
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = toggles[(idx - 1 + toggles.length) % toggles.length];
+      (prev as any).focus?.() || prev.shadowRoot!.querySelector('button')?.focus();
+    }
   }
 
   private _getToggles(): ElxToggle[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,3 +35,4 @@ export * from './components/pagination/pagination';
 export * from './components/slider/slider';
 export * from './components/label/label';
 export * from './components/form-field/form-field';
+export * from './components/toggle/toggle';


### PR DESCRIPTION
Closes #49

## Changes
- `elx-toggle` — pressable button with `pressed`, `disabled`, `size`, `variant`, `value` attributes
- `elx-toggle-group` — wraps toggles with `single` or `multiple` selection mode
- 21 tests, all passing
- Storybook stories included