### PR TITLE
chore: add workflow to auto-request Copilot review on PRs

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,20 @@
+name: Request Copilot Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  request-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request Copilot review
+        run: |
+          gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            -X POST \
+            -f reviewers[]="copilot" \
+            || echo "Copilot reviewer not available"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically requests a Copilot review whenever a PR is opened, reopened, or marked ready for review.