### PR TITLE
feat: add ContextMenu component

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "40 kB",
+      "limit": "40.5 kB",
       "gzip": true
     },
     {

--- a/src/components/context-menu/context-menu.stories.ts
+++ b/src/components/context-menu/context-menu.stories.ts
@@ -19,8 +19,8 @@ type Story = StoryObj;
 
 export const Default: Story = {
   render: () => html`
-    <elx-context-menu>
-      <div slot="trigger" style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
+    <elx-context-menu label="Edit menu">
+      <div style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
         Right-click here
       </div>
       <elx-context-menu-item value="copy">Copy</elx-context-menu-item>
@@ -34,8 +34,8 @@ export const Default: Story = {
 
 export const WithDisabledItems: Story = {
   render: () => html`
-    <elx-context-menu>
-      <div slot="trigger" style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
+    <elx-context-menu label="Edit menu">
+      <div style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
         Right-click here
       </div>
       <elx-context-menu-item value="copy">Copy</elx-context-menu-item>
@@ -49,8 +49,8 @@ export const WithDisabledItems: Story = {
 
 export const WithIcons: Story = {
   render: () => html`
-    <elx-context-menu>
-      <div slot="trigger" style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
+    <elx-context-menu label="Edit menu">
+      <div style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
         Right-click here
       </div>
       <elx-context-menu-item value="copy">
@@ -76,8 +76,8 @@ export const WithIcons: Story = {
 
 export const WithShortcuts: Story = {
   render: () => html`
-    <elx-context-menu>
-      <div slot="trigger" style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
+    <elx-context-menu label="Edit menu">
+      <div style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
         Right-click here
       </div>
       <elx-context-menu-item value="copy">

--- a/src/components/context-menu/context-menu.stories.ts
+++ b/src/components/context-menu/context-menu.stories.ts
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './context-menu.js';
+
+const meta: Meta = {
+  title: 'Components/ContextMenu',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'A right-click context menu component. Right-click the trigger area to open.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`
+    <elx-context-menu>
+      <div slot="trigger" style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
+        Right-click here
+      </div>
+      <elx-context-menu-item value="copy">Copy</elx-context-menu-item>
+      <elx-context-menu-item value="cut">Cut</elx-context-menu-item>
+      <elx-context-menu-item value="paste">Paste</elx-context-menu-item>
+      <elx-context-menu-divider></elx-context-menu-divider>
+      <elx-context-menu-item value="delete">Delete</elx-context-menu-item>
+    </elx-context-menu>
+  `,
+};
+
+export const WithDisabledItems: Story = {
+  render: () => html`
+    <elx-context-menu>
+      <div slot="trigger" style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
+        Right-click here
+      </div>
+      <elx-context-menu-item value="copy">Copy</elx-context-menu-item>
+      <elx-context-menu-item value="cut" disabled>Cut (disabled)</elx-context-menu-item>
+      <elx-context-menu-item value="paste" disabled>Paste (disabled)</elx-context-menu-item>
+      <elx-context-menu-divider></elx-context-menu-divider>
+      <elx-context-menu-item value="delete">Delete</elx-context-menu-item>
+    </elx-context-menu>
+  `,
+};
+
+export const WithIcons: Story = {
+  render: () => html`
+    <elx-context-menu>
+      <div slot="trigger" style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
+        Right-click here
+      </div>
+      <elx-context-menu-item value="copy">
+        <span slot="prefix">📋</span>
+        Copy
+      </elx-context-menu-item>
+      <elx-context-menu-item value="cut">
+        <span slot="prefix">✂️</span>
+        Cut
+      </elx-context-menu-item>
+      <elx-context-menu-item value="paste">
+        <span slot="prefix">📌</span>
+        Paste
+      </elx-context-menu-item>
+      <elx-context-menu-divider></elx-context-menu-divider>
+      <elx-context-menu-item value="delete">
+        <span slot="prefix">🗑️</span>
+        Delete
+      </elx-context-menu-item>
+    </elx-context-menu>
+  `,
+};
+
+export const WithShortcuts: Story = {
+  render: () => html`
+    <elx-context-menu>
+      <div slot="trigger" style="padding: 2rem; border: 2px dashed #e2e8f0; border-radius: 0.5rem; text-align: center; color: #64748b; user-select: none;">
+        Right-click here
+      </div>
+      <elx-context-menu-item value="copy">
+        Copy
+        <span slot="suffix" style="font-size: 0.75rem; color: #94a3b8;">⌘C</span>
+      </elx-context-menu-item>
+      <elx-context-menu-item value="cut">
+        Cut
+        <span slot="suffix" style="font-size: 0.75rem; color: #94a3b8;">⌘X</span>
+      </elx-context-menu-item>
+      <elx-context-menu-item value="paste">
+        Paste
+        <span slot="suffix" style="font-size: 0.75rem; color: #94a3b8;">⌘V</span>
+      </elx-context-menu-item>
+      <elx-context-menu-divider></elx-context-menu-divider>
+      <elx-context-menu-item value="select-all">
+        Select All
+        <span slot="suffix" style="font-size: 0.75rem; color: #94a3b8;">⌘A</span>
+      </elx-context-menu-item>
+    </elx-context-menu>
+  `,
+};

--- a/src/components/context-menu/context-menu.test.ts
+++ b/src/components/context-menu/context-menu.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import './context-menu';
+
+function createMenu(items = 3, opts: { disabled?: number[] } = {}): HTMLElement {
+  const el = document.createElement('elx-context-menu') as any;
+  for (let i = 0; i < items; i++) {
+    const item = document.createElement('elx-context-menu-item');
+    item.textContent = 'Item ' + (i + 1);
+    item.setAttribute('value', 'item-' + (i + 1));
+    if (opts.disabled) {
+      for (let d = 0; d < opts.disabled.length; d++) {
+        if (opts.disabled[d] === i) {
+          item.setAttribute('disabled', '');
+        }
+      }
+    }
+    el.appendChild(item);
+  }
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('elx-context-menu', () => {
+  it('should be defined as a custom element', () => {
+    expect(customElements.get('elx-context-menu')).toBeDefined();
+  });
+
+  it('should render shadow DOM with menu role', () => {
+    const el = createMenu();
+    const menu = el.shadowRoot!.querySelector('.context-menu');
+    expect(menu).toBeTruthy();
+    expect(menu!.getAttribute('role')).toBe('menu');
+    expect(menu!.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('should have part attribute on menu', () => {
+    const el = createMenu();
+    const menu = el.shadowRoot!.querySelector('.context-menu');
+    expect(menu!.getAttribute('part')).toBe('menu');
+  });
+
+  it('should be closed by default', () => {
+    const el = createMenu() as any;
+    expect(el.open).toBe(false);
+    const menu = el.shadowRoot!.querySelector('.context-menu');
+    expect(menu!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('should open at specified position via show()', () => {
+    const el = createMenu() as any;
+    el.show(100, 200);
+    expect(el.open).toBe(true);
+    const menu = el.shadowRoot!.querySelector('.context-menu') as HTMLElement;
+    expect(menu.style.left).toBe('100px');
+    expect(menu.style.top).toBe('200px');
+  });
+
+  it('should dispatch open event on show()', () => {
+    const el = createMenu() as any;
+    const spy = vi.fn();
+    el.addEventListener('open', spy);
+    el.show(0, 0);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close via hide()', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    el.hide();
+    expect(el.open).toBe(false);
+  });
+
+  it('should dispatch close event on hide()', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    const spy = vi.fn();
+    el.addEventListener('close', spy);
+    el.hide();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should open on contextmenu event', () => {
+    const el = createMenu() as any;
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 150,
+      clientY: 250,
+    });
+    el.dispatchEvent(event);
+    expect(el.open).toBe(true);
+    const menu = el.shadowRoot!.querySelector('.context-menu') as HTMLElement;
+    expect(menu.style.left).toBe('150px');
+    expect(menu.style.top).toBe('250px');
+  });
+
+  it('should prevent default on contextmenu', () => {
+    const el = createMenu() as any;
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 0,
+      clientY: 0,
+    });
+    const spy = vi.spyOn(event, 'preventDefault');
+    el.dispatchEvent(event);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should close on Escape key', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(el.open).toBe(false);
+  });
+
+  it('should close on outside click', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(el.open).toBe(false);
+  });
+
+  it('should not close on click inside', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(el.open).toBe(true);
+  });
+
+  it('should navigate items with ArrowDown', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    const items = el.querySelectorAll('elx-context-menu-item');
+    const focused = items[0].shadowRoot!.querySelector('.menu-item');
+    expect(focused).toBe(document.activeElement?.shadowRoot?.querySelector('.menu-item') || focused);
+  });
+
+  it('should navigate items with ArrowUp', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    // Should wrap to last item
+    const items = el.querySelectorAll('elx-context-menu-item');
+    expect(items.length).toBe(3);
+  });
+
+  it('should navigate to first item with Home', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(el.open).toBe(true);
+  });
+
+  it('should navigate to last item with End', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(el.open).toBe(true);
+  });
+
+  it('should skip disabled items in navigation', () => {
+    const el = createMenu(3, { disabled: [0] }) as any;
+    el.show(0, 0);
+    const items = el.querySelectorAll('elx-context-menu-item:not([disabled])');
+    expect(items.length).toBe(2);
+  });
+
+  it('should clean up listeners on disconnect', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    el.remove();
+    // Should not throw when dispatching events after removal
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  it('should re-attach listeners on reconnect', () => {
+    const el = createMenu() as any;
+    el.remove();
+    document.body.appendChild(el);
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 50,
+      clientY: 60,
+    });
+    el.dispatchEvent(event);
+    expect(el.open).toBe(true);
+  });
+});
+
+describe('elx-context-menu-item', () => {
+  it('should be defined as a custom element', () => {
+    expect(customElements.get('elx-context-menu-item')).toBeDefined();
+  });
+
+  it('should render with menuitem role', () => {
+    const el = createMenu();
+    const item = el.querySelector('elx-context-menu-item')!;
+    expect(item.getAttribute('role')).toBe('menuitem');
+  });
+
+  it('should have part attribute on base', () => {
+    const el = createMenu();
+    const item = el.querySelector('elx-context-menu-item')!;
+    const base = item.shadowRoot!.querySelector('.menu-item');
+    expect(base!.getAttribute('part')).toBe('base');
+  });
+
+  it('should have tabindex 0 by default', () => {
+    const el = createMenu();
+    const item = el.querySelector('elx-context-menu-item')!;
+    expect(item.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should have tabindex -1 when disabled', () => {
+    const el = createMenu(3, { disabled: [0] });
+    const item = el.querySelector('elx-context-menu-item[disabled]')!;
+    expect(item.getAttribute('tabindex')).toBe('-1');
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('should dispatch select event on click', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    const item = el.querySelector('elx-context-menu-item')!;
+    const spy = vi.fn();
+    el.addEventListener('elx-context-menu-select', spy);
+    item.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail.value).toBe('item-1');
+  });
+
+  it('should close menu on item click', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    const item = el.querySelector('elx-context-menu-item')!;
+    item.click();
+    expect(el.open).toBe(false);
+  });
+
+  it('should not dispatch select when disabled', () => {
+    const el = createMenu(3, { disabled: [0] }) as any;
+    el.show(0, 0);
+    const item = el.querySelector('elx-context-menu-item[disabled]')!;
+    const spy = vi.fn();
+    el.addEventListener('elx-context-menu-select', spy);
+    item.click();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should activate on Enter key', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    const item = el.querySelector('elx-context-menu-item')!;
+    const spy = vi.fn();
+    el.addEventListener('elx-context-menu-select', spy);
+    item.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should activate on Space key', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    const item = el.querySelector('elx-context-menu-item')!;
+    const spy = vi.fn();
+    el.addEventListener('elx-context-menu-select', spy);
+    item.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should toggle disabled via property', () => {
+    const el = createMenu();
+    const item = el.querySelector('elx-context-menu-item') as any;
+    item.disabled = true;
+    expect(item.getAttribute('disabled')).toBe('');
+    expect(item.getAttribute('tabindex')).toBe('-1');
+    item.disabled = false;
+    expect(item.hasAttribute('disabled')).toBe(false);
+    expect(item.getAttribute('tabindex')).toBe('0');
+  });
+});
+
+describe('elx-context-menu-divider', () => {
+  it('should be defined as a custom element', () => {
+    expect(customElements.get('elx-context-menu-divider')).toBeDefined();
+  });
+
+  it('should render with separator role', () => {
+    const el = document.createElement('elx-context-menu-divider');
+    document.body.appendChild(el);
+    expect(el.getAttribute('role')).toBe('separator');
+    expect(el.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('should render divider element', () => {
+    const el = document.createElement('elx-context-menu-divider');
+    document.body.appendChild(el);
+    const divider = el.shadowRoot!.querySelector('.divider');
+    expect(divider).toBeTruthy();
+  });
+});

--- a/src/components/context-menu/context-menu.test.ts
+++ b/src/components/context-menu/context-menu.test.ts
@@ -193,6 +193,39 @@ describe('elx-context-menu', () => {
     el.dispatchEvent(event);
     expect(el.open).toBe(true);
   });
+
+  it('should close on Tab key', () => {
+    const el = createMenu() as any;
+    el.show(0, 0);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(el.open).toBe(false);
+  });
+
+  it('should update aria-hidden when open attribute changes', () => {
+    const el = createMenu() as any;
+    el.setAttribute('open', '');
+    const menu = el.shadowRoot!.querySelector('.context-menu');
+    expect(menu!.getAttribute('aria-hidden')).toBe('false');
+    el.removeAttribute('open');
+    expect(menu!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('should support label attribute for aria-label', () => {
+    const el = document.createElement('elx-context-menu') as any;
+    el.setAttribute('label', 'Edit options');
+    document.body.appendChild(el);
+    const menu = el.shadowRoot!.querySelector('.context-menu');
+    expect(menu!.getAttribute('aria-label')).toBe('Edit options');
+  });
+
+  it('should update aria-label when label attribute changes', () => {
+    const el = createMenu() as any;
+    el.setAttribute('label', 'Context options');
+    const menu = el.shadowRoot!.querySelector('.context-menu');
+    expect(menu!.getAttribute('aria-label')).toBe('Context options');
+    el.setAttribute('label', 'New label');
+    expect(menu!.getAttribute('aria-label')).toBe('New label');
+  });
 });
 
 describe('elx-context-menu-item', () => {

--- a/src/components/context-menu/context-menu.ts
+++ b/src/components/context-menu/context-menu.ts
@@ -1,0 +1,388 @@
+const contextMenuStyles = `
+  :host {
+    --elx-context-menu-bg: var(--elx-color-surface, #ffffff);
+    --elx-context-menu-border: var(--elx-color-border, #e2e8f0);
+    --elx-context-menu-radius: var(--elx-radius-md, 0.5rem);
+    --elx-context-menu-shadow: var(--elx-shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.1));
+    --elx-context-menu-item-hover: var(--elx-color-surface-hover, #f1f5f9);
+    --elx-context-menu-item-padding: 0.5rem 0.75rem;
+    --elx-context-menu-item-gap: 0.5rem;
+    --elx-context-menu-divider: var(--elx-color-border, #e2e8f0);
+    display: contents;
+  }
+
+  .context-menu {
+    position: fixed;
+    background: var(--elx-context-menu-bg);
+    border: 1px solid var(--elx-context-menu-border);
+    border-radius: var(--elx-context-menu-radius);
+    box-shadow: var(--elx-context-menu-shadow);
+    padding: 0.25rem 0;
+    min-width: 160px;
+    z-index: 10000;
+    opacity: 0;
+    visibility: hidden;
+    transform: scale(0.95);
+    transform-origin: top left;
+    transition: opacity 150ms ease, visibility 150ms ease, transform 150ms ease;
+  }
+
+  :host([open]) .context-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+  }
+
+  ::slotted(elx-context-menu-item) {
+    display: block;
+  }
+
+  ::slotted(elx-context-menu-divider) {
+    display: block;
+  }
+`;
+
+const contextMenuItemStyles = `
+  :host {
+    display: block;
+  }
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: var(--elx-context-menu-item-gap, 0.5rem);
+    padding: var(--elx-context-menu-item-padding, 0.5rem 0.75rem);
+    cursor: pointer;
+    border: none;
+    background: none;
+    width: 100%;
+    text-align: start;
+    font: inherit;
+    color: inherit;
+    outline: none;
+    transition: background-color 0.15s;
+  }
+
+  .menu-item:hover,
+  .menu-item:focus-visible {
+    background: var(--elx-context-menu-item-hover, #f1f5f9);
+  }
+
+  .menu-item:focus-visible {
+    outline: 2px solid var(--elx-color-primary-500, #3b82f6);
+    outline-offset: -2px;
+  }
+
+  :host([disabled]) .menu-item {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  ::slotted([slot="prefix"]) {
+    flex-shrink: 0;
+  }
+
+  ::slotted([slot="suffix"]) {
+    flex-shrink: 0;
+    margin-inline-start: auto;
+  }
+`;
+
+const contextMenuDividerStyles = `
+  :host {
+    display: block;
+  }
+
+  .divider {
+    height: 1px;
+    background: var(--elx-context-menu-divider, #e2e8f0);
+    margin: 0.25rem 0;
+  }
+`;
+
+export class ElxContextMenu extends HTMLElement {
+  private _onContextMenu: (e: Event) => void;
+  private _onClickOutside: (e: Event) => void;
+  private _onKeydown: (e: KeyboardEvent) => void;
+  private _menuElement: HTMLElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._onContextMenu = (e: Event) => this._handleContextMenu(e);
+    this._onClickOutside = (e: Event) => this._handleClickOutside(e);
+    this._onKeydown = (e: KeyboardEvent) => this._handleKeydown(e);
+  }
+
+  connectedCallback() {
+    this._buildDom();
+    this._update();
+    this.addEventListener('contextmenu', this._onContextMenu);
+    document.addEventListener('click', this._onClickOutside);
+    document.addEventListener('keydown', this._onKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('contextmenu', this._onContextMenu);
+    document.removeEventListener('click', this._onClickOutside);
+    document.removeEventListener('keydown', this._onKeydown);
+  }
+
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+
+  set open(val: boolean) {
+    val ? this.setAttribute('open', '') : this.removeAttribute('open');
+  }
+
+  show(x: number, y: number) {
+    this.open = true;
+    if (this._menuElement) {
+      this._menuElement.style.left = x + 'px';
+      this._menuElement.style.top = y + 'px';
+    }
+    this.dispatchEvent(new CustomEvent('open', { bubbles: true, composed: true }));
+    this._focusFirst();
+  }
+
+  hide() {
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+  }
+
+  private _handleContextMenu(e: Event) {
+    const evt = e as MouseEvent;
+    evt.preventDefault();
+    this.show(evt.clientX, evt.clientY);
+  }
+
+  private _handleClickOutside(e: Event) {
+    if (!this.open) return;
+    const path = e.composedPath();
+    let found = false;
+    for (let i = 0; i < path.length; i++) {
+      if (path[i] === this) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      this.hide();
+    }
+  }
+
+  private _handleKeydown(e: KeyboardEvent) {
+    if (!this.open) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.hide();
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      this._focusItem(1);
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      this._focusItem(-1);
+    }
+    if (e.key === 'Home') {
+      e.preventDefault();
+      this._focusItem(0, true);
+    }
+    if (e.key === 'End') {
+      e.preventDefault();
+      this._focusItem(-1, true);
+    }
+  }
+
+  private _getItems(): ElxContextMenuItem[] {
+    const items: ElxContextMenuItem[] = [];
+    this.querySelectorAll('elx-context-menu-item:not([disabled])').forEach(el => {
+      items.push(el as ElxContextMenuItem);
+    });
+    return items;
+  }
+
+  private _focusItem(direction: number, absolute = false) {
+    const items = this._getItems();
+    if (items.length === 0) return;
+    const active = document.activeElement as HTMLElement;
+    let currentIndex = -1;
+    for (let i = 0; i < items.length; i++) {
+      if (items[i] === active) {
+        currentIndex = i;
+        break;
+      }
+    }
+    let nextIndex: number;
+    if (absolute) {
+      nextIndex = direction >= 0 ? 0 : items.length - 1;
+    } else if (currentIndex === -1) {
+      nextIndex = direction > 0 ? 0 : items.length - 1;
+    } else {
+      nextIndex = (currentIndex + direction + items.length) % items.length;
+    }
+    const item = items[nextIndex];
+    const inner = item.shadowRoot?.querySelector('.menu-item') as HTMLElement;
+    inner?.focus();
+  }
+
+  private _focusFirst() {
+    const items = this._getItems();
+    if (items.length > 0) {
+      const inner = items[0].shadowRoot?.querySelector('.menu-item') as HTMLElement;
+      inner?.focus();
+    }
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = contextMenuStyles;
+
+    const menu = document.createElement('div');
+    menu.className = 'context-menu';
+    menu.setAttribute('role', 'menu');
+    menu.setAttribute('aria-orientation', 'vertical');
+    menu.setAttribute('part', 'menu');
+    const slot = document.createElement('slot');
+    menu.appendChild(slot);
+
+    this._menuElement = menu;
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(menu);
+  }
+
+  private _update() {
+    const menu = this.shadowRoot?.querySelector('.context-menu');
+    if (menu) {
+      menu.setAttribute('aria-hidden', String(!this.open));
+    }
+  }
+}
+
+export class ElxContextMenuItem extends HTMLElement {
+  static observedAttributes = ['disabled'];
+
+  private _rendered = false;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this._rendered) {
+      this._render();
+      this._rendered = true;
+    }
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'menuitem');
+    }
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', this.hasAttribute('disabled') ? '-1' : '0');
+    }
+    if (this.hasAttribute('disabled')) {
+      this.setAttribute('aria-disabled', 'true');
+    }
+    this.addEventListener('click', this._handleClick);
+    this.addEventListener('keydown', this._handleKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('click', this._handleClick);
+    this.removeEventListener('keydown', this._handleKeydown);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(val: boolean) {
+    if (val) {
+      this.setAttribute('disabled', '');
+      this.setAttribute('tabindex', '-1');
+    } else {
+      this.removeAttribute('disabled');
+      this.setAttribute('tabindex', '0');
+    }
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    if (_name === 'disabled') {
+      this.setAttribute('tabindex', newVal !== null ? '-1' : '0');
+      if (newVal !== null) {
+        this.setAttribute('aria-disabled', 'true');
+      } else {
+        this.removeAttribute('aria-disabled');
+      }
+    }
+  }
+
+  private _handleClick = () => {
+    if (this.disabled) return;
+    this.dispatchEvent(new CustomEvent('elx-context-menu-select', {
+      bubbles: true,
+      composed: true,
+      detail: { value: this.getAttribute('value') || this.textContent?.trim() },
+    }));
+    const menu = this.closest('elx-context-menu') as ElxContextMenu;
+    menu?.hide();
+  };
+
+  private _handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this._handleClick();
+    }
+  };
+
+  private _render() {
+    this.shadowRoot!.innerHTML = `
+      <style>${contextMenuItemStyles}</style>
+      <div class="menu-item" part="base">
+        <slot name="prefix"></slot>
+        <slot></slot>
+        <slot name="suffix"></slot>
+      </div>
+    `;
+  }
+}
+
+export class ElxContextMenuDivider extends HTMLElement {
+  private _rendered = false;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this._rendered) {
+      this._render();
+      this._rendered = true;
+    }
+    this.setAttribute('role', 'separator');
+    this.setAttribute('aria-hidden', 'true');
+  }
+
+  private _render() {
+    this.shadowRoot!.innerHTML = `
+      <style>${contextMenuDividerStyles}</style>
+      <div class="divider"></div>
+    `;
+  }
+}
+
+if (!customElements.get('elx-context-menu')) {
+  customElements.define('elx-context-menu', ElxContextMenu);
+}
+if (!customElements.get('elx-context-menu-item')) {
+  customElements.define('elx-context-menu-item', ElxContextMenuItem);
+}
+if (!customElements.get('elx-context-menu-divider')) {
+  customElements.define('elx-context-menu-divider', ElxContextMenuDivider);
+}

--- a/src/components/context-menu/context-menu.ts
+++ b/src/components/context-menu/context-menu.ts
@@ -102,6 +102,8 @@ const contextMenuDividerStyles = `
 `;
 
 export class ElxContextMenu extends HTMLElement {
+  static observedAttributes = ['open', 'label'];
+
   private _onContextMenu: (e: Event) => void;
   private _onClickOutside: (e: Event) => void;
   private _onKeydown: (e: KeyboardEvent) => void;
@@ -129,6 +131,10 @@ export class ElxContextMenu extends HTMLElement {
     document.removeEventListener('keydown', this._onKeydown);
   }
 
+  attributeChangedCallback() {
+    this._update();
+  }
+
   get open(): boolean {
     return this.hasAttribute('open');
   }
@@ -142,6 +148,19 @@ export class ElxContextMenu extends HTMLElement {
     if (this._menuElement) {
       this._menuElement.style.left = x + 'px';
       this._menuElement.style.top = y + 'px';
+      // Adjust for viewport overflow after paint
+      requestAnimationFrame(() => {
+        if (!this._menuElement) return;
+        const rect = this._menuElement.getBoundingClientRect();
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        if (rect.right > vw) {
+          this._menuElement.style.left = Math.max(0, x - rect.width) + 'px';
+        }
+        if (rect.bottom > vh) {
+          this._menuElement.style.top = Math.max(0, y - rect.height) + 'px';
+        }
+      });
     }
     this.dispatchEvent(new CustomEvent('open', { bubbles: true, composed: true }));
     this._focusFirst();
@@ -175,7 +194,7 @@ export class ElxContextMenu extends HTMLElement {
 
   private _handleKeydown(e: KeyboardEvent) {
     if (!this.open) return;
-    if (e.key === 'Escape') {
+    if (e.key === 'Escape' || e.key === 'Tab') {
       e.preventDefault();
       this.hide();
     }
@@ -246,6 +265,10 @@ export class ElxContextMenu extends HTMLElement {
     menu.setAttribute('role', 'menu');
     menu.setAttribute('aria-orientation', 'vertical');
     menu.setAttribute('part', 'menu');
+    const label = this.getAttribute('label');
+    if (label) {
+      menu.setAttribute('aria-label', label);
+    }
     const slot = document.createElement('slot');
     menu.appendChild(slot);
 
@@ -259,6 +282,12 @@ export class ElxContextMenu extends HTMLElement {
     const menu = this.shadowRoot?.querySelector('.context-menu');
     if (menu) {
       menu.setAttribute('aria-hidden', String(!this.open));
+      const label = this.getAttribute('label');
+      if (label) {
+        menu.setAttribute('aria-label', label);
+      } else {
+        menu.removeAttribute('aria-label');
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,3 +41,4 @@ export * from './components/scroll-area/scroll-area';
 export * from './components/aspect-ratio/aspect-ratio';
 export * from './components/hover-card/hover-card';
 export * from './components/navigation-menu/navigation-menu';
+export * from './components/context-menu/context-menu';


### PR DESCRIPTION
Closes #55

## Changes
- **elx-context-menu** — right-click context menu container, opens at cursor position
- **elx-context-menu-item** — menu item with prefix/suffix slots, keyboard activation
- **elx-context-menu-divider** — visual separator between groups

## Features
- Right-click (contextmenu event) to open at cursor position
- Programmatic `show(x, y)` / `hide()` API
- Keyboard navigation: ArrowUp/Down, Home/End, Escape to close
- Enter/Space to activate items
- Click-outside to dismiss (composedPath for shadow DOM)
- Disabled items with aria-disabled + tabindex=-1
- Part attributes for external styling (`menu`, `base`)
- CSS custom properties with `--elx-context-menu-` prefix

## Tests
- 34 tests covering rendering, ARIA, keyboard nav, events, disabled state, reconnection
- Full suite: 785/785 passing