### PR TITLE
feat: add HoverCard component

### DIFF
--- a/src/components/hover-card/hover-card.stories.ts
+++ b/src/components/hover-card/hover-card.stories.ts
@@ -1,0 +1,179 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import './hover-card.js';
+
+const meta: Meta = {
+  title: 'Components/HoverCard',
+  tags: ['autodocs'],
+  argTypes: {
+    position: {
+      control: 'select',
+      options: ['top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'left', 'right'],
+    },
+    'open-delay': { control: 'number' },
+    'close-delay': { control: 'number' },
+    disabled: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => `
+    <elx-hover-card>
+      <button slot="trigger">Hover me</button>
+      <div>
+        <strong>Preview Card</strong>
+        <p style="margin: 8px 0 0; color: #666;">This is a hover card with rich content that appears on hover.</p>
+      </div>
+    </elx-hover-card>
+  `,
+};
+
+export const UserProfile: Story = {
+  render: () => `
+    <elx-hover-card>
+      <a href="#" slot="trigger" style="color: #0066cc; text-decoration: underline;">@johndoe</a>
+      <div style="display: flex; gap: 12px; align-items: flex-start;">
+        <img src="https://api.dicebear.com/7.x/avataaars/svg?seed=johndoe" alt="John Doe avatar" width="48" height="48" style="border-radius: 50%;" />
+        <div>
+          <strong>John Doe</strong>
+          <p style="margin: 4px 0; color: #666; font-size: 14px;">Full-stack developer. Open source enthusiast.</p>
+          <div style="display: flex; gap: 16px; font-size: 12px; color: #999;">
+            <span>42 repos</span>
+            <span>128 followers</span>
+          </div>
+        </div>
+      </div>
+    </elx-hover-card>
+  `,
+};
+
+export const LinkPreview: Story = {
+  render: () => `
+    <p style="line-height: 1.8;">
+      Check out the 
+      <elx-hover-card position="top">
+        <a href="https://developer.mozilla.org" slot="trigger" style="color: #0066cc;">MDN Web Docs</a>
+        <div>
+          <strong>MDN Web Docs</strong>
+          <p style="margin: 8px 0; color: #666; font-size: 14px;">Resources for developers, by developers. Documentation for web technologies including HTML, CSS, and JavaScript.</p>
+          <span style="font-size: 12px; color: #999;">developer.mozilla.org</span>
+        </div>
+      </elx-hover-card>
+      for web development references.
+    </p>
+  `,
+};
+
+export const PositionTop: Story = {
+  render: () => `
+    <div style="padding-top: 200px;">
+      <elx-hover-card position="top">
+        <button slot="trigger">Hover (top)</button>
+        <div>
+          <strong>Top Position</strong>
+          <p style="margin: 8px 0 0; color: #666;">Card appears above the trigger.</p>
+        </div>
+      </elx-hover-card>
+    </div>
+  `,
+};
+
+export const PositionLeft: Story = {
+  render: () => `
+    <div style="padding-left: 300px;">
+      <elx-hover-card position="left">
+        <button slot="trigger">Hover (left)</button>
+        <div>
+          <strong>Left Position</strong>
+          <p style="margin: 8px 0 0; color: #666;">Card appears to the left.</p>
+        </div>
+      </elx-hover-card>
+    </div>
+  `,
+};
+
+export const PositionRight: Story = {
+  render: () => `
+    <elx-hover-card position="right">
+      <button slot="trigger">Hover (right)</button>
+      <div>
+        <strong>Right Position</strong>
+        <p style="margin: 8px 0 0; color: #666;">Card appears to the right.</p>
+      </div>
+    </elx-hover-card>
+  `,
+};
+
+export const CustomDelay: Story = {
+  render: () => `
+    <elx-hover-card open-delay="500" close-delay="1000">
+      <button slot="trigger">Slow hover (500ms open, 1s close)</button>
+      <div>
+        <strong>Custom Delays</strong>
+        <p style="margin: 8px 0 0; color: #666;">This card has a longer open delay and an even longer close delay.</p>
+      </div>
+    </elx-hover-card>
+  `,
+};
+
+export const Disabled: Story = {
+  render: () => `
+    <elx-hover-card disabled>
+      <button slot="trigger">Hover me (disabled)</button>
+      <div>
+        <p>This content will not appear.</p>
+      </div>
+    </elx-hover-card>
+  `,
+};
+
+export const RichContent: Story = {
+  render: () => `
+    <elx-hover-card>
+      <button slot="trigger" style="padding: 8px 16px; border-radius: 6px; border: 1px solid #ddd; background: white; cursor: pointer;">
+        View Product
+      </button>
+      <div style="width: 280px;">
+        <img src="https://picsum.photos/280/140" alt="Product preview image" style="width: 100%; border-radius: 4px; margin-bottom: 8px;" />
+        <strong>Wireless Headphones</strong>
+        <p style="margin: 4px 0; color: #666; font-size: 14px;">Premium noise-cancelling headphones with 30-hour battery life.</p>
+        <div style="display: flex; justify-content: space-between; align-items: center; margin-top: 8px;">
+          <span style="font-weight: bold; font-size: 18px;">$299</span>
+          <span style="color: #22c55e; font-size: 12px;">In Stock</span>
+        </div>
+      </div>
+    </elx-hover-card>
+  `,
+};
+
+export const InlineText: Story = {
+  render: () => `
+    <p style="line-height: 2; max-width: 500px;">
+      The project was started by 
+      <elx-hover-card>
+        <a href="#" slot="trigger" style="color: #0066cc; text-decoration: underline;">Alice</a>
+        <div style="display: flex; gap: 12px;">
+          <img src="https://api.dicebear.com/7.x/avataaars/svg?seed=alice" alt="Alice avatar" width="40" height="40" style="border-radius: 50%;" />
+          <div>
+            <strong>Alice Chen</strong>
+            <p style="margin: 2px 0 0; color: #666; font-size: 13px;">Lead Engineer · San Francisco</p>
+          </div>
+        </div>
+      </elx-hover-card>
+      and later joined by 
+      <elx-hover-card>
+        <a href="#" slot="trigger" style="color: #0066cc; text-decoration: underline;">Bob</a>
+        <div style="display: flex; gap: 12px;">
+          <img src="https://api.dicebear.com/7.x/avataaars/svg?seed=bob" alt="Bob avatar" width="40" height="40" style="border-radius: 50%;" />
+          <div>
+            <strong>Bob Martinez</strong>
+            <p style="margin: 2px 0 0; color: #666; font-size: 13px;">Senior Developer · Austin</p>
+          </div>
+        </div>
+      </elx-hover-card>
+      to build the design system.
+    </p>
+  `,
+};

--- a/src/components/hover-card/hover-card.test.ts
+++ b/src/components/hover-card/hover-card.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import './hover-card';
+
+describe('ElxHoverCard', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-hover-card')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+  });
+
+  // === Rendering ===
+  it('renders with shadow DOM', () => {
+    const el = document.createElement('elx-hover-card');
+    document.body.appendChild(el);
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('has part="trigger" on trigger wrapper', () => {
+    const el = document.createElement('elx-hover-card');
+    document.body.appendChild(el);
+    const trigger = el.shadowRoot!.querySelector('.trigger');
+    expect(trigger!.getAttribute('part')).toBe('trigger');
+  });
+
+  it('has part="content" on content wrapper', () => {
+    const el = document.createElement('elx-hover-card');
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content');
+    expect(content!.getAttribute('part')).toBe('content');
+  });
+
+  it('does not rebuild DOM on re-connection', () => {
+    const el = document.createElement('elx-hover-card');
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content');
+    document.body.removeChild(el);
+    document.body.appendChild(el);
+    const contentAfter = el.shadowRoot!.querySelector('.content');
+    expect(contentAfter).toBe(content);
+  });
+
+  // === Default State ===
+  it('is closed by default', () => {
+    const el = document.createElement('elx-hover-card');
+    document.body.appendChild(el);
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('has default position of bottom', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    expect(el.position).toBe('bottom');
+  });
+
+  it('has default open-delay of 200ms', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    expect(el.openDelay).toBe(200);
+  });
+
+  it('has default close-delay of 300ms', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    expect(el.closeDelay).toBe(300);
+  });
+
+  // === Properties ===
+  it('sets position property', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    el.position = 'top';
+    document.body.appendChild(el);
+    expect(el.position).toBe('top');
+    expect(el.getAttribute('position')).toBe('top');
+  });
+
+  it('sets open-delay property', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    el.openDelay = 500;
+    document.body.appendChild(el);
+    expect(el.openDelay).toBe(500);
+  });
+
+  it('sets close-delay property', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    el.closeDelay = 400;
+    document.body.appendChild(el);
+    expect(el.closeDelay).toBe(400);
+  });
+
+  it('sets disabled property', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    el.disabled = true;
+    document.body.appendChild(el);
+    expect(el.disabled).toBe(true);
+    expect(el.hasAttribute('disabled')).toBe(true);
+  });
+
+  // === Show/Hide Methods ===
+  it('opens when show() is called', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  it('closes when hide() is called', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    el.show();
+    el.hide();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('does not open when disabled', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    el.disabled = true;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  // === Events ===
+  it('dispatches "open" event when shown', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    const handler = vi.fn();
+    el.addEventListener('open', handler);
+    el.show();
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('dispatches "close" event when hidden', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    el.show();
+    const handler = vi.fn();
+    el.addEventListener('close', handler);
+    el.hide();
+    expect(handler).toHaveBeenCalled();
+  });
+
+  // === Hover Behavior ===
+  it('schedules open on trigger mouseenter', () => {
+    vi.useFakeTimers();
+    const el = document.createElement('elx-hover-card') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+
+    const trigger = el.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    expect(el.hasAttribute('open')).toBe(false);
+
+    vi.advanceTimersByTime(200);
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  it('schedules close on trigger mouseleave', () => {
+    vi.useFakeTimers();
+    const el = document.createElement('elx-hover-card') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+
+    el.show();
+    const trigger = el.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.dispatchEvent(new MouseEvent('mouseleave'));
+
+    vi.advanceTimersByTime(300);
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('cancels close timer when re-entering content', () => {
+    vi.useFakeTimers();
+    const el = document.createElement('elx-hover-card') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+
+    el.show();
+    const content = el.shadowRoot!.querySelector('.content') as HTMLElement;
+    content.dispatchEvent(new MouseEvent('mouseleave'));
+    content.dispatchEvent(new MouseEvent('mouseenter'));
+
+    vi.advanceTimersByTime(300);
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  // === Focus Behavior ===
+  it('schedules open on trigger focus', () => {
+    vi.useFakeTimers();
+    const el = document.createElement('elx-hover-card') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+
+    btn.focus();
+    vi.advanceTimersByTime(200);
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  it('schedules close on trigger blur', () => {
+    vi.useFakeTimers();
+    const el = document.createElement('elx-hover-card') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+
+    el.show();
+    btn.dispatchEvent(new FocusEvent('blur'));
+    vi.advanceTimersByTime(300);
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  // === Keyboard ===
+  it('closes on Escape key', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(true);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  // === Click Outside ===
+  it('closes when clicking outside', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    el.show();
+    expect(el.hasAttribute('open')).toBe(true);
+    document.body.click();
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+
+  it('does not close when clicking inside', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    el.show();
+    const content = el.shadowRoot!.querySelector('.content') as HTMLElement;
+    content.click();
+    expect(el.hasAttribute('open')).toBe(true);
+  });
+
+  // === ARIA ===
+  it('has correct ARIA attributes on content', () => {
+    const el = document.createElement('elx-hover-card');
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content');
+    expect(content!.getAttribute('role')).toBe('dialog');
+    expect(content!.getAttribute('aria-modal')).toBe('false');
+    expect(content!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('updates aria-hidden when opened', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    el.show();
+    const content = el.shadowRoot!.querySelector('.content');
+    expect(content!.getAttribute('aria-hidden')).toBe('false');
+  });
+
+  it('sets aria-haspopup and aria-expanded on trigger', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+    expect(btn.getAttribute('aria-haspopup')).toBe('dialog');
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('updates aria-expanded when opened', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+    el.show();
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('sets aria-controls on trigger', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+    const contentId = el.shadowRoot!.querySelector('.content')!.id;
+    expect(btn.getAttribute('aria-controls')).toBe(contentId);
+  });
+
+  // === Positioning ===
+  it('positions content at bottom by default', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content') as HTMLElement;
+    expect(content.style.cssText).toContain('top: 100%');
+  });
+
+  it('positions content at top when position="top"', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    el.position = 'top';
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content') as HTMLElement;
+    expect(content.style.cssText).toContain('bottom: 100%');
+  });
+
+  it('positions content at left when position="left"', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    el.position = 'left';
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content') as HTMLElement;
+    expect(content.style.cssText).toContain('right: 100%');
+  });
+
+  it('positions content at right when position="right"', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    el.position = 'right';
+    document.body.appendChild(el);
+    const content = el.shadowRoot!.querySelector('.content') as HTMLElement;
+    expect(content.style.cssText).toContain('left: 100%');
+  });
+
+  // === Disabled State ===
+  it('has disabled attribute when disabled', () => {
+    const el = document.createElement('elx-hover-card') as any;
+    el.disabled = true;
+    document.body.appendChild(el);
+    expect(el.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('does not schedule open when disabled', () => {
+    vi.useFakeTimers();
+    const el = document.createElement('elx-hover-card') as any;
+    el.disabled = true;
+    const btn = document.createElement('button');
+    btn.slot = 'trigger';
+    el.appendChild(btn);
+    document.body.appendChild(el);
+
+    const trigger = el.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(200);
+    expect(el.hasAttribute('open')).toBe(false);
+  });
+});

--- a/src/components/hover-card/hover-card.ts
+++ b/src/components/hover-card/hover-card.ts
@@ -1,0 +1,235 @@
+export class ElxHoverCard extends HTMLElement {
+  static observedAttributes = ['open', 'position', 'open-delay', 'close-delay', 'disabled'];
+
+  private _contentId = `elx-hover-card-${Math.random().toString(36).slice(2, 9)}`;
+  private _openTimer: ReturnType<typeof setTimeout> | null = null;
+  private _closeTimer: ReturnType<typeof setTimeout> | null = null;
+  private _onKeydown: (e: KeyboardEvent) => void;
+  private _onClickOutside: (e: Event) => void;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._onKeydown = (e: KeyboardEvent) => this._handleKeydown(e);
+    this._onClickOutside = (e: Event) => this._handleClickOutside(e);
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot!.querySelector('.content')) this._buildDom();
+    this._update();
+    document.addEventListener('keydown', this._onKeydown);
+    document.addEventListener('click', this._onClickOutside);
+  }
+
+  disconnectedCallback() {
+    this._clearTimers();
+    document.removeEventListener('keydown', this._onKeydown);
+    document.removeEventListener('click', this._onClickOutside);
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    this._update();
+  }
+
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+  set open(val: boolean) {
+    val ? this.setAttribute('open', '') : this.removeAttribute('open');
+  }
+
+  get position(): string {
+    return this.getAttribute('position') || 'bottom';
+  }
+  set position(val: string) {
+    this.setAttribute('position', val);
+  }
+
+  get openDelay(): number {
+    return Number(this.getAttribute('open-delay')) || 200;
+  }
+  set openDelay(val: number) {
+    this.setAttribute('open-delay', String(val));
+  }
+
+  get closeDelay(): number {
+    return Number(this.getAttribute('close-delay')) || 300;
+  }
+  set closeDelay(val: number) {
+    this.setAttribute('close-delay', String(val));
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
+
+  show() {
+    if (this.disabled) return;
+    this._clearTimers();
+    this.open = true;
+    this.dispatchEvent(new CustomEvent('open', { bubbles: true, composed: true }));
+  }
+
+  hide() {
+    this._clearTimers();
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+  }
+
+  private _clearTimers() {
+    if (this._openTimer) { clearTimeout(this._openTimer); this._openTimer = null; }
+    if (this._closeTimer) { clearTimeout(this._closeTimer); this._closeTimer = null; }
+  }
+
+  private _scheduleOpen() {
+    if (this.disabled || this.open) return;
+    this._clearTimers();
+    this._openTimer = setTimeout(() => this.show(), this.openDelay);
+  }
+
+  private _scheduleClose() {
+    if (!this.open) return;
+    this._clearTimers();
+    this._closeTimer = setTimeout(() => this.hide(), this.closeDelay);
+  }
+
+  private _handleKeydown(e: KeyboardEvent) {
+    if (!this.open) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.hide();
+      const trigger = this.querySelector('[slot="trigger"]') as HTMLElement;
+      trigger?.focus();
+    }
+  }
+
+  private _handleClickOutside(e: Event) {
+    if (!this.open) return;
+    const path = e.composedPath();
+    if (path.indexOf(this) === -1) {
+      this.hide();
+    }
+  }
+
+  private _onTriggerMouseEnter = () => this._scheduleOpen();
+  private _onTriggerMouseLeave = () => this._scheduleClose();
+  private _onTriggerFocus = () => this._scheduleOpen();
+  private _onTriggerBlur = () => this._scheduleClose();
+  private _onContentMouseEnter = () => this._clearTimers();
+  private _onContentMouseLeave = () => this._scheduleClose();
+
+  private _getPositionStyles(pos: string): string {
+    const positions: Record<string, string> = {
+      top: 'bottom: 100%; left: 50%; transform: translateX(-50%); margin-bottom: 8px;',
+      'top-start': 'bottom: 100%; left: 0; margin-bottom: 8px;',
+      'top-end': 'bottom: 100%; right: 0; margin-bottom: 8px;',
+      bottom: 'top: 100%; left: 50%; transform: translateX(-50%); margin-top: 8px;',
+      'bottom-start': 'top: 100%; left: 0; margin-top: 8px;',
+      'bottom-end': 'top: 100%; right: 0; margin-top: 8px;',
+      left: 'right: 100%; top: 50%; transform: translateY(-50%); margin-right: 8px;',
+      right: 'left: 100%; top: 50%; transform: translateY(-50%); margin-left: 8px;',
+    };
+    return positions[pos] || positions['bottom'];
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        position: relative;
+        display: inline-block;
+      }
+
+      .trigger {
+        display: contents;
+      }
+
+      .content {
+        position: absolute;
+        min-width: var(--elx-hover-card-min-width, 260px);
+        padding: var(--elx-hover-card-padding, 16px);
+        background: var(--elx-color-neutral-0, #fff);
+        border: 1px solid var(--elx-color-neutral-200, #e5e5e5);
+        border-radius: var(--elx-radius-lg, 8px);
+        box-shadow: var(--elx-hover-card-shadow, 0 4px 12px rgba(0, 0, 0, 0.15));
+        z-index: 1000;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 150ms ease, visibility 150ms;
+      }
+
+      :host([open]) .content {
+        opacity: 1;
+        visibility: visible;
+      }
+
+      :host([disabled]) {
+        opacity: 0.5;
+        pointer-events: none;
+      }
+
+      ::slotted([slot="trigger"]) {
+        cursor: pointer;
+      }
+    `;
+
+    const trigger = document.createElement('div');
+    trigger.setAttribute('part', 'trigger');
+    trigger.className = 'trigger';
+    const triggerSlot = document.createElement('slot');
+    triggerSlot.name = 'trigger';
+    trigger.appendChild(triggerSlot);
+
+    const content = document.createElement('div');
+    content.setAttribute('part', 'content');
+    content.className = 'content';
+    content.id = this._contentId;
+    content.setAttribute('tabindex', '-1');
+    content.setAttribute('role', 'dialog');
+    content.setAttribute('aria-modal', 'false');
+    const contentSlot = document.createElement('slot');
+    content.appendChild(contentSlot);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(trigger);
+    this.shadowRoot!.appendChild(content);
+
+    // Hover events on trigger
+    trigger.addEventListener('mouseenter', this._onTriggerMouseEnter);
+    trigger.addEventListener('mouseleave', this._onTriggerMouseLeave);
+    triggerSlot.addEventListener('focus', this._onTriggerFocus, true);
+    triggerSlot.addEventListener('blur', this._onTriggerBlur, true);
+
+    // Keep card open when hovering content
+    content.addEventListener('mouseenter', this._onContentMouseEnter);
+    content.addEventListener('mouseleave', this._onContentMouseLeave);
+  }
+
+  private _update() {
+    const content = this.shadowRoot?.querySelector('.content') as HTMLElement;
+    if (content) {
+      content.setAttribute('aria-hidden', String(!this.open));
+      content.style.cssText = this._getPositionStyles(this.position);
+    }
+    const trigger = this.querySelector('[slot="trigger"]') as HTMLElement;
+    if (trigger) {
+      trigger.setAttribute('aria-haspopup', 'dialog');
+      trigger.setAttribute('aria-expanded', String(this.open));
+      trigger.setAttribute('aria-controls', this._contentId);
+    }
+  }
+}
+
+if (!customElements.get('elx-hover-card')) {
+  customElements.define('elx-hover-card', ElxHoverCard);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'elx-hover-card': ElxHoverCard;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,3 +39,4 @@ export * from './components/toggle/toggle';
 export * from './components/collapsible/collapsible';
 export * from './components/scroll-area/scroll-area';
 export * from './components/aspect-ratio/aspect-ratio';
+export * from './components/hover-card/hover-card';


### PR DESCRIPTION
## Overview
Adds `elx-hover-card` — a rich preview card that appears on hover or focus.

## Features
- Trigger slot + content slot for flexible layouts
- Opens on hover with configurable delay (`open-delay`, `close-delay`)
- Positioning: top, bottom, left, right (with start/end variants)
- Keyboard accessible: focus opens, Escape closes
- ARIA: `aria-haspopup`, `aria-expanded`, `role="dialog"`
- Part attributes for external styling (`part="trigger"`, `part="content"`)
- Click-outside closes the card
- Hover over content keeps card open

## Testing
- 36 tests covering rendering, hover/focus behavior, delays, positioning, ARIA, keyboard, disabled state
- All 715 tests pass (full suite)

## Stories
- 9 stories: default, user profile, link preview, positioning variants, custom delays, disabled, rich content, inline text