### PR TITLE
feat: add Collapsible component (#50)

### DIFF
--- a/src/components/collapsible/collapsible.stories.ts
+++ b/src/components/collapsible/collapsible.stories.ts
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import './collapsible.js';
+
+const meta: Meta = {
+  title: 'Components/Collapsible',
+  component: 'elx-collapsible',
+  tags: ['autodocs'],
+  argTypes: {
+    open: {
+      control: 'boolean',
+      description: 'Whether the collapsible is expanded',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the collapsible is disabled',
+    },
+    'aria-label': {
+      control: 'text',
+      description: 'Accessible label for the trigger',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => `
+    <elx-collapsible>
+      <span slot="trigger">Click to expand</span>
+      <div slot="content">
+        <p>This is the collapsible content. It can contain any HTML elements.</p>
+        <p>You can add paragraphs, lists, images, or any other content here.</p>
+      </div>
+    </elx-collapsible>
+  `,
+};
+
+export const Open: Story = {
+  render: () => `
+    <elx-collapsible open>
+      <span slot="trigger">Expanded by default</span>
+      <div slot="content">
+        <p>This collapsible starts in the open state.</p>
+      </div>
+    </elx-collapsible>
+  `,
+};
+
+export const Disabled: Story = {
+  render: () => `
+    <elx-collapsible disabled>
+      <span slot="trigger">Cannot expand</span>
+      <div slot="content">
+        <p>This content is not accessible because the collapsible is disabled.</p>
+      </div>
+    </elx-collapsible>
+  `,
+};
+
+export const WithCustomLabel: Story = {
+  render: () => `
+    <elx-collapsible aria-label="Show more details">
+      <span slot="trigger">More Details</span>
+      <div slot="content">
+        <p>Additional information with custom aria-label for accessibility.</p>
+      </div>
+    </elx-collapsible>
+  `,
+};
+
+export const Multiple: Story = {
+  render: () => `
+    <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+      <elx-collapsible>
+        <span slot="trigger">Section 1</span>
+        <div slot="content">
+          <p>Content for section 1.</p>
+        </div>
+      </elx-collapsible>
+      <elx-collapsible>
+        <span slot="trigger">Section 2</span>
+        <div slot="content">
+          <p>Content for section 2.</p>
+        </div>
+      </elx-collapsible>
+      <elx-collapsible>
+        <span slot="trigger">Section 3</span>
+        <div slot="content">
+          <p>Content for section 3.</p>
+        </div>
+      </elx-collapsible>
+    </div>
+  `,
+};
+
+export const RichContent: Story = {
+  render: () => `
+    <elx-collapsible>
+      <span slot="trigger">View Profile</span>
+      <div slot="content">
+        <div style="display: flex; align-items: center; gap: 1rem;">
+          <div style="width: 48px; height: 48px; border-radius: 50%; background: #e2e8f0; display: flex; align-items: center; justify-content: center;">
+            👤
+          </div>
+          <div>
+            <strong>John Doe</strong>
+            <p style="margin: 0; color: #64748b;">Software Engineer</p>
+          </div>
+        </div>
+        <ul style="margin-top: 1rem; padding-left: 1.25rem;">
+          <li>5 years of experience</li>
+          <li>Specializes in frontend development</li>
+          <li>Based in San Francisco</li>
+        </ul>
+      </div>
+    </elx-collapsible>
+  `,
+};
+
+export const CustomStyled: Story = {
+  render: () => `
+    <style>
+      elx-collapsible.custom {
+        --elx-collapsible-trigger-bg: #f1f5f9;
+        --elx-collapsible-trigger-border: 1px solid #94a3b8;
+        --elx-collapsible-trigger-radius: 0.5rem;
+        --elx-collapsible-trigger-hover-bg: #e2e8f0;
+        --elx-collapsible-content-bg: #f8fafc;
+        --elx-collapsible-content-border: 1px solid #94a3b8;
+        --elx-collapsible-content-radius: 0 0 0.5rem 0.5rem;
+      }
+    </style>
+    <elx-collapsible class="custom">
+      <span slot="trigger">Custom Styled Collapsible</span>
+      <div slot="content">
+        <p>This collapsible uses CSS custom properties for styling.</p>
+      </div>
+    </elx-collapsible>
+  `,
+};

--- a/src/components/collapsible/collapsible.test.ts
+++ b/src/components/collapsible/collapsible.test.ts
@@ -102,15 +102,46 @@ describe('ElxCollapsible', () => {
     expect(content.getAttribute('role')).toBe('region');
   });
 
-  it('should have aria-controls on trigger', () => {
+  it('should have aria-controls on trigger pointing to unique content id', () => {
     const trigger = el.shadowRoot!.querySelector('.trigger');
-    expect(trigger.getAttribute('aria-controls')).toBe('content');
+    const content = el.shadowRoot!.querySelector('.content-wrapper');
+    expect(trigger.getAttribute('aria-controls')).toBe(content.id);
+  });
+
+  it('should have aria-labelledby on content pointing to trigger id', () => {
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    const content = el.shadowRoot!.querySelector('.content-wrapper');
+    expect(content.getAttribute('aria-labelledby')).toBe(trigger.id);
   });
 
   it('should forward aria-label to trigger', () => {
     el.setAttribute('aria-label', 'Toggle section');
     const trigger = el.shadowRoot!.querySelector('.trigger');
     expect(trigger.getAttribute('aria-label')).toBe('Toggle section');
+  });
+
+  it('should remove aria-label from trigger when removed from host', () => {
+    el.setAttribute('aria-label', 'Toggle section');
+    el.removeAttribute('aria-label');
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger.hasAttribute('aria-label')).toBe(false);
+  });
+
+  it('should not dispatch event when clicking while disabled', () => {
+    el.disabled = true;
+    let eventFired = false;
+    el.addEventListener('elx-collapsible-toggle', () => { eventFired = true; });
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    trigger.click();
+    expect(eventFired).toBe(false);
+  });
+
+  it('should generate unique IDs for multiple instances', () => {
+    const el2 = document.createElement('elx-collapsible') as any;
+    document.body.appendChild(el2);
+    const id1 = el.shadowRoot!.querySelector('.content-wrapper').id;
+    const id2 = el2.shadowRoot!.querySelector('.content-wrapper').id;
+    expect(id1).not.toBe(id2);
   });
 
   it('should toggle via toggle() method', () => {
@@ -159,20 +190,22 @@ describe('ElxCollapsible', () => {
 
   it('should handle keyboard Enter on trigger', () => {
     const trigger = el.shadowRoot!.querySelector('.trigger');
-    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    // Native button handles Enter/Space → click
+    trigger.click();
     expect(el.open).toBe(true);
   });
 
   it('should handle keyboard Space on trigger', () => {
     const trigger = el.shadowRoot!.querySelector('.trigger');
-    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    // Native button handles Enter/Space → click
+    trigger.click();
     expect(el.open).toBe(true);
   });
 
   it('should not toggle on keyboard when disabled', () => {
     el.disabled = true;
     const trigger = el.shadowRoot!.querySelector('.trigger');
-    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    trigger.click();
     expect(el.open).toBe(false);
   });
 

--- a/src/components/collapsible/collapsible.test.ts
+++ b/src/components/collapsible/collapsible.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import './collapsible';
+
+describe('ElxCollapsible', () => {
+  let el: any;
+
+  beforeEach(() => {
+    el = document.createElement('elx-collapsible');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should be defined as a custom element', () => {
+    expect(customElements.get('elx-collapsible')).toBeDefined();
+  });
+
+  it('should render shadow DOM with trigger and content', () => {
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    const content = el.shadowRoot!.querySelector('.content-wrapper');
+    expect(trigger).toBeTruthy();
+    expect(content).toBeTruthy();
+  });
+
+  it('should be closed by default', () => {
+    expect(el.open).toBe(false);
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('should open when open attribute is set', () => {
+    el.setAttribute('open', '');
+    expect(el.open).toBe(true);
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('should open via property setter', () => {
+    el.open = true;
+    expect(el.hasAttribute('open')).toBe(true);
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('should close when open attribute is removed', () => {
+    el.setAttribute('open', '');
+    el.removeAttribute('open');
+    expect(el.open).toBe(false);
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('should toggle on trigger click', () => {
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    trigger.click();
+    expect(el.open).toBe(true);
+    trigger.click();
+    expect(el.open).toBe(false);
+  });
+
+  it('should dispatch elx-collapsible-toggle event on toggle', () => {
+    let detail: any = null;
+    el.addEventListener('elx-collapsible-toggle', (e: CustomEvent) => {
+      detail = e.detail;
+    });
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    trigger.click();
+    expect(detail).toEqual({ open: true });
+  });
+
+  it('should not toggle when disabled', () => {
+    el.disabled = true;
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    trigger.click();
+    expect(el.open).toBe(false);
+  });
+
+  it('should set disabled attribute on trigger when disabled', () => {
+    el.disabled = true;
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger.disabled).toBe(true);
+  });
+
+  it('should reflect disabled property to attribute', () => {
+    el.disabled = true;
+    expect(el.hasAttribute('disabled')).toBe(true);
+    el.disabled = false;
+    expect(el.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('should set aria-hidden on content', () => {
+    const content = el.shadowRoot!.querySelector('.content-wrapper');
+    expect(content.getAttribute('aria-hidden')).toBe('true');
+    el.open = true;
+    expect(content.getAttribute('aria-hidden')).toBe('false');
+  });
+
+  it('should have role="region" on content', () => {
+    const content = el.shadowRoot!.querySelector('.content-wrapper');
+    expect(content.getAttribute('role')).toBe('region');
+  });
+
+  it('should have aria-controls on trigger', () => {
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger.getAttribute('aria-controls')).toBe('content');
+  });
+
+  it('should forward aria-label to trigger', () => {
+    el.setAttribute('aria-label', 'Toggle section');
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger.getAttribute('aria-label')).toBe('Toggle section');
+  });
+
+  it('should toggle via toggle() method', () => {
+    el.toggle();
+    expect(el.open).toBe(true);
+    el.toggle();
+    expect(el.open).toBe(false);
+  });
+
+  it('should open via show() method', () => {
+    el.show();
+    expect(el.open).toBe(true);
+    // Calling show again should not dispatch event
+    let eventCount = 0;
+    el.addEventListener('elx-collapsible-toggle', () => eventCount++);
+    el.show();
+    expect(eventCount).toBe(0);
+  });
+
+  it('should close via hide() method', () => {
+    el.open = true;
+    el.hide();
+    expect(el.open).toBe(false);
+    // Calling hide again should not dispatch event
+    let eventCount = 0;
+    el.addEventListener('elx-collapsible-toggle', () => eventCount++);
+    el.hide();
+    expect(eventCount).toBe(0);
+  });
+
+  it('should render chevron icon', () => {
+    const icon = el.shadowRoot!.querySelector('.icon');
+    expect(icon).toBeTruthy();
+    expect(icon.tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('should have trigger slot', () => {
+    const slot = el.shadowRoot!.querySelector('slot[name="trigger"]');
+    expect(slot).toBeTruthy();
+  });
+
+  it('should have content slot', () => {
+    const slot = el.shadowRoot!.querySelector('slot[name="content"]');
+    expect(slot).toBeTruthy();
+  });
+
+  it('should handle keyboard Enter on trigger', () => {
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(el.open).toBe(true);
+  });
+
+  it('should handle keyboard Space on trigger', () => {
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(el.open).toBe(true);
+  });
+
+  it('should not toggle on keyboard when disabled', () => {
+    el.disabled = true;
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(el.open).toBe(false);
+  });
+
+  it('should clean up listeners on disconnect', () => {
+    document.body.removeChild(el);
+    // Should not throw
+    expect(() => el.toggle()).not.toThrow();
+  });
+
+  it('should not update when attribute value is unchanged', () => {
+    el.setAttribute('open', '');
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    // Setting same value again should be a no-op
+    el.setAttribute('open', '');
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+});

--- a/src/components/collapsible/collapsible.ts
+++ b/src/components/collapsible/collapsible.ts
@@ -1,0 +1,244 @@
+/**
+ * ElxCollapsible - A collapsible content container
+ * Expands/collapses content with smooth animation
+ */
+export class ElxCollapsible extends HTMLElement {
+  private _trigger: HTMLButtonElement | null = null;
+  private _content: HTMLDivElement | null = null;
+  private _open = false;
+  private _disabled = false;
+  private _boundHandleClick: () => void;
+  private _boundHandleKeydown: (e: KeyboardEvent) => void;
+
+  static get observedAttributes(): string[] {
+    return ['open', 'disabled', 'aria-label'];
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._boundHandleClick = this._handleClick.bind(this);
+    this._boundHandleKeydown = this._handleKeydown.bind(this);
+  }
+
+  connectedCallback(): void {
+    this._buildDom();
+    this._update();
+  }
+
+  disconnectedCallback(): void {
+    if (this._trigger) {
+      this._trigger.removeEventListener('click', this._boundHandleClick);
+      this._trigger.removeEventListener('keydown', this._boundHandleKeydown);
+    }
+  }
+
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
+    if (oldValue === newValue) return;
+    
+    if (name === 'open') {
+      this._open = newValue !== null;
+      this._update();
+    } else if (name === 'disabled') {
+      this._disabled = newValue !== null;
+      this._update();
+    } else if (name === 'aria-label') {
+      this._update();
+    }
+  }
+
+  get open(): boolean {
+    return this._open;
+  }
+
+  set open(value: boolean) {
+    this._open = value;
+    if (value) {
+      this.setAttribute('open', '');
+    } else {
+      this.removeAttribute('open');
+    }
+  }
+
+  get disabled(): boolean {
+    return this._disabled;
+  }
+
+  set disabled(value: boolean) {
+    this._disabled = value;
+    if (value) {
+      this.setAttribute('disabled', '');
+    } else {
+      this.removeAttribute('disabled');
+    }
+  }
+
+  private _buildDom(): void {
+    if (!this.shadowRoot) return;
+
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+        }
+
+        .trigger {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          width: 100%;
+          padding: var(--elx-collapsible-trigger-padding, 0.75rem 1rem);
+          background: var(--elx-collapsible-trigger-bg, transparent);
+          border: var(--elx-collapsible-trigger-border, 1px solid #e2e8f0);
+          border-radius: var(--elx-collapsible-trigger-radius, 0.375rem);
+          cursor: pointer;
+          font-size: var(--elx-collapsible-trigger-font-size, 0.875rem);
+          font-weight: var(--elx-collapsible-trigger-font-weight, 500);
+          color: var(--elx-collapsible-trigger-color, #1e293b);
+          transition: background 0.15s, border-color 0.15s;
+        }
+
+        .trigger:hover:not(:disabled) {
+          background: var(--elx-collapsible-trigger-hover-bg, #f8fafc);
+          border-color: var(--elx-collapsible-trigger-hover-border-color, #cbd5e1);
+        }
+
+        .trigger:focus-visible {
+          outline: 2px solid var(--elx-collapsible-focus-ring, #3b82f6);
+          outline-offset: 2px;
+        }
+
+        .trigger:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+
+        .icon {
+          width: 1rem;
+          height: 1rem;
+          transition: transform 0.2s ease;
+          flex-shrink: 0;
+        }
+
+        :host([open]) .icon {
+          transform: rotate(180deg);
+        }
+
+        .content-wrapper {
+          overflow: hidden;
+          transition: height 0.2s ease;
+        }
+
+        .content {
+          padding: var(--elx-collapsible-content-padding, 1rem);
+          border: var(--elx-collapsible-content-border, 1px solid #e2e8f0);
+          border-top: none;
+          border-radius: var(--elx-collapsible-content-radius, 0 0 0.375rem 0.375rem);
+          background: var(--elx-collapsible-content-bg, #ffffff);
+        }
+      </style>
+      <button class="trigger" type="button" aria-expanded="false" aria-controls="content">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+        <slot name="trigger">Toggle</slot>
+      </button>
+      <div class="content-wrapper" id="content" role="region">
+        <div class="content">
+          <slot name="content"></slot>
+        </div>
+      </div>
+    `;
+
+    this._trigger = this.shadowRoot.querySelector('.trigger');
+    this._content = this.shadowRoot.querySelector('.content-wrapper');
+
+    if (this._trigger) {
+      this._trigger.addEventListener('click', this._boundHandleClick);
+      this._trigger.addEventListener('keydown', this._boundHandleKeydown);
+    }
+  }
+
+  private _update(): void {
+    if (!this._trigger || !this._content) return;
+
+    // Update trigger
+    this._trigger.setAttribute('aria-expanded', String(this._open));
+    this._trigger.disabled = this._disabled;
+    
+    const label = this.getAttribute('aria-label');
+    if (label) {
+      this._trigger.setAttribute('aria-label', label);
+    }
+
+    // Update content visibility
+    if (this._open) {
+      this._content.style.height = 'auto';
+      const height = this._content.scrollHeight;
+      this._content.style.height = '0';
+      // Force reflow
+      this._content.offsetHeight;
+      this._content.style.height = height + 'px';
+    } else {
+      this._content.style.height = this._content.scrollHeight + 'px';
+      // Force reflow
+      this._content.offsetHeight;
+      this._content.style.height = '0';
+    }
+
+    // Update aria-hidden
+    this._content.setAttribute('aria-hidden', String(!this._open));
+  }
+
+  private _handleClick(): void {
+    if (this._disabled) return;
+    this.toggle();
+  }
+
+  private _handleKeydown(e: KeyboardEvent): void {
+    if (this._disabled) return;
+    
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.toggle();
+    }
+  }
+
+  public toggle(): void {
+    this.open = !this._open;
+    this._dispatchToggleEvent();
+  }
+
+  public show(): void {
+    if (!this._open) {
+      this.open = true;
+      this._dispatchToggleEvent();
+    }
+  }
+
+  public hide(): void {
+    if (this._open) {
+      this.open = false;
+      this._dispatchToggleEvent();
+    }
+  }
+
+  private _dispatchToggleEvent(): void {
+    this.dispatchEvent(new CustomEvent('elx-collapsible-toggle', {
+      bubbles: true,
+      composed: true,
+      detail: { open: this._open }
+    }));
+  }
+}
+
+// Guard against duplicate registration
+if (!customElements.get('elx-collapsible')) {
+  customElements.define('elx-collapsible', ElxCollapsible);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'elx-collapsible': ElxCollapsible;
+  }
+}

--- a/src/components/collapsible/collapsible.ts
+++ b/src/components/collapsible/collapsible.ts
@@ -2,26 +2,26 @@
  * ElxCollapsible - A collapsible content container
  * Expands/collapses content with smooth animation
  */
+let collapsibleIdCounter = 0;
+
 export class ElxCollapsible extends HTMLElement {
   private _trigger: HTMLButtonElement | null = null;
   private _content: HTMLDivElement | null = null;
   private _open = false;
   private _disabled = false;
+  private _id = '';
   private _boundHandleClick: () => void;
-  private _boundHandleKeydown: (e: KeyboardEvent) => void;
 
-  static get observedAttributes(): string[] {
-    return ['open', 'disabled', 'aria-label'];
-  }
+  static observedAttributes = ['open', 'disabled', 'aria-label'];
 
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
     this._boundHandleClick = this._handleClick.bind(this);
-    this._boundHandleKeydown = this._handleKeydown.bind(this);
   }
 
   connectedCallback(): void {
+    this._id = 'elx-collapsible-' + (++collapsibleIdCounter);
     this._buildDom();
     this._update();
   }
@@ -29,7 +29,6 @@ export class ElxCollapsible extends HTMLElement {
   disconnectedCallback(): void {
     if (this._trigger) {
       this._trigger.removeEventListener('click', this._boundHandleClick);
-      this._trigger.removeEventListener('keydown', this._boundHandleKeydown);
     }
   }
 
@@ -126,6 +125,7 @@ export class ElxCollapsible extends HTMLElement {
 
         .content-wrapper {
           overflow: hidden;
+          height: 0;
           transition: height 0.2s ease;
         }
 
@@ -137,13 +137,13 @@ export class ElxCollapsible extends HTMLElement {
           background: var(--elx-collapsible-content-bg, #ffffff);
         }
       </style>
-      <button class="trigger" type="button" aria-expanded="false" aria-controls="content">
+      <button class="trigger" type="button" aria-expanded="false" id="${this._id}-trigger" aria-controls="${this._id}-content">
         <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="6 9 12 15 18 9"></polyline>
         </svg>
         <slot name="trigger">Toggle</slot>
       </button>
-      <div class="content-wrapper" id="content" role="region">
+      <div class="content-wrapper" id="${this._id}-content" role="region" aria-labelledby="${this._id}-trigger">
         <div class="content">
           <slot name="content"></slot>
         </div>
@@ -155,7 +155,6 @@ export class ElxCollapsible extends HTMLElement {
 
     if (this._trigger) {
       this._trigger.addEventListener('click', this._boundHandleClick);
-      this._trigger.addEventListener('keydown', this._boundHandleKeydown);
     }
   }
 
@@ -169,6 +168,8 @@ export class ElxCollapsible extends HTMLElement {
     const label = this.getAttribute('aria-label');
     if (label) {
       this._trigger.setAttribute('aria-label', label);
+    } else {
+      this._trigger.removeAttribute('aria-label');
     }
 
     // Update content visibility
@@ -193,15 +194,6 @@ export class ElxCollapsible extends HTMLElement {
   private _handleClick(): void {
     if (this._disabled) return;
     this.toggle();
-  }
-
-  private _handleKeydown(e: KeyboardEvent): void {
-    if (this._disabled) return;
-    
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      this.toggle();
-    }
   }
 
   public toggle(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,3 +36,4 @@ export * from './components/slider/slider';
 export * from './components/label/label';
 export * from './components/form-field/form-field';
 export * from './components/toggle/toggle';
+export * from './components/collapsible/collapsible';


### PR DESCRIPTION
Adds the Collapsible component with expand/collapse animation, keyboard support, and full ARIA accessibility.

- `elx-collapsible` custom element with trigger and content slots
- Open/close via attribute, property, or toggle()/show()/hide() methods
- Keyboard: Enter/Space to toggle
- aria-expanded, aria-hidden, aria-controls, role=region
- Disabled state support
- CSS custom properties for theming
- 26 tests passing