### PR TITLE
feat: add NavigationMenu component

### DIFF
--- a/src/components/navigation-menu/navigation-menu.stories.ts
+++ b/src/components/navigation-menu/navigation-menu.stories.ts
@@ -1,0 +1,202 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import './navigation-menu.js';
+
+const meta: Meta = {
+  title: 'Components/NavigationMenu',
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => `
+    <elx-navigation-menu>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Home</span>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Products</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Electronics</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Clothing</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Books</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Services</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Consulting</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Support</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">About</span>
+      </elx-navigation-menu-item>
+    </elx-navigation-menu>
+  `,
+};
+
+export const WithIcons: Story = {
+  render: () => `
+    <elx-navigation-menu>
+      <elx-navigation-menu-item>
+        <span slot="trigger">🏠 Home</span>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">📦 Products</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">⚡ Electronics</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">👕 Clothing</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">📚 Books</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">🛠️ Services</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">💼 Consulting</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">🎧 Support</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">ℹ️ About</span>
+      </elx-navigation-menu-item>
+    </elx-navigation-menu>
+  `,
+};
+
+export const NestedDropdowns: Story = {
+  render: () => `
+    <elx-navigation-menu>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Developers</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Documentation</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">API Reference</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">SDKs</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Code Examples</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Company</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">About Us</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Blog</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Careers</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Contact</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Resources</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Guides</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Tutorials</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">FAQ</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+    </elx-navigation-menu>
+  `,
+};
+
+export const Disabled: Story = {
+  render: () => `
+    <elx-navigation-menu>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Home</span>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item disabled>
+        <span slot="trigger">Disabled Menu</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">This won't open</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">About</span>
+      </elx-navigation-menu-item>
+    </elx-navigation-menu>
+  `,
+};
+
+export const RichContent: Story = {
+  render: () => `
+    <elx-navigation-menu>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Solutions</span>
+        <elx-navigation-menu-content style="min-width: 300px;">
+          <div style="padding: 0.75rem;">
+            <div style="margin-bottom: 1rem;">
+              <strong style="display: block; margin-bottom: 0.5rem;">For Enterprise</strong>
+              <a href="#" style="display: block; padding: 0.25rem 0; text-decoration: none; color: #0066cc; font-size: 0.875rem;">Large-scale deployments</a>
+              <a href="#" style="display: block; padding: 0.25rem 0; text-decoration: none; color: #0066cc; font-size: 0.875rem;">Advanced security</a>
+            </div>
+            <div>
+              <strong style="display: block; margin-bottom: 0.5rem;">For Startups</strong>
+              <a href="#" style="display: block; padding: 0.25rem 0; text-decoration: none; color: #0066cc; font-size: 0.875rem;">Quick setup</a>
+              <a href="#" style="display: block; padding: 0.25rem 0; text-decoration: none; color: #0066cc; font-size: 0.875rem;">Flexible pricing</a>
+            </div>
+          </div>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Learn</span>
+        <elx-navigation-menu-content style="min-width: 280px;">
+          <div style="padding: 0.75rem;">
+            <div style="margin-bottom: 0.75rem;">
+              <a href="#" style="display: block; padding: 0.5rem; text-decoration: none; color: inherit; border-radius: 0.375rem; transition: background 0.15s;" onmouseover="this.style.background='#f1f5f9'" onmouseout="this.style.background='transparent'">
+                <strong>Getting Started</strong>
+                <p style="margin: 0.25rem 0 0; font-size: 0.875rem; color: #666;">Learn the basics in 5 minutes</p>
+              </a>
+            </div>
+            <div>
+              <a href="#" style="display: block; padding: 0.5rem; text-decoration: none; color: inherit; border-radius: 0.375rem; transition: background 0.15s;" onmouseover="this.style.background='#f1f5f9'" onmouseout="this.style.background='transparent'">
+                <strong>Advanced Topics</strong>
+                <p style="margin: 0.25rem 0 0; font-size: 0.875rem; color: #666;">Deep dive into features</p>
+              </a>
+            </div>
+          </div>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+    </elx-navigation-menu>
+  `,
+};
+
+export const ManyItems: Story = {
+  render: () => `
+    <elx-navigation-menu>
+      <elx-navigation-menu-item>
+        <span slot="trigger">File</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">New</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Open</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Save</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Exit</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Edit</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Undo</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Redo</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Cut</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Copy</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Paste</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">View</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Zoom In</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Zoom Out</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Reset</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+      <elx-navigation-menu-item>
+        <span slot="trigger">Help</span>
+        <elx-navigation-menu-content>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">Documentation</a>
+          <a href="#" style="display: block; padding: 0.5rem 0.75rem; text-decoration: none; color: inherit;">About</a>
+        </elx-navigation-menu-content>
+      </elx-navigation-menu-item>
+    </elx-navigation-menu>
+  `,
+};

--- a/src/components/navigation-menu/navigation-menu.test.ts
+++ b/src/components/navigation-menu/navigation-menu.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import './navigation-menu';
+
+function makeMenu(html = '') {
+  const el = document.createElement('elx-navigation-menu') as any;
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeItem(withContent = false) {
+  const item = document.createElement('elx-navigation-menu-item') as any;
+  const trigger = document.createElement('span');
+  trigger.slot = 'trigger';
+  trigger.textContent = 'Item';
+  item.appendChild(trigger);
+  if (withContent) {
+    const content = document.createElement('elx-navigation-menu-content');
+    content.textContent = 'Content';
+    item.appendChild(content);
+  }
+  return item;
+}
+
+describe('ElxNavigationMenu', () => {
+  beforeAll(() => {
+    expect(customElements.get('elx-navigation-menu')).toBeDefined();
+    expect(customElements.get('elx-navigation-menu-item')).toBeDefined();
+    expect(customElements.get('elx-navigation-menu-content')).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  // === ElxNavigationMenu ===
+
+  it('renders with shadow DOM', () => {
+    const el = makeMenu();
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it('has part="nav" on nav element', () => {
+    const el = makeMenu();
+    expect(el.shadowRoot!.querySelector('nav')!.getAttribute('part')).toBe('nav');
+  });
+
+  it('has part="list" on list element', () => {
+    const el = makeMenu();
+    expect(el.shadowRoot!.querySelector('.nav-menu')!.getAttribute('part')).toBe('list');
+  });
+
+  it('has role="menubar" on list', () => {
+    const el = makeMenu();
+    expect(el.shadowRoot!.querySelector('.nav-menu')!.getAttribute('role')).toBe('menubar');
+  });
+
+  it('does not rebuild DOM on re-connection', () => {
+    const el = makeMenu();
+    const nav = el.shadowRoot!.querySelector('nav');
+    document.body.removeChild(el);
+    document.body.appendChild(el);
+    expect(el.shadowRoot!.querySelector('nav')).toBe(nav);
+  });
+
+  it('closeAll() closes all open items', () => {
+    const el = makeMenu();
+    const item1 = makeItem(true);
+    const item2 = makeItem(true);
+    el.appendChild(item1);
+    el.appendChild(item2);
+    item1.show();
+    item2.show();
+    el.closeAll();
+    expect(item1.open).toBe(false);
+    expect(item2.open).toBe(false);
+  });
+
+  it('closes all items when clicking outside', () => {
+    const el = makeMenu();
+    const item = makeItem(true);
+    el.appendChild(item);
+    item.show();
+    expect(item.open).toBe(true);
+    document.body.click();
+    expect(item.open).toBe(false);
+  });
+
+  it('closes open item on Escape key', () => {
+    const el = makeMenu();
+    const item = makeItem(true);
+    el.appendChild(item);
+    item.show();
+    const trigger = item.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.focus();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(item.open).toBe(false);
+  });
+
+  // === ElxNavigationMenuItem ===
+
+  it('renders item with shadow DOM', () => {
+    const item = makeItem();
+    document.body.appendChild(item);
+    expect(item.shadowRoot).toBeTruthy();
+  });
+
+  it('has trigger button in shadow DOM', () => {
+    const item = makeItem();
+    document.body.appendChild(item);
+    expect(item.shadowRoot!.querySelector('.trigger')).toBeTruthy();
+  });
+
+  it('has part="trigger" on trigger button', () => {
+    const item = makeItem();
+    document.body.appendChild(item);
+    expect(item.shadowRoot!.querySelector('.trigger')!.getAttribute('part')).toBe('trigger');
+  });
+
+  it('is closed by default', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    expect(item.open).toBe(false);
+  });
+
+  it('opens when show() is called', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    item.show();
+    expect(item.open).toBe(true);
+  });
+
+  it('closes when close() is called', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    item.show();
+    item.close();
+    expect(item.open).toBe(false);
+  });
+
+  it('toggles open state', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    item.toggle();
+    expect(item.open).toBe(true);
+    item.toggle();
+    expect(item.open).toBe(false);
+  });
+
+  it('does not open when disabled', () => {
+    const item = makeItem(true);
+    item.disabled = true;
+    document.body.appendChild(item);
+    item.show();
+    expect(item.open).toBe(false);
+  });
+
+  it('dispatches "open" event when shown', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    let fired = false;
+    item.addEventListener('open', () => { fired = true; });
+    item.show();
+    expect(fired).toBe(true);
+  });
+
+  it('dispatches "close" event when closed', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    item.show();
+    let fired = false;
+    item.addEventListener('close', () => { fired = true; });
+    item.close();
+    expect(fired).toBe(true);
+  });
+
+  it('opens on trigger click', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    const trigger = item.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.click();
+    expect(item.open).toBe(true);
+  });
+
+  it('opens on trigger Enter key', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    const trigger = item.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(item.open).toBe(true);
+  });
+
+  it('opens on trigger Space key', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    const trigger = item.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(item.open).toBe(true);
+  });
+
+  it('opens on ArrowDown key', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    const trigger = item.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(item.open).toBe(true);
+  });
+
+  it('sets aria-expanded on trigger', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    const trigger = item.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    item.show();
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('sets aria-haspopup on trigger when content present', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    const trigger = item.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    expect(trigger.getAttribute('aria-haspopup')).toBe('true');
+  });
+
+  it('sets aria-controls on trigger matching content id', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    const trigger = item.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    const content = item.querySelector('elx-navigation-menu-content') as HTMLElement;
+    expect(trigger.getAttribute('aria-controls')).toBe(content.id);
+  });
+
+  it('shows content when item opens', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    item.show();
+    const content = item.querySelector('elx-navigation-menu-content') as HTMLElement;
+    expect(content.hasAttribute('visible')).toBe(true);
+  });
+
+  it('hides content when item closes', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    item.show();
+    item.close();
+    const content = item.querySelector('elx-navigation-menu-content') as HTMLElement;
+    expect(content.hasAttribute('visible')).toBe(false);
+  });
+
+  it('closes siblings when opening a new item', () => {
+    const el = makeMenu();
+    const item1 = makeItem(true);
+    const item2 = makeItem(true);
+    el.appendChild(item1);
+    el.appendChild(item2);
+    item1.show();
+    expect(item1.open).toBe(true);
+    item2.show();
+    expect(item1.open).toBe(false);
+    expect(item2.open).toBe(true);
+  });
+
+  it('opens on mouseenter', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+    expect(item.open).toBe(true);
+  });
+
+  it('closes on mouseleave', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    item.show();
+    item.dispatchEvent(new MouseEvent('mouseleave'));
+    expect(item.open).toBe(false);
+  });
+
+  it('does not rebuild DOM on re-connection', () => {
+    const item = makeItem(true);
+    document.body.appendChild(item);
+    const trigger = item.shadowRoot!.querySelector('.trigger');
+    document.body.removeChild(item);
+    document.body.appendChild(item);
+    expect(item.shadowRoot!.querySelector('.trigger')).toBe(trigger);
+  });
+
+  // === ElxNavigationMenuContent ===
+
+  it('renders content with shadow DOM', () => {
+    const content = document.createElement('elx-navigation-menu-content');
+    document.body.appendChild(content);
+    expect(content.shadowRoot).toBeTruthy();
+  });
+
+  it('has role="menu" on content', () => {
+    const content = document.createElement('elx-navigation-menu-content');
+    document.body.appendChild(content);
+    expect(content.getAttribute('role')).toBe('menu');
+  });
+
+  it('has aria-hidden="true" when not visible', () => {
+    const content = document.createElement('elx-navigation-menu-content');
+    document.body.appendChild(content);
+    expect(content.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('has aria-hidden="false" when visible', () => {
+    const content = document.createElement('elx-navigation-menu-content');
+    document.body.appendChild(content);
+    content.setAttribute('visible', '');
+    expect(content.getAttribute('aria-hidden')).toBe('false');
+  });
+
+  it('has part="content" on wrapper', () => {
+    const content = document.createElement('elx-navigation-menu-content');
+    document.body.appendChild(content);
+    expect(content.shadowRoot!.querySelector('[part="content"]')).toBeTruthy();
+  });
+});

--- a/src/components/navigation-menu/navigation-menu.ts
+++ b/src/components/navigation-menu/navigation-menu.ts
@@ -1,0 +1,413 @@
+// ── Styles ──────────────────────────────────────────────────────────
+
+const navMenuStyles = `
+  :host {
+    --elx-nav-menu-bg: var(--elx-color-surface, #ffffff);
+    --elx-nav-menu-border: var(--elx-color-border, #e2e8f0);
+    --elx-nav-menu-gap: 0.25rem;
+    display: block;
+  }
+
+  .nav-menu {
+    display: flex;
+    align-items: center;
+    gap: var(--elx-nav-menu-gap);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+`;
+
+const navMenuItemStyles = `
+  :host {
+    position: relative;
+    display: inline-block;
+  }
+
+  .trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: var(--elx-nav-menu-item-padding, 0.5rem 0.75rem);
+    border: none;
+    background: none;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    border-radius: var(--elx-radius-md, 0.375rem);
+    transition: background-color 0.15s;
+    outline: none;
+    white-space: nowrap;
+  }
+
+  .trigger:hover,
+  .trigger:focus-visible {
+    background: var(--elx-nav-menu-item-hover, var(--elx-color-surface-hover, #f1f5f9));
+  }
+
+  :host([open]) .trigger {
+    background: var(--elx-nav-menu-item-hover, var(--elx-color-surface-hover, #f1f5f9));
+  }
+
+  :host([disabled]) .trigger {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .arrow {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    transition: transform 0.2s;
+  }
+
+  .arrow svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  :host([open]) .arrow {
+    transform: rotate(180deg);
+  }
+`;
+
+const navMenuContentStyles = `
+  :host {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    display: none;
+    min-width: var(--elx-nav-menu-content-min-width, 200px);
+    padding: var(--elx-nav-menu-content-padding, 0.75rem);
+    margin-top: 0.25rem;
+    background: var(--elx-nav-menu-bg, var(--elx-color-surface, #ffffff));
+    border: 1px solid var(--elx-nav-menu-border, var(--elx-color-border, #e2e8f0));
+    border-radius: var(--elx-radius-lg, 0.5rem);
+    box-shadow: var(--elx-nav-menu-shadow, var(--elx-shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.1)));
+    opacity: 0;
+    transition: opacity 150ms ease;
+  }
+
+  :host([visible]) {
+    display: block;
+    opacity: 1;
+  }
+`;
+
+// ── ElxNavigationMenu ───────────────────────────────────────────────
+
+export class ElxNavigationMenu extends HTMLElement {
+  private _boundKeydown: (e: KeyboardEvent) => void;
+  private _boundClickOutside: (e: Event) => void;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._boundKeydown = this._handleKeydown.bind(this);
+    this._boundClickOutside = this._handleClickOutside.bind(this);
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot!.querySelector('.nav-menu')) this._buildDom();
+    document.addEventListener('keydown', this._boundKeydown);
+    document.addEventListener('click', this._boundClickOutside);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('keydown', this._boundKeydown);
+    document.removeEventListener('click', this._boundClickOutside);
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = navMenuStyles;
+
+    const nav = document.createElement('nav');
+    nav.setAttribute('part', 'nav');
+    nav.setAttribute('aria-label', this.getAttribute('aria-label') || 'Main navigation');
+
+    const list = document.createElement('div');
+    list.className = 'nav-menu';
+    list.setAttribute('role', 'menubar');
+    list.setAttribute('part', 'list');
+    const slot = document.createElement('slot');
+    list.appendChild(slot);
+
+    nav.appendChild(list);
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(nav);
+  }
+
+  private _getItems(): HTMLElement[] {
+    const items: HTMLElement[] = [];
+    this.querySelectorAll('elx-navigation-menu-item:not([disabled])').forEach(el => items.push(el as HTMLElement));
+    return items;
+  }
+
+  private _handleKeydown(e: KeyboardEvent) {
+    const items = this._getItems();
+    if (items.length === 0) return;
+
+    const active = document.activeElement;
+    // Check if focus is within one of our items
+    let currentIdx = -1;
+    for (let i = 0; i < items.length; i++) {
+      if (items[i] === active || items[i].contains(active as Node)) {
+        currentIdx = i;
+        break;
+      }
+    }
+    if (currentIdx === -1) return;
+
+    const currentItem = items[currentIdx] as any;
+
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      currentItem.close?.();
+      const next = currentIdx < items.length - 1 ? currentIdx + 1 : 0;
+      (items[next] as any).focusTrigger?.();
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      currentItem.close?.();
+      const prev = currentIdx > 0 ? currentIdx - 1 : items.length - 1;
+      (items[prev] as any).focusTrigger?.();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      currentItem.close?.();
+      currentItem.focusTrigger?.();
+    }
+  }
+
+  private _handleClickOutside(e: Event) {
+    const path = e.composedPath();
+    if (path.indexOf(this) === -1) {
+      this.closeAll();
+    }
+  }
+
+  closeAll() {
+    this._getItems().forEach(item => (item as any).close?.());
+  }
+}
+
+// ── ElxNavigationMenuItem ───────────────────────────────────────────
+
+export class ElxNavigationMenuItem extends HTMLElement {
+  static observedAttributes = ['open', 'disabled'];
+
+  private _contentId = `elx-nav-content-${Math.random().toString(36).slice(2, 9)}`;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot!.querySelector('.trigger')) this._buildDom();
+    this._update();
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'none');
+    }
+  }
+
+  disconnectedCallback() {
+    // Listeners are on shadow DOM elements, cleaned up automatically
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    this._update();
+  }
+
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+  set open(val: boolean) {
+    val ? this.setAttribute('open', '') : this.removeAttribute('open');
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
+
+  show() {
+    if (this.disabled || this.open) return;
+    // Close siblings
+    const parent = this.closest('elx-navigation-menu') as any;
+    if (parent) parent.closeAll();
+    this.open = true;
+    this.dispatchEvent(new CustomEvent('open', { bubbles: true, composed: true }));
+    // Show content
+    const content = this.querySelector('elx-navigation-menu-content') as HTMLElement;
+    if (content) content.setAttribute('visible', '');
+  }
+
+  close() {
+    if (!this.open) return;
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+    const content = this.querySelector('elx-navigation-menu-content') as HTMLElement;
+    if (content) content.removeAttribute('visible');
+  }
+
+  toggle() {
+    this.open ? this.close() : this.show();
+  }
+
+  focusTrigger() {
+    const trigger = this.shadowRoot?.querySelector('.trigger') as HTMLElement;
+    trigger?.focus();
+  }
+
+  private _onTriggerClick = () => {
+    if (this.disabled) return;
+    this.toggle();
+  };
+
+  private _onTriggerKeydown = (e: KeyboardEvent) => {
+    if (this.disabled) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.toggle();
+    } else if (e.key === 'ArrowDown' && !this.open) {
+      e.preventDefault();
+      this.show();
+    }
+  };
+
+  private _onMouseEnter = () => {
+    if (!this.disabled) this.show();
+  };
+
+  private _onMouseLeave = () => {
+    this.close();
+  };
+
+  private _hasContent(): boolean {
+    return !!this.querySelector('elx-navigation-menu-content');
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = navMenuItemStyles;
+
+    const trigger = document.createElement('button');
+    trigger.className = 'trigger';
+    trigger.setAttribute('part', 'trigger');
+    trigger.setAttribute('role', 'menuitem');
+
+    const labelSlot = document.createElement('slot');
+    labelSlot.name = 'trigger';
+    trigger.appendChild(labelSlot);
+
+    // Arrow indicator for items with content
+    const arrow = document.createElement('span');
+    arrow.className = 'arrow';
+    arrow.setAttribute('aria-hidden', 'true');
+    arrow.innerHTML = '<svg viewBox="0 0 10 6" fill="none"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    trigger.appendChild(arrow);
+
+    const contentSlot = document.createElement('slot');
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(trigger);
+    this.shadowRoot!.appendChild(contentSlot);
+
+    trigger.addEventListener('click', this._onTriggerClick);
+    trigger.addEventListener('keydown', this._onTriggerKeydown);
+
+    // Hover to open/close
+    this.addEventListener('mouseenter', this._onMouseEnter);
+    this.addEventListener('mouseleave', this._onMouseLeave);
+  }
+
+  private _update() {
+    const trigger = this.shadowRoot?.querySelector('.trigger') as HTMLElement;
+    if (!trigger) return;
+
+    const hasContent = this._hasContent();
+    trigger.setAttribute('aria-expanded', String(this.open));
+    if (hasContent) {
+      trigger.setAttribute('aria-haspopup', 'true');
+      trigger.setAttribute('aria-controls', this._contentId);
+    }
+
+    // Hide arrow if no content
+    const arrow = this.shadowRoot?.querySelector('.arrow') as HTMLElement;
+    if (arrow) {
+      arrow.style.display = hasContent ? 'inline-block' : 'none';
+    }
+
+    // Sync content visibility
+    const content = this.querySelector('elx-navigation-menu-content') as HTMLElement;
+    if (content) {
+      content.id = this._contentId;
+      if (this.open) {
+        content.setAttribute('visible', '');
+      } else {
+        content.removeAttribute('visible');
+      }
+    }
+  }
+}
+
+// ── ElxNavigationMenuContent ────────────────────────────────────────
+
+export class ElxNavigationMenuContent extends HTMLElement {
+  static observedAttributes = ['visible'];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot!.querySelector('slot')) this._buildDom();
+    this.setAttribute('role', 'menu');
+    this.setAttribute('aria-hidden', String(!this.hasAttribute('visible')));
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    this.setAttribute('aria-hidden', String(!this.hasAttribute('visible')));
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = navMenuContentStyles;
+
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('part', 'content');
+    const slot = document.createElement('slot');
+    wrapper.appendChild(slot);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(wrapper);
+  }
+}
+
+// ── Registration ────────────────────────────────────────────────────
+
+if (!customElements.get('elx-navigation-menu')) {
+  customElements.define('elx-navigation-menu', ElxNavigationMenu);
+}
+if (!customElements.get('elx-navigation-menu-item')) {
+  customElements.define('elx-navigation-menu-item', ElxNavigationMenuItem);
+}
+if (!customElements.get('elx-navigation-menu-content')) {
+  customElements.define('elx-navigation-menu-content', ElxNavigationMenuContent);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'elx-navigation-menu': ElxNavigationMenu;
+    'elx-navigation-menu-item': ElxNavigationMenuItem;
+    'elx-navigation-menu-content': ElxNavigationMenuContent;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,3 +40,4 @@ export * from './components/collapsible/collapsible';
 export * from './components/scroll-area/scroll-area';
 export * from './components/aspect-ratio/aspect-ratio';
 export * from './components/hover-card/hover-card';
+export * from './components/navigation-menu/navigation-menu';


### PR DESCRIPTION
## Overview
Adds `elx-navigation-menu`, `elx-navigation-menu-item`, and `elx-navigation-menu-content` — a top-level navigation bar with dropdown support.

## Features
- Three sub-components: `elx-navigation-menu` (container), `elx-navigation-menu-item` (trigger with dropdown), `elx-navigation-menu-content` (dropdown panel)
- Horizontal layout with dropdown panels
- Opens on hover and click
- Keyboard navigation: ArrowLeft/ArrowRight to move between items, ArrowDown to open, Escape to close
- `aria-expanded`, `aria-haspopup`, `aria-controls` on triggers
- `role="menubar"` on container, `role="menuitem"` on triggers, `role="menu"` on content
- Part attributes for external styling
- Click-outside closes all open items
- Opening a new item closes siblings

## Testing
- 36 tests covering rendering, open/close, hover, keyboard, ARIA, disabled state, re-connection
- All 751 tests pass (full suite)

## Stories
- 6 stories: default, with icons, nested dropdowns, disabled, rich content, many items