### PR TITLE
feat: add AspectRatio component (#52)

### DIFF
--- a/src/components/aspect-ratio/aspect-ratio.stories.ts
+++ b/src/components/aspect-ratio/aspect-ratio.stories.ts
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import './aspect-ratio.js';
+
+const meta: Meta = {
+  title: 'Components/AspectRatio',
+  component: 'elx-aspect-ratio',
+  tags: ['autodocs'],
+  argTypes: {
+    ratio: {
+      control: 'text',
+      description: 'Aspect ratio as number (1.77) or fraction string ("16/9")',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default16x9: Story = {
+  render: () => `
+    <elx-aspect-ratio>
+      <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800" alt="Mountain landscape">
+    </elx-aspect-ratio>
+  `,
+};
+
+export const Ratio4x3: Story = {
+  render: () => `
+    <elx-aspect-ratio ratio="4/3">
+      <img src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=800" alt="Nature scene">
+    </elx-aspect-ratio>
+  `,
+};
+
+export const Square1x1: Story = {
+  render: () => `
+    <elx-aspect-ratio ratio="1/1">
+      <img src="https://images.unsplash.com/photo-1518791841217-8f162f1e1131?w=800" alt="Cat portrait">
+    </elx-aspect-ratio>
+  `,
+};
+
+export const Portrait9x16: Story = {
+  render: () => `
+    <elx-aspect-ratio ratio="9/16">
+      <img src="https://images.unsplash.com/photo-1516762689617-e1cffcef479d?w=800" alt="Portrait photo">
+    </elx-aspect-ratio>
+  `,
+};
+
+export const Cinematic21x9: Story = {
+  render: () => `
+    <elx-aspect-ratio ratio="21/9">
+      <img src="https://images.unsplash.com/photo-1534447677768-be436bb09401?w=800" alt="Wide landscape">
+    </elx-aspect-ratio>
+  `,
+};
+
+export const CustomRatio: Story = {
+  render: () => `
+    <elx-aspect-ratio ratio="2.35">
+      <img src="https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?w=800" alt="Cinematic view">
+    </elx-aspect-ratio>
+  `,
+};
+
+export const WithVideo: Story = {
+  render: () => `
+    <elx-aspect-ratio ratio="16/9">
+      <video controls style="width: 100%; height: 100%;">
+        <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
+    </elx-aspect-ratio>
+  `,
+};
+
+export const WithIframe: Story = {
+  render: () => `
+    <elx-aspect-ratio ratio="16/9">
+      <iframe 
+        src="https://www.youtube.com/embed/dQw4w9WgXcQ" 
+        style="width: 100%; height: 100%; border: none;"
+        allowfullscreen>
+      </iframe>
+    </elx-aspect-ratio>
+  `,
+};
+
+export const WithContent: Story = {
+  render: () => `
+    <elx-aspect-ratio ratio="16/9">
+      <div style="width: 100%; height: 100%; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); display: flex; align-items: center; justify-content: center; color: white; font-size: 1.5rem; font-weight: bold;">
+        Any Content
+      </div>
+    </elx-aspect-ratio>
+  `,
+};
+
+export const CustomObjectFit: Story = {
+  render: () => `
+    <style>
+      elx-aspect-ratio.contain {
+        --elx-aspect-ratio-object-fit: contain;
+        --elx-aspect-ratio-object-position: center;
+        background: #f1f5f9;
+      }
+    </style>
+    <elx-aspect-ratio class="contain" ratio="16/9">
+      <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800" alt="Mountain landscape with contain fit">
+    </elx-aspect-ratio>
+  `,
+};
+
+export const ResponsiveGrid: Story = {
+  render: () => `
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem;">
+      <elx-aspect-ratio ratio="1/1">
+        <img src="https://images.unsplash.com/photo-1518791841217-8f162f1e1131?w=400" alt="Image 1">
+      </elx-aspect-ratio>
+      <elx-aspect-ratio ratio="1/1">
+        <img src="https://images.unsplash.com/photo-1516762689617-e1cffcef479d?w=400" alt="Image 2">
+      </elx-aspect-ratio>
+      <elx-aspect-ratio ratio="1/1">
+        <img src="https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?w=400" alt="Image 3">
+      </elx-aspect-ratio>
+      <elx-aspect-ratio ratio="1/1">
+        <img src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=400" alt="Image 4">
+      </elx-aspect-ratio>
+    </div>
+  `,
+};

--- a/src/components/aspect-ratio/aspect-ratio.stories.ts
+++ b/src/components/aspect-ratio/aspect-ratio.stories.ts
@@ -80,6 +80,7 @@ export const WithIframe: Story = {
     <elx-aspect-ratio ratio="16/9">
       <iframe 
         src="https://www.youtube.com/embed/dQw4w9WgXcQ" 
+        title="YouTube video player"
         style="width: 100%; height: 100%; border: none;"
         allowfullscreen>
       </iframe>

--- a/src/components/aspect-ratio/aspect-ratio.test.ts
+++ b/src/components/aspect-ratio/aspect-ratio.test.ts
@@ -142,4 +142,22 @@ describe('ElxAspectRatio', () => {
     el.setAttribute('ratio', '9/16');
     expect(el.ratio).toBeCloseTo(9 / 16, 5);
   });
+
+  it('should have part="wrapper" on aspect-ratio div', () => {
+    const wrapper = el.shadowRoot!.querySelector('.aspect-ratio');
+    expect(wrapper.getAttribute('part')).toBe('wrapper');
+  });
+
+  it('should have part="content" on content div', () => {
+    const content = el.shadowRoot!.querySelector('.content');
+    expect(content.getAttribute('part')).toBe('content');
+  });
+
+  it('should not rebuild DOM on re-connection', () => {
+    const wrapper = el.shadowRoot!.querySelector('.aspect-ratio');
+    document.body.removeChild(el);
+    document.body.appendChild(el);
+    const wrapperAfter = el.shadowRoot!.querySelector('.aspect-ratio');
+    expect(wrapperAfter).toBe(wrapper);
+  });
 });

--- a/src/components/aspect-ratio/aspect-ratio.test.ts
+++ b/src/components/aspect-ratio/aspect-ratio.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import './aspect-ratio';
+
+describe('ElxAspectRatio', () => {
+  let el: any;
+
+  beforeEach(() => {
+    el = document.createElement('elx-aspect-ratio');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should be defined as a custom element', () => {
+    expect(customElements.get('elx-aspect-ratio')).toBeDefined();
+  });
+
+  it('should render shadow DOM with aspect-ratio wrapper', () => {
+    const wrapper = el.shadowRoot!.querySelector('.aspect-ratio');
+    expect(wrapper).toBeTruthy();
+  });
+
+  it('should have a content div inside wrapper', () => {
+    const content = el.shadowRoot!.querySelector('.content');
+    expect(content).toBeTruthy();
+  });
+
+  it('should have a slot for content', () => {
+    const slot = el.shadowRoot!.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('should default to 16/9 ratio', () => {
+    expect(el.ratio).toBeCloseTo(16 / 9, 5);
+  });
+
+  it('should set ratio via attribute as number', () => {
+    el.setAttribute('ratio', '2');
+    expect(el.ratio).toBe(2);
+  });
+
+  it('should set ratio via attribute as fraction string', () => {
+    el.setAttribute('ratio', '4/3');
+    expect(el.ratio).toBeCloseTo(4 / 3, 5);
+  });
+
+  it('should set ratio via attribute as 16/9', () => {
+    el.setAttribute('ratio', '16/9');
+    expect(el.ratio).toBeCloseTo(16 / 9, 5);
+  });
+
+  it('should set ratio via attribute as 1/1', () => {
+    el.setAttribute('ratio', '1/1');
+    expect(el.ratio).toBe(1);
+  });
+
+  it('should set ratio via property', () => {
+    el.ratio = 2.35;
+    expect(el.ratio).toBe(2.35);
+    expect(el.getAttribute('ratio')).toBe('2.35');
+  });
+
+  it('should update padding-bottom when ratio changes', () => {
+    el.ratio = 1;
+    const wrapper = el.shadowRoot!.querySelector('.aspect-ratio');
+    expect(wrapper.style.paddingBottom).toBe('100%');
+  });
+
+  it('should set correct padding-bottom for 16/9', () => {
+    el.setAttribute('ratio', '16/9');
+    const wrapper = el.shadowRoot!.querySelector('.aspect-ratio');
+    const expected = (9 / 16 * 100).toFixed(4);
+    expect(parseFloat(wrapper.style.paddingBottom)).toBeCloseTo(parseFloat(expected), 1);
+  });
+
+  it('should set correct padding-bottom for 4/3', () => {
+    el.setAttribute('ratio', '4/3');
+    const wrapper = el.shadowRoot!.querySelector('.aspect-ratio');
+    const expected = (3 / 4 * 100);
+    expect(parseFloat(wrapper.style.paddingBottom)).toBeCloseTo(expected, 1);
+  });
+
+  it('should ignore invalid ratio attribute', () => {
+    el.setAttribute('ratio', 'invalid');
+    expect(el.ratio).toBeCloseTo(16 / 9, 5);
+  });
+
+  it('should ignore zero ratio', () => {
+    const prevRatio = el.ratio;
+    el.ratio = 0;
+    expect(el.ratio).toBe(prevRatio);
+  });
+
+  it('should ignore negative ratio', () => {
+    const prevRatio = el.ratio;
+    el.ratio = -1;
+    expect(el.ratio).toBe(prevRatio);
+  });
+
+  it('should handle ratio attribute removal gracefully', () => {
+    el.setAttribute('ratio', '2');
+    el.removeAttribute('ratio');
+    expect(el.ratio).toBeCloseTo(16 / 9, 5);
+  });
+
+  it('should have content positioned absolutely', () => {
+    const style = el.shadowRoot!.querySelector('style');
+    expect(style?.textContent).toContain('position: absolute');
+  });
+
+  it('should have CSS custom properties for object-fit', () => {
+    const style = el.shadowRoot!.querySelector('style');
+    expect(style?.textContent).toContain('--elx-aspect-ratio-object-fit');
+  });
+
+  it('should have CSS custom properties for object-position', () => {
+    const style = el.shadowRoot!.querySelector('style');
+    expect(style?.textContent).toContain('--elx-aspect-ratio-object-position');
+  });
+
+  it('should not update ratio when attribute value is unchanged', () => {
+    el.setAttribute('ratio', '2');
+    const ratio = el.ratio;
+    el.setAttribute('ratio', '2');
+    expect(el.ratio).toBe(ratio);
+  });
+
+  it('should handle ratio as decimal string', () => {
+    el.setAttribute('ratio', '2.35');
+    expect(el.ratio).toBe(2.35);
+  });
+
+  it('should support square ratio 1:1', () => {
+    el.ratio = 1;
+    const wrapper = el.shadowRoot!.querySelector('.aspect-ratio');
+    expect(wrapper.style.paddingBottom).toBe('100%');
+  });
+
+  it('should support portrait ratio 9:16', () => {
+    el.setAttribute('ratio', '9/16');
+    expect(el.ratio).toBeCloseTo(9 / 16, 5);
+  });
+});

--- a/src/components/aspect-ratio/aspect-ratio.ts
+++ b/src/components/aspect-ratio/aspect-ratio.ts
@@ -13,7 +13,9 @@ export class ElxAspectRatio extends HTMLElement {
   }
 
   connectedCallback(): void {
-    this._buildDom();
+    if (!this.shadowRoot!.querySelector('.aspect-ratio')) {
+      this._buildDom();
+    }
   }
 
   attributeChangedCallback(_name: string, oldValue: string | null, newValue: string | null): void {
@@ -91,7 +93,6 @@ export class ElxAspectRatio extends HTMLElement {
         ::slotted(*) {
           width: 100%;
           height: 100%;
-          object-fit: cover;
         }
 
         ::slotted(img),
@@ -100,8 +101,8 @@ export class ElxAspectRatio extends HTMLElement {
           object-position: var(--elx-aspect-ratio-object-position, center);
         }
       </style>
-      <div class="aspect-ratio">
-        <div class="content">
+      <div class="aspect-ratio" part="wrapper">
+        <div class="content" part="content">
           <slot></slot>
         </div>
       </div>

--- a/src/components/aspect-ratio/aspect-ratio.ts
+++ b/src/components/aspect-ratio/aspect-ratio.ts
@@ -1,0 +1,128 @@
+/**
+ * ElxAspectRatio - A container that maintains a consistent aspect ratio
+ * Useful for responsive images, videos, and other media
+ */
+export class ElxAspectRatio extends HTMLElement {
+  private _ratio = 16 / 9;
+
+  static observedAttributes = ['ratio'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    this._buildDom();
+  }
+
+  attributeChangedCallback(_name: string, oldValue: string | null, newValue: string | null): void {
+    if (oldValue === newValue) return;
+    this._parseRatio(newValue);
+    this._updateStyle();
+  }
+
+  get ratio(): number {
+    return this._ratio;
+  }
+
+  set ratio(value: number) {
+    if (value > 0) {
+      this._ratio = value;
+      this.setAttribute('ratio', String(value));
+      this._updateStyle();
+    }
+  }
+
+  private _parseRatio(value: string | null): void {
+    if (!value) {
+      this._ratio = 16 / 9;
+      return;
+    }
+
+    // Try parsing as "width/height" format first (e.g., "16/9", "4/3")
+    const parts = value.split('/');
+    if (parts.length === 2) {
+      const width = parseFloat(parts[0]);
+      const height = parseFloat(parts[1]);
+      if (!isNaN(width) && !isNaN(height) && width > 0 && height > 0) {
+        this._ratio = width / height;
+        return;
+      }
+    }
+
+    // Try parsing as number
+    const num = parseFloat(value);
+    if (!isNaN(num) && num > 0) {
+      this._ratio = num;
+      return;
+    }
+
+    // Default fallback
+    this._ratio = 16 / 9;
+  }
+
+  private _buildDom(): void {
+    if (!this.shadowRoot) return;
+
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          position: relative;
+          width: 100%;
+        }
+
+        .aspect-ratio {
+          position: relative;
+          width: 100%;
+          padding-bottom: ${100 / this._ratio}%;
+        }
+
+        .content {
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          overflow: hidden;
+        }
+
+        ::slotted(*) {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+        }
+
+        ::slotted(img),
+        ::slotted(video) {
+          object-fit: var(--elx-aspect-ratio-object-fit, cover);
+          object-position: var(--elx-aspect-ratio-object-position, center);
+        }
+      </style>
+      <div class="aspect-ratio">
+        <div class="content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
+  }
+
+  private _updateStyle(): void {
+    const wrapper = this.shadowRoot?.querySelector('.aspect-ratio') as HTMLElement;
+    if (wrapper) {
+      wrapper.style.paddingBottom = `${100 / this._ratio}%`;
+    }
+  }
+}
+
+// Guard against duplicate registration
+if (!customElements.get('elx-aspect-ratio')) {
+  customElements.define('elx-aspect-ratio', ElxAspectRatio);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'elx-aspect-ratio': ElxAspectRatio;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,4 @@ export * from './components/form-field/form-field';
 export * from './components/toggle/toggle';
 export * from './components/collapsible/collapsible';
 export * from './components/scroll-area/scroll-area';
+export * from './components/aspect-ratio/aspect-ratio';


### PR DESCRIPTION
Adds the AspectRatio component for maintaining consistent width/height ratios.

- `elx-aspect-ratio` custom element with padding-bottom technique
- Ratio as number (1.77) or fraction string ("16/9", "4/3", "1/1")
- Common presets: 16/9, 4/3, 1/1, 9/16, 21/9
- CSS custom properties for object-fit and object-position
- Works with images, videos, iframes, and any content
- 24 tests passing