### PR TITLE
feat: add Menubar component

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "40.5 kB",
+      "limit": "41 kB",
       "gzip": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "41 kB",
+      "limit": "42 kB",
       "gzip": true
     },
     {

--- a/src/components/menubar/menubar.stories.ts
+++ b/src/components/menubar/menubar.stories.ts
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './menubar.js';
+
+const meta: Meta = {
+  title: 'Components/Menubar',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'A horizontal menu bar component with dropdown menus, keyboard navigation, and ARIA support.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`
+    <elx-menubar>
+      <elx-menubar-menu label="File">
+        <span slot="trigger">File</span>
+        <elx-menubar-item value="new">New</elx-menubar-item>
+        <elx-menubar-item value="open">Open</elx-menubar-item>
+        <elx-menubar-separator></elx-menubar-separator>
+        <elx-menubar-item value="save">Save</elx-menubar-item>
+        <elx-menubar-item value="save-as">Save As...</elx-menubar-item>
+        <elx-menubar-separator></elx-menubar-separator>
+        <elx-menubar-item value="exit">Exit</elx-menubar-item>
+      </elx-menubar-menu>
+      <elx-menubar-menu label="Edit">
+        <span slot="trigger">Edit</span>
+        <elx-menubar-item value="undo">Undo</elx-menubar-item>
+        <elx-menubar-item value="redo">Redo</elx-menubar-item>
+        <elx-menubar-separator></elx-menubar-separator>
+        <elx-menubar-item value="cut">Cut</elx-menubar-item>
+        <elx-menubar-item value="copy">Copy</elx-menubar-item>
+        <elx-menubar-item value="paste">Paste</elx-menubar-item>
+      </elx-menubar-menu>
+      <elx-menubar-menu label="View">
+        <span slot="trigger">View</span>
+        <elx-menubar-item value="zoom-in">Zoom In</elx-menubar-item>
+        <elx-menubar-item value="zoom-out">Zoom Out</elx-menubar-item>
+        <elx-menubar-separator></elx-menubar-separator>
+        <elx-menubar-item value="fullscreen">Fullscreen</elx-menubar-item>
+      </elx-menubar-menu>
+    </elx-menubar>
+  `,
+};
+
+export const WithDisabledItems: Story = {
+  render: () => html`
+    <elx-menubar>
+      <elx-menubar-menu label="File">
+        <span slot="trigger">File</span>
+        <elx-menubar-item value="new">New</elx-menubar-item>
+        <elx-menubar-item value="open">Open</elx-menubar-item>
+        <elx-menubar-item value="save" disabled>Save (disabled)</elx-menubar-item>
+      </elx-menubar-menu>
+      <elx-menubar-menu label="Edit" disabled>
+        <span slot="trigger">Edit (disabled)</span>
+        <elx-menubar-item value="undo">Undo</elx-menubar-item>
+      </elx-menubar-menu>
+    </elx-menubar>
+  `,
+};
+
+export const WithShortcuts: Story = {
+  render: () => html`
+    <elx-menubar>
+      <elx-menubar-menu label="File">
+        <span slot="trigger">File</span>
+        <elx-menubar-item value="new">
+          New
+          <span slot="suffix" style="font-size: 0.75rem; color: #94a3b8;">⌘N</span>
+        </elx-menubar-item>
+        <elx-menubar-item value="open">
+          Open
+          <span slot="suffix" style="font-size: 0.75rem; color: #94a3b8;">⌘O</span>
+        </elx-menubar-item>
+        <elx-menubar-separator></elx-menubar-separator>
+        <elx-menubar-item value="save">
+          Save
+          <span slot="suffix" style="font-size: 0.75rem; color: #94a3b8;">⌘S</span>
+        </elx-menubar-item>
+      </elx-menubar-menu>
+      <elx-menubar-menu label="Edit">
+        <span slot="trigger">Edit</span>
+        <elx-menubar-item value="undo">
+          Undo
+          <span slot="suffix" style="font-size: 0.75rem; color: #94a3b8;">⌘Z</span>
+        </elx-menubar-item>
+        <elx-menubar-item value="redo">
+          Redo
+          <span slot="suffix" style="font-size: 0.75rem; color: #94a3b8;">⇧⌘Z</span>
+        </elx-menubar-item>
+      </elx-menubar-menu>
+    </elx-menubar>
+  `,
+};

--- a/src/components/menubar/menubar.test.ts
+++ b/src/components/menubar/menubar.test.ts
@@ -395,7 +395,7 @@ describe('elx-menubar-item', () => {
     const el = createMenubar();
     const menu = el.querySelector('elx-menubar-menu') as any;
     menu.show();
-    const item = el.querySelector('elx-menubar-item')!;
+    const item = el.querySelector('elx-menubar-item') as HTMLElement;
     const spy = vi.fn();
     el.addEventListener('elx-menubar-select', spy);
     item.click();
@@ -407,7 +407,7 @@ describe('elx-menubar-item', () => {
     const el = createMenubar();
     const menu = el.querySelector('elx-menubar-menu') as any;
     menu.show();
-    const item = el.querySelector('elx-menubar-item')!;
+    const item = el.querySelector('elx-menubar-item') as HTMLElement;
     item.removeAttribute('value');
     const spy = vi.fn();
     el.addEventListener('elx-menubar-select', spy);
@@ -420,7 +420,7 @@ describe('elx-menubar-item', () => {
     const el = createMenubar();
     const menu = el.querySelector('elx-menubar-menu') as any;
     menu.show();
-    const item = el.querySelector('elx-menubar-item')!;
+    const item = el.querySelector('elx-menubar-item') as HTMLElement;
     item.click();
     expect(menu.open).toBe(false);
   });

--- a/src/components/menubar/menubar.test.ts
+++ b/src/components/menubar/menubar.test.ts
@@ -116,7 +116,6 @@ describe('elx-menubar', () => {
     const menus = el.querySelectorAll('elx-menubar-menu');
     (menus[0] as any).show();
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
-    // First menu should close, second should open
     expect((menus[0] as any).open).toBe(false);
     expect((menus[1] as any).open).toBe(true);
   });
@@ -156,6 +155,36 @@ describe('elx-menubar', () => {
     expect((menus[0] as any).open).toBe(false);
   });
 
+  it('should close on Tab key', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[0] as any).show();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect((menus[0] as any).open).toBe(false);
+  });
+
+  it('should skip disabled menus during ArrowRight navigation', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[1] as any).disabled = true;
+    (menus[0] as any).show();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect((menus[0] as any).open).toBe(false);
+    expect((menus[1] as any).open).toBe(false);
+    expect((menus[2] as any).open).toBe(true);
+  });
+
+  it('should skip disabled menus during ArrowLeft navigation', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[1] as any).disabled = true;
+    (menus[2] as any).show();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect((menus[2] as any).open).toBe(false);
+    expect((menus[1] as any).open).toBe(false);
+    expect((menus[0] as any).open).toBe(true);
+  });
+
   it('should expose closeAll method', () => {
     const el = createMenubar() as any;
     const menus = el.querySelectorAll('elx-menubar-menu');
@@ -169,7 +198,6 @@ describe('elx-menubar', () => {
   it('should clean up listeners on disconnect', () => {
     const el = createMenubar();
     el.remove();
-    // Should not throw
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
@@ -297,13 +325,20 @@ describe('elx-menubar-menu', () => {
     expect(trigger!.getAttribute('aria-label')).toBe('File');
   });
 
+  it('should not set aria-label when label is empty', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.removeAttribute('label');
+    const trigger = menu.shadowRoot!.querySelector('.trigger');
+    expect(trigger!.hasAttribute('aria-label')).toBe(false);
+  });
+
   it('should navigate items with ArrowDown inside menu', () => {
     const el = createMenubar();
     const menu = el.querySelector('elx-menubar-menu') as any;
     menu.show();
-    const menuEl = menu.shadowRoot!.querySelector('.menu') as HTMLElement;
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-    // Should not throw
+    // Dispatch on the host element (where listener is attached)
+    menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
     expect(menu.open).toBe(true);
   });
 
@@ -311,8 +346,7 @@ describe('elx-menubar-menu', () => {
     const el = createMenubar();
     const menu = el.querySelector('elx-menubar-menu') as any;
     menu.show();
-    const menuEl = menu.shadowRoot!.querySelector('.menu') as HTMLElement;
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
     expect(menu.open).toBe(true);
   });
 
@@ -320,8 +354,7 @@ describe('elx-menubar-menu', () => {
     const el = createMenubar();
     const menu = el.querySelector('elx-menubar-menu') as any;
     menu.show();
-    const menuEl = menu.shadowRoot!.querySelector('.menu') as HTMLElement;
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
     expect(menu.open).toBe(true);
   });
 
@@ -329,8 +362,7 @@ describe('elx-menubar-menu', () => {
     const el = createMenubar();
     const menu = el.querySelector('elx-menubar-menu') as any;
     menu.show();
-    const menuEl = menu.shadowRoot!.querySelector('.menu') as HTMLElement;
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
     expect(menu.open).toBe(true);
   });
 });
@@ -353,10 +385,10 @@ describe('elx-menubar-item', () => {
     expect(base!.getAttribute('part')).toBe('base');
   });
 
-  it('should have tabindex 0 by default', () => {
+  it('should have tabindex -1 by default (roving tabindex)', () => {
     const el = createMenubar();
     const item = el.querySelector('elx-menubar-item')!;
-    expect(item.getAttribute('tabindex')).toBe('0');
+    expect(item.getAttribute('tabindex')).toBe('-1');
   });
 
   it('should dispatch select event on click', () => {
@@ -369,6 +401,19 @@ describe('elx-menubar-item', () => {
     item.click();
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.mock.calls[0][0].detail.value).toBe('new');
+  });
+
+  it('should fall back to textContent when value is absent', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const item = el.querySelector('elx-menubar-item')!;
+    item.removeAttribute('value');
+    const spy = vi.fn();
+    el.addEventListener('elx-menubar-select', spy);
+    item.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail.value).toBe('New');
   });
 
   it('should close menu on item click', () => {
@@ -423,6 +468,14 @@ describe('elx-menubar-item', () => {
     expect(item.getAttribute('aria-disabled')).toBe('true');
     item.disabled = false;
     expect(item.hasAttribute('disabled')).toBe(false);
+    expect(item.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('should set tabindex to 0 when focused', () => {
+    const el = createMenubar();
+    const item = el.querySelector('elx-menubar-item') as any;
+    expect(item.getAttribute('tabindex')).toBe('-1');
+    item.focus();
     expect(item.getAttribute('tabindex')).toBe('0');
   });
 });

--- a/src/components/menubar/menubar.test.ts
+++ b/src/components/menubar/menubar.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import './menubar';
+
+function createMenubar(): HTMLElement {
+  const el = document.createElement('elx-menubar') as any;
+
+  // File menu
+  const fileMenu = document.createElement('elx-menubar-menu');
+  fileMenu.setAttribute('label', 'File');
+  const fileTrigger = document.createElement('span');
+  fileTrigger.slot = 'trigger';
+  fileTrigger.textContent = 'File';
+  fileMenu.appendChild(fileTrigger);
+
+  const newItem = document.createElement('elx-menubar-item');
+  newItem.textContent = 'New';
+  newItem.setAttribute('value', 'new');
+  fileMenu.appendChild(newItem);
+
+  const openItem = document.createElement('elx-menubar-item');
+  openItem.textContent = 'Open';
+  openItem.setAttribute('value', 'open');
+  fileMenu.appendChild(openItem);
+
+  const sep = document.createElement('elx-menubar-separator');
+  fileMenu.appendChild(sep);
+
+  const saveItem = document.createElement('elx-menubar-item');
+  saveItem.textContent = 'Save';
+  saveItem.setAttribute('value', 'save');
+  fileMenu.appendChild(saveItem);
+
+  el.appendChild(fileMenu);
+
+  // Edit menu
+  const editMenu = document.createElement('elx-menubar-menu');
+  editMenu.setAttribute('label', 'Edit');
+  const editTrigger = document.createElement('span');
+  editTrigger.slot = 'trigger';
+  editTrigger.textContent = 'Edit';
+  editMenu.appendChild(editTrigger);
+
+  const undoItem = document.createElement('elx-menubar-item');
+  undoItem.textContent = 'Undo';
+  undoItem.setAttribute('value', 'undo');
+  editMenu.appendChild(undoItem);
+
+  const redoItem = document.createElement('elx-menubar-item');
+  redoItem.textContent = 'Redo';
+  redoItem.setAttribute('value', 'redo');
+  editMenu.appendChild(redoItem);
+
+  el.appendChild(editMenu);
+
+  // View menu
+  const viewMenu = document.createElement('elx-menubar-menu');
+  viewMenu.setAttribute('label', 'View');
+  const viewTrigger = document.createElement('span');
+  viewTrigger.slot = 'trigger';
+  viewTrigger.textContent = 'View';
+  viewMenu.appendChild(viewTrigger);
+
+  const zoomItem = document.createElement('elx-menubar-item');
+  zoomItem.textContent = 'Zoom In';
+  zoomItem.setAttribute('value', 'zoom-in');
+  viewMenu.appendChild(zoomItem);
+
+  el.appendChild(viewMenu);
+
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('elx-menubar', () => {
+  it('should be defined as a custom element', () => {
+    expect(customElements.get('elx-menubar')).toBeDefined();
+  });
+
+  it('should render shadow DOM with menubar role', () => {
+    const el = createMenubar();
+    const bar = el.shadowRoot!.querySelector('.menubar');
+    expect(bar).toBeTruthy();
+    expect(bar!.getAttribute('role')).toBe('menubar');
+    expect(bar!.getAttribute('aria-orientation')).toBe('horizontal');
+  });
+
+  it('should have part attribute on base', () => {
+    const el = createMenubar();
+    const bar = el.shadowRoot!.querySelector('.menubar');
+    expect(bar!.getAttribute('part')).toBe('base');
+  });
+
+  it('should close all menus on outside click', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[0] as any).show();
+    expect((menus[0] as any).open).toBe(true);
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect((menus[0] as any).open).toBe(false);
+  });
+
+  it('should not close on click inside', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[0] as any).show();
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect((menus[0] as any).open).toBe(true);
+  });
+
+  it('should navigate menus with ArrowRight', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[0] as any).show();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    // First menu should close, second should open
+    expect((menus[0] as any).open).toBe(false);
+    expect((menus[1] as any).open).toBe(true);
+  });
+
+  it('should navigate menus with ArrowLeft', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[1] as any).show();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect((menus[1] as any).open).toBe(false);
+    expect((menus[0] as any).open).toBe(true);
+  });
+
+  it('should wrap ArrowRight from last to first', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[2] as any).show();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect((menus[2] as any).open).toBe(false);
+    expect((menus[0] as any).open).toBe(true);
+  });
+
+  it('should wrap ArrowLeft from first to last', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[0] as any).show();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect((menus[0] as any).open).toBe(false);
+    expect((menus[2] as any).open).toBe(true);
+  });
+
+  it('should close on Escape and keep focus on trigger', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[0] as any).show();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect((menus[0] as any).open).toBe(false);
+  });
+
+  it('should expose closeAll method', () => {
+    const el = createMenubar() as any;
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    (menus[0] as any).show();
+    (menus[1] as any).show();
+    el.closeAll();
+    expect((menus[0] as any).open).toBe(false);
+    expect((menus[1] as any).open).toBe(false);
+  });
+
+  it('should clean up listeners on disconnect', () => {
+    const el = createMenubar();
+    el.remove();
+    // Should not throw
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  it('should re-attach listeners on reconnect', () => {
+    const el = createMenubar();
+    const menus = el.querySelectorAll('elx-menubar-menu');
+    el.remove();
+    document.body.appendChild(el);
+    (menus[0] as any).show();
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect((menus[0] as any).open).toBe(false);
+  });
+});
+
+describe('elx-menubar-menu', () => {
+  it('should be defined as a custom element', () => {
+    expect(customElements.get('elx-menubar-menu')).toBeDefined();
+  });
+
+  it('should render trigger with aria-haspopup', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu')!;
+    const trigger = menu.shadowRoot!.querySelector('.trigger');
+    expect(trigger!.getAttribute('aria-haspopup')).toBe('menu');
+  });
+
+  it('should have part attributes on trigger and menu', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu')!;
+    expect(menu.shadowRoot!.querySelector('.trigger')!.getAttribute('part')).toBe('trigger');
+    expect(menu.shadowRoot!.querySelector('.menu')!.getAttribute('part')).toBe('menu');
+  });
+
+  it('should be closed by default', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    expect(menu.open).toBe(false);
+    const trigger = menu.shadowRoot!.querySelector('.trigger');
+    expect(trigger!.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('should open via show()', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    expect(menu.open).toBe(true);
+    const trigger = menu.shadowRoot!.querySelector('.trigger');
+    expect(trigger!.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('should dispatch open event', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    const spy = vi.fn();
+    menu.addEventListener('open', spy);
+    menu.show();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close via hide()', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    menu.hide();
+    expect(menu.open).toBe(false);
+  });
+
+  it('should dispatch close event', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const spy = vi.fn();
+    menu.addEventListener('close', spy);
+    menu.hide();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should toggle on trigger click', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    const trigger = menu.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.click();
+    expect(menu.open).toBe(true);
+    trigger.click();
+    expect(menu.open).toBe(false);
+  });
+
+  it('should not open when disabled', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.disabled = true;
+    menu.show();
+    expect(menu.open).toBe(false);
+  });
+
+  it('should open on Enter key on trigger', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    const trigger = menu.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(menu.open).toBe(true);
+  });
+
+  it('should open on Space key on trigger', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    const trigger = menu.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(menu.open).toBe(true);
+  });
+
+  it('should open on ArrowDown on trigger', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    const trigger = menu.shadowRoot!.querySelector('.trigger') as HTMLElement;
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(menu.open).toBe(true);
+  });
+
+  it('should set aria-label from label attribute', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    const trigger = menu.shadowRoot!.querySelector('.trigger');
+    expect(trigger!.getAttribute('aria-label')).toBe('File');
+  });
+
+  it('should navigate items with ArrowDown inside menu', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const menuEl = menu.shadowRoot!.querySelector('.menu') as HTMLElement;
+    menuEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    // Should not throw
+    expect(menu.open).toBe(true);
+  });
+
+  it('should navigate items with ArrowUp inside menu', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const menuEl = menu.shadowRoot!.querySelector('.menu') as HTMLElement;
+    menuEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(menu.open).toBe(true);
+  });
+
+  it('should navigate to first item with Home', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const menuEl = menu.shadowRoot!.querySelector('.menu') as HTMLElement;
+    menuEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(menu.open).toBe(true);
+  });
+
+  it('should navigate to last item with End', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const menuEl = menu.shadowRoot!.querySelector('.menu') as HTMLElement;
+    menuEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(menu.open).toBe(true);
+  });
+});
+
+describe('elx-menubar-item', () => {
+  it('should be defined as a custom element', () => {
+    expect(customElements.get('elx-menubar-item')).toBeDefined();
+  });
+
+  it('should render with menuitem role', () => {
+    const el = createMenubar();
+    const item = el.querySelector('elx-menubar-item')!;
+    expect(item.getAttribute('role')).toBe('menuitem');
+  });
+
+  it('should have part attribute on base', () => {
+    const el = createMenubar();
+    const item = el.querySelector('elx-menubar-item')!;
+    const base = item.shadowRoot!.querySelector('.item');
+    expect(base!.getAttribute('part')).toBe('base');
+  });
+
+  it('should have tabindex 0 by default', () => {
+    const el = createMenubar();
+    const item = el.querySelector('elx-menubar-item')!;
+    expect(item.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should dispatch select event on click', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const item = el.querySelector('elx-menubar-item')!;
+    const spy = vi.fn();
+    el.addEventListener('elx-menubar-select', spy);
+    item.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail.value).toBe('new');
+  });
+
+  it('should close menu on item click', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const item = el.querySelector('elx-menubar-item')!;
+    item.click();
+    expect(menu.open).toBe(false);
+  });
+
+  it('should not dispatch select when disabled', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const item = el.querySelector('elx-menubar-item') as any;
+    item.disabled = true;
+    const spy = vi.fn();
+    el.addEventListener('elx-menubar-select', spy);
+    item.click();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should activate on Enter key', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const item = el.querySelector('elx-menubar-item')!;
+    const spy = vi.fn();
+    el.addEventListener('elx-menubar-select', spy);
+    item.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should activate on Space key', () => {
+    const el = createMenubar();
+    const menu = el.querySelector('elx-menubar-menu') as any;
+    menu.show();
+    const item = el.querySelector('elx-menubar-item')!;
+    const spy = vi.fn();
+    el.addEventListener('elx-menubar-select', spy);
+    item.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should toggle disabled via property', () => {
+    const el = createMenubar();
+    const item = el.querySelector('elx-menubar-item') as any;
+    item.disabled = true;
+    expect(item.getAttribute('disabled')).toBe('');
+    expect(item.getAttribute('tabindex')).toBe('-1');
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+    item.disabled = false;
+    expect(item.hasAttribute('disabled')).toBe(false);
+    expect(item.getAttribute('tabindex')).toBe('0');
+  });
+});
+
+describe('elx-menubar-separator', () => {
+  it('should be defined as a custom element', () => {
+    expect(customElements.get('elx-menubar-separator')).toBeDefined();
+  });
+
+  it('should render with separator role', () => {
+    const el = document.createElement('elx-menubar-separator');
+    document.body.appendChild(el);
+    expect(el.getAttribute('role')).toBe('separator');
+    expect(el.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('should render separator element', () => {
+    const el = document.createElement('elx-menubar-separator');
+    document.body.appendChild(el);
+    const sep = el.shadowRoot!.querySelector('.separator');
+    expect(sep).toBeTruthy();
+  });
+});

--- a/src/components/menubar/menubar.ts
+++ b/src/components/menubar/menubar.ts
@@ -1,0 +1,582 @@
+const menubarStyles = `
+  :host {
+    --elx-menubar-bg: var(--elx-color-surface, #ffffff);
+    --elx-menubar-border: var(--elx-color-border, #e2e8f0);
+    --elx-menubar-radius: var(--elx-radius-md, 0.5rem);
+    --elx-menubar-item-hover: var(--elx-color-surface-hover, #f1f5f9);
+    --elx-menubar-item-active: var(--elx-color-primary, #3b82f6);
+    --elx-menubar-item-active-bg: var(--elx-color-primary-light, #eff6ff);
+    --elx-menubar-item-padding: 0.375rem 0.75rem;
+    --elx-menubar-gap: 0.25rem;
+    display: block;
+  }
+
+  .menubar {
+    display: flex;
+    align-items: center;
+    gap: var(--elx-menubar-gap);
+    background: var(--elx-menubar-bg);
+    border: 1px solid var(--elx-menubar-border);
+    border-radius: var(--elx-menubar-radius);
+    padding: 0.25rem;
+  }
+`;
+
+const menubarMenuStyles = `
+  :host {
+    position: relative;
+    display: inline-block;
+  }
+
+  .trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: var(--elx-menubar-item-padding, 0.375rem 0.75rem);
+    border: none;
+    background: none;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    border-radius: var(--elx-radius-sm, 0.25rem);
+    transition: background-color 0.15s;
+    outline: none;
+    white-space: nowrap;
+    font-size: 0.875rem;
+  }
+
+  .trigger:hover,
+  .trigger:focus-visible {
+    background: var(--elx-menubar-item-hover, #f1f5f9);
+  }
+
+  .trigger:focus-visible {
+    outline: 2px solid var(--elx-color-primary-500, #3b82f6);
+    outline-offset: -2px;
+  }
+
+  :host([open]) .trigger {
+    background: var(--elx-menubar-item-active-bg, #eff6ff);
+    color: var(--elx-menubar-item-active, #3b82f6);
+  }
+
+  :host([disabled]) .trigger {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    min-width: 180px;
+    background: var(--elx-menubar-bg, #ffffff);
+    border: 1px solid var(--elx-menubar-border, #e2e8f0);
+    border-radius: var(--elx-menubar-radius, 0.5rem);
+    box-shadow: var(--elx-shadow-lg, 0 10px 15px -3px rgba(0,0,0,0.1));
+    padding: 0.25rem 0;
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-4px);
+    transition: opacity 150ms ease, visibility 150ms ease, transform 150ms ease;
+  }
+
+  :host([open]) .menu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+`;
+
+const menubarItemStyles = `
+  :host {
+    display: block;
+  }
+
+  .item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    border: none;
+    background: none;
+    width: 100%;
+    text-align: start;
+    font: inherit;
+    font-size: 0.875rem;
+    color: inherit;
+    outline: none;
+    transition: background-color 0.15s;
+  }
+
+  .item:hover,
+  .item:focus-visible {
+    background: var(--elx-menubar-item-hover, #f1f5f9);
+  }
+
+  .item:focus-visible {
+    outline: 2px solid var(--elx-color-primary-500, #3b82f6);
+    outline-offset: -2px;
+  }
+
+  :host([disabled]) .item {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  ::slotted([slot="prefix"]) {
+    flex-shrink: 0;
+  }
+
+  ::slotted([slot="suffix"]) {
+    flex-shrink: 0;
+    margin-inline-start: auto;
+  }
+`;
+
+const menubarSeparatorStyles = `
+  :host {
+    display: block;
+  }
+
+  .separator {
+    height: 1px;
+    background: var(--elx-menubar-border, #e2e8f0);
+    margin: 0.25rem 0;
+  }
+`;
+
+export class ElxMenubar extends HTMLElement {
+  private _rendered = false;
+  private _onClickOutside: (e: Event) => void;
+  private _onKeydown: (e: KeyboardEvent) => void;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._onClickOutside = (e: Event) => this._handleClickOutside(e);
+    this._onKeydown = (e: KeyboardEvent) => this._handleKeydown(e);
+  }
+
+  connectedCallback() {
+    if (!this._rendered) {
+      this._buildDom();
+      this._rendered = true;
+    }
+    document.addEventListener('click', this._onClickOutside);
+    document.addEventListener('keydown', this._onKeydown);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('click', this._onClickOutside);
+    document.removeEventListener('keydown', this._onKeydown);
+  }
+
+  private _getMenus(): ElxMenubarMenu[] {
+    const menus: ElxMenubarMenu[] = [];
+    this.querySelectorAll('elx-menubar-menu').forEach(el => {
+      menus.push(el as ElxMenubarMenu);
+    });
+    return menus;
+  }
+
+  private _handleClickOutside(e: Event) {
+    const path = e.composedPath();
+    let found = false;
+    for (let i = 0; i < path.length; i++) {
+      if (path[i] === this) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      this._closeAll();
+    }
+  }
+
+  private _handleKeydown(e: KeyboardEvent) {
+    const menus = this._getMenus();
+    if (menus.length === 0) return;
+
+    // Find which menu (or its child) is currently focused/open
+    let activeIndex = -1;
+    for (let i = 0; i < menus.length; i++) {
+      if (menus[i].open || menus[i].contains(document.activeElement) ||
+          menus[i].shadowRoot?.contains(document.activeElement)) {
+        activeIndex = i;
+        break;
+      }
+    }
+
+    if (activeIndex === -1) return;
+
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      const wasOpen = menus[activeIndex].open;
+      this._closeAll();
+      const next = (activeIndex + 1) % menus.length;
+      menus[next].focusTrigger();
+      if (wasOpen) menus[next].show();
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const wasOpen = menus[activeIndex].open;
+      this._closeAll();
+      const prev = (activeIndex - 1 + menus.length) % menus.length;
+      menus[prev].focusTrigger();
+      if (wasOpen) menus[prev].show();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      const wasOpen = menus[activeIndex].open;
+      this._closeAll();
+      if (wasOpen) menus[activeIndex].focusTrigger();
+    }
+  }
+
+  closeAll() {
+    this._closeAll();
+  }
+
+  private _closeAll() {
+    const menus = this._getMenus();
+    for (let i = 0; i < menus.length; i++) {
+      menus[i].hide();
+    }
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = menubarStyles;
+
+    const bar = document.createElement('div');
+    bar.className = 'menubar';
+    bar.setAttribute('role', 'menubar');
+    bar.setAttribute('aria-orientation', 'horizontal');
+    bar.setAttribute('part', 'base');
+    const slot = document.createElement('slot');
+    bar.appendChild(slot);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(bar);
+  }
+}
+
+export class ElxMenubarMenu extends HTMLElement {
+  static observedAttributes = ['open', 'disabled', 'label'];
+
+  private _rendered = false;
+  private _triggerEl: HTMLElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this._rendered) {
+      this._buildDom();
+      this._rendered = true;
+    }
+    this._update();
+  }
+
+  attributeChangedCallback() {
+    if (this._rendered) this._update();
+  }
+
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+
+  set open(val: boolean) {
+    val ? this.setAttribute('open', '') : this.removeAttribute('open');
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(val: boolean) {
+    val ? this.setAttribute('disabled', '') : this.removeAttribute('disabled');
+  }
+
+  get label(): string {
+    return this.getAttribute('label') || '';
+  }
+
+  set label(val: string) {
+    this.setAttribute('label', val);
+  }
+
+  show() {
+    if (this.disabled) return;
+    this.open = true;
+    this.dispatchEvent(new CustomEvent('open', { bubbles: true, composed: true }));
+    this._focusFirstItem();
+  }
+
+  hide() {
+    if (!this.open) return;
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+  }
+
+  focusTrigger() {
+    this._triggerEl?.focus();
+  }
+
+  private _focusFirstItem() {
+    const items = this._getItems();
+    if (items.length > 0) {
+      const inner = items[0].shadowRoot?.querySelector('.item') as HTMLElement;
+      inner?.focus();
+    }
+  }
+
+  private _getItems(): ElxMenubarItem[] {
+    const items: ElxMenubarItem[] = [];
+    this.querySelectorAll('elx-menubar-item:not([disabled])').forEach(el => {
+      items.push(el as ElxMenubarItem);
+    });
+    return items;
+  }
+
+  private _onTriggerClick = () => {
+    if (this.disabled) return;
+    this.open ? this.hide() : this.show();
+  };
+
+  private _onTriggerKeydown = (e: KeyboardEvent) => {
+    if (this.disabled) return;
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!this.open) this.show();
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (!this.open) {
+        this.show();
+        // Focus last item
+        const items = this._getItems();
+        if (items.length > 0) {
+          const inner = items[items.length - 1].shadowRoot?.querySelector('.item') as HTMLElement;
+          inner?.focus();
+        }
+      }
+    }
+  };
+
+  private _onMenuKeydown = (e: KeyboardEvent) => {
+    if (!this.open) return;
+    const items = this._getItems();
+    if (items.length === 0) return;
+
+    const active = document.activeElement as HTMLElement;
+    let currentIndex = -1;
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].shadowRoot?.contains(active)) {
+        currentIndex = i;
+        break;
+      }
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = currentIndex < items.length - 1 ? currentIndex + 1 : 0;
+      const inner = items[next].shadowRoot?.querySelector('.item') as HTMLElement;
+      inner?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = currentIndex > 0 ? currentIndex - 1 : items.length - 1;
+      const inner = items[prev].shadowRoot?.querySelector('.item') as HTMLElement;
+      inner?.focus();
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      const inner = items[0].shadowRoot?.querySelector('.item') as HTMLElement;
+      inner?.focus();
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      const inner = items[items.length - 1].shadowRoot?.querySelector('.item') as HTMLElement;
+      inner?.focus();
+    }
+  };
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = menubarMenuStyles;
+
+    const trigger = document.createElement('button');
+    trigger.className = 'trigger';
+    trigger.setAttribute('part', 'trigger');
+    trigger.setAttribute('aria-haspopup', 'menu');
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('type', 'button');
+    const triggerSlot = document.createElement('slot');
+    triggerSlot.name = 'trigger';
+    trigger.appendChild(triggerSlot);
+    this._triggerEl = trigger;
+
+    const menu = document.createElement('div');
+    menu.className = 'menu';
+    menu.setAttribute('role', 'menu');
+    menu.setAttribute('aria-orientation', 'vertical');
+    menu.setAttribute('part', 'menu');
+    const menuSlot = document.createElement('slot');
+    menu.appendChild(menuSlot);
+
+    trigger.addEventListener('click', this._onTriggerClick);
+    trigger.addEventListener('keydown', this._onTriggerKeydown);
+    menu.addEventListener('keydown', this._onMenuKeydown);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(trigger);
+    this.shadowRoot!.appendChild(menu);
+  }
+
+  private _update() {
+    const trigger = this.shadowRoot?.querySelector('.trigger');
+    const menu = this.shadowRoot?.querySelector('.menu');
+    if (trigger) {
+      trigger.setAttribute('aria-expanded', String(this.open));
+      trigger.setAttribute('aria-label', this.label);
+      if (this.disabled) {
+        trigger.setAttribute('disabled', '');
+      } else {
+        trigger.removeAttribute('disabled');
+      }
+    }
+    if (menu) {
+      menu.setAttribute('aria-hidden', String(!this.open));
+    }
+  }
+}
+
+export class ElxMenubarItem extends HTMLElement {
+  static observedAttributes = ['disabled'];
+
+  private _rendered = false;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this._rendered) {
+      this._render();
+      this._rendered = true;
+    }
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'menuitem');
+    }
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', this.hasAttribute('disabled') ? '-1' : '0');
+    }
+    if (this.hasAttribute('disabled')) {
+      this.setAttribute('aria-disabled', 'true');
+    }
+    this.addEventListener('click', this._handleClick);
+    this.addEventListener('keydown', this._handleKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('click', this._handleClick);
+    this.removeEventListener('keydown', this._handleKeydown);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(val: boolean) {
+    if (val) {
+      this.setAttribute('disabled', '');
+      this.setAttribute('tabindex', '-1');
+    } else {
+      this.removeAttribute('disabled');
+      this.setAttribute('tabindex', '0');
+    }
+  }
+
+  attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
+    if (oldVal === newVal) return;
+    if (_name === 'disabled') {
+      this.setAttribute('tabindex', newVal !== null ? '-1' : '0');
+      if (newVal !== null) {
+        this.setAttribute('aria-disabled', 'true');
+      } else {
+        this.removeAttribute('aria-disabled');
+      }
+    }
+  }
+
+  private _handleClick = () => {
+    if (this.disabled) return;
+    this.dispatchEvent(new CustomEvent('elx-menubar-select', {
+      bubbles: true,
+      composed: true,
+      detail: { value: this.getAttribute('value') || this.textContent?.trim() },
+    }));
+    const menu = this.closest('elx-menubar-menu') as ElxMenubarMenu;
+    menu?.hide();
+  };
+
+  private _handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this._handleClick();
+    }
+  };
+
+  private _render() {
+    this.shadowRoot!.innerHTML = `
+      <style>${menubarItemStyles}</style>
+      <div class="item" part="base">
+        <slot name="prefix"></slot>
+        <slot></slot>
+        <slot name="suffix"></slot>
+      </div>
+    `;
+  }
+}
+
+export class ElxMenubarSeparator extends HTMLElement {
+  private _rendered = false;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    if (!this._rendered) {
+      this._render();
+      this._rendered = true;
+    }
+    this.setAttribute('role', 'separator');
+    this.setAttribute('aria-hidden', 'true');
+  }
+
+  private _render() {
+    this.shadowRoot!.innerHTML = `
+      <style>${menubarSeparatorStyles}</style>
+      <div class="separator"></div>
+    `;
+  }
+}
+
+if (!customElements.get('elx-menubar')) {
+  customElements.define('elx-menubar', ElxMenubar);
+}
+if (!customElements.get('elx-menubar-menu')) {
+  customElements.define('elx-menubar-menu', ElxMenubarMenu);
+}
+if (!customElements.get('elx-menubar-item')) {
+  customElements.define('elx-menubar-item', ElxMenubarItem);
+}
+if (!customElements.get('elx-menubar-separator')) {
+  customElements.define('elx-menubar-separator', ElxMenubarSeparator);
+}

--- a/src/components/menubar/menubar.ts
+++ b/src/components/menubar/menubar.ts
@@ -40,7 +40,6 @@ const menubarMenuStyles = `
     cursor: pointer;
     border-radius: var(--elx-radius-sm, 0.25rem);
     transition: background-color 0.15s;
-    outline: none;
     white-space: nowrap;
     font-size: 0.875rem;
   }
@@ -108,7 +107,6 @@ const menubarItemStyles = `
     font: inherit;
     font-size: 0.875rem;
     color: inherit;
-    outline: none;
     transition: background-color 0.15s;
   }
 
@@ -178,9 +176,13 @@ export class ElxMenubar extends HTMLElement {
 
   private _getMenus(): ElxMenubarMenu[] {
     const menus: ElxMenubarMenu[] = [];
-    this.querySelectorAll('elx-menubar-menu').forEach(el => {
-      menus.push(el as ElxMenubarMenu);
-    });
+    // Only direct children
+    for (let i = 0; i < this.children.length; i++) {
+      const child = this.children[i];
+      if (child.tagName === 'ELX-MENUBAR-MENU') {
+        menus.push(child as ElxMenubarMenu);
+      }
+    }
     return menus;
   }
 
@@ -218,21 +220,33 @@ export class ElxMenubar extends HTMLElement {
       e.preventDefault();
       const wasOpen = menus[activeIndex].open;
       this._closeAll();
-      const next = (activeIndex + 1) % menus.length;
+      // Skip disabled menus
+      let next = (activeIndex + 1) % menus.length;
+      let count = 0;
+      while (menus[next].disabled && count < menus.length) {
+        next = (next + 1) % menus.length;
+        count++;
+      }
       menus[next].focusTrigger();
-      if (wasOpen) menus[next].show();
+      if (wasOpen && !menus[next].disabled) menus[next].show();
     } else if (e.key === 'ArrowLeft') {
       e.preventDefault();
       const wasOpen = menus[activeIndex].open;
       this._closeAll();
-      const prev = (activeIndex - 1 + menus.length) % menus.length;
+      // Skip disabled menus
+      let prev = (activeIndex - 1 + menus.length) % menus.length;
+      let count = 0;
+      while (menus[prev].disabled && count < menus.length) {
+        prev = (prev - 1 + menus.length) % menus.length;
+        count++;
+      }
       menus[prev].focusTrigger();
-      if (wasOpen) menus[prev].show();
-    } else if (e.key === 'Escape') {
+      if (wasOpen && !menus[prev].disabled) menus[prev].show();
+    } else if (e.key === 'Escape' || e.key === 'Tab') {
       e.preventDefault();
       const wasOpen = menus[activeIndex].open;
       this._closeAll();
-      if (wasOpen) menus[activeIndex].focusTrigger();
+      if (wasOpen && e.key === 'Escape') menus[activeIndex].focusTrigger();
     }
   }
 
@@ -269,10 +283,12 @@ export class ElxMenubarMenu extends HTMLElement {
 
   private _rendered = false;
   private _triggerEl: HTMLElement | null = null;
+  private _onMenuKeydown: (e: KeyboardEvent) => void;
 
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
+    this._onMenuKeydown = (e: KeyboardEvent) => this._handleMenuKeydown(e);
   }
 
   connectedCallback() {
@@ -281,6 +297,12 @@ export class ElxMenubarMenu extends HTMLElement {
       this._rendered = true;
     }
     this._update();
+    // Attach keydown listener to host (not shadow div) to catch events from slotted items
+    this.addEventListener('keydown', this._onMenuKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('keydown', this._onMenuKeydown);
   }
 
   attributeChangedCallback() {
@@ -331,8 +353,7 @@ export class ElxMenubarMenu extends HTMLElement {
   private _focusFirstItem() {
     const items = this._getItems();
     if (items.length > 0) {
-      const inner = items[0].shadowRoot?.querySelector('.item') as HTMLElement;
-      inner?.focus();
+      items[0].focus();
     }
   }
 
@@ -362,22 +383,22 @@ export class ElxMenubarMenu extends HTMLElement {
         // Focus last item
         const items = this._getItems();
         if (items.length > 0) {
-          const inner = items[items.length - 1].shadowRoot?.querySelector('.item') as HTMLElement;
-          inner?.focus();
+          items[items.length - 1].focus();
         }
       }
     }
   };
 
-  private _onMenuKeydown = (e: KeyboardEvent) => {
+  private _handleMenuKeydown(e: KeyboardEvent) {
     if (!this.open) return;
     const items = this._getItems();
     if (items.length === 0) return;
 
+    // Find current item by checking if it or its shadow contains activeElement
     const active = document.activeElement as HTMLElement;
     let currentIndex = -1;
     for (let i = 0; i < items.length; i++) {
-      if (items[i].shadowRoot?.contains(active)) {
+      if (items[i] === active || items[i].shadowRoot?.contains(active)) {
         currentIndex = i;
         break;
       }
@@ -386,23 +407,19 @@ export class ElxMenubarMenu extends HTMLElement {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       const next = currentIndex < items.length - 1 ? currentIndex + 1 : 0;
-      const inner = items[next].shadowRoot?.querySelector('.item') as HTMLElement;
-      inner?.focus();
+      items[next].focus();
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       const prev = currentIndex > 0 ? currentIndex - 1 : items.length - 1;
-      const inner = items[prev].shadowRoot?.querySelector('.item') as HTMLElement;
-      inner?.focus();
+      items[prev].focus();
     } else if (e.key === 'Home') {
       e.preventDefault();
-      const inner = items[0].shadowRoot?.querySelector('.item') as HTMLElement;
-      inner?.focus();
+      items[0].focus();
     } else if (e.key === 'End') {
       e.preventDefault();
-      const inner = items[items.length - 1].shadowRoot?.querySelector('.item') as HTMLElement;
-      inner?.focus();
+      items[items.length - 1].focus();
     }
-  };
+  }
 
   private _buildDom() {
     const style = document.createElement('style');
@@ -429,7 +446,6 @@ export class ElxMenubarMenu extends HTMLElement {
 
     trigger.addEventListener('click', this._onTriggerClick);
     trigger.addEventListener('keydown', this._onTriggerKeydown);
-    menu.addEventListener('keydown', this._onMenuKeydown);
 
     this.shadowRoot!.appendChild(style);
     this.shadowRoot!.appendChild(trigger);
@@ -441,7 +457,12 @@ export class ElxMenubarMenu extends HTMLElement {
     const menu = this.shadowRoot?.querySelector('.menu');
     if (trigger) {
       trigger.setAttribute('aria-expanded', String(this.open));
-      trigger.setAttribute('aria-label', this.label);
+      // Only set aria-label if label attribute is present (otherwise slotted content provides name)
+      if (this.label) {
+        trigger.setAttribute('aria-label', this.label);
+      } else {
+        trigger.removeAttribute('aria-label');
+      }
       if (this.disabled) {
         trigger.setAttribute('disabled', '');
       } else {
@@ -472,8 +493,10 @@ export class ElxMenubarItem extends HTMLElement {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'menuitem');
     }
+    // Use tabindex="-1" by default (roving tabindex pattern)
+    // The parent menu will call focus() on the host element
     if (!this.hasAttribute('tabindex')) {
-      this.setAttribute('tabindex', this.hasAttribute('disabled') ? '-1' : '0');
+      this.setAttribute('tabindex', '-1');
     }
     if (this.hasAttribute('disabled')) {
       this.setAttribute('aria-disabled', 'true');
@@ -497,20 +520,26 @@ export class ElxMenubarItem extends HTMLElement {
       this.setAttribute('tabindex', '-1');
     } else {
       this.removeAttribute('disabled');
-      this.setAttribute('tabindex', '0');
+      this.setAttribute('tabindex', '-1');
     }
   }
 
   attributeChangedCallback(_name: string, oldVal: string | null, newVal: string | null) {
     if (oldVal === newVal) return;
     if (_name === 'disabled') {
-      this.setAttribute('tabindex', newVal !== null ? '-1' : '0');
+      this.setAttribute('tabindex', '-1');
       if (newVal !== null) {
         this.setAttribute('aria-disabled', 'true');
       } else {
         this.removeAttribute('aria-disabled');
       }
     }
+  }
+
+  focus() {
+    // When focused, update tabindex for roving pattern
+    this.setAttribute('tabindex', '0');
+    super.focus();
   }
 
   private _handleClick = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,3 +42,4 @@ export * from './components/aspect-ratio/aspect-ratio';
 export * from './components/hover-card/hover-card';
 export * from './components/navigation-menu/navigation-menu';
 export * from './components/context-menu/context-menu';
+export * from './components/menubar/menubar';


### PR DESCRIPTION
Closes #56

## Changes
- **elx-menubar** — horizontal menu bar container with menubar role
- **elx-menubar-menu** — dropdown menu with trigger button, opens on click/Enter/Space/ArrowDown
- **elx-menubar-item** — menu item with prefix/suffix slots, keyboard activation
- **elx-menubar-separator** — visual separator between groups

## Features
- Horizontal ArrowLeft/ArrowRight navigation between menus (with wrapping)
- Vertical ArrowUp/ArrowDown/Home/End navigation within open menus
- Enter/Space to activate items, Escape to close
- Click-outside to dismiss (composedPath for shadow DOM)
- Disabled menus and items with proper ARIA
- Part attributes for external styling (base, trigger, menu, base)
- CSS custom properties with `--elx-menubar-` prefix
- `closeAll()` public API

## Tests
- 44 tests covering rendering, ARIA, keyboard nav, events, disabled state, wrapping, reconnection
- Full suite: 833/833 passing