### PR TITLE
feat: add DataList component

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "44 kB",
+      "limit": "45 kB",
       "gzip": true
     },
     {

--- a/src/components/datalist/datalist.stories.ts
+++ b/src/components/datalist/datalist.stories.ts
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './datalist.js';
+
+const meta: Meta = {
+  title: 'Components/DataList',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'A filterable list component for selecting items from a dataset.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+const fruits = [
+  { id: 'apple', label: 'Apple', description: 'Red or green fruit', group: 'Fruits' },
+  { id: 'banana', label: 'Banana', description: 'Yellow tropical fruit', group: 'Fruits' },
+  { id: 'cherry', label: 'Cherry', description: 'Small red fruit', group: 'Fruits' },
+  { id: 'mango', label: 'Mango', description: 'Sweet tropical fruit', group: 'Fruits' },
+  { id: 'carrot', label: 'Carrot', description: 'Orange root vegetable', group: 'Vegetables' },
+  { id: 'broccoli', label: 'Broccoli', description: 'Green cruciferous vegetable', group: 'Vegetables' },
+  { id: 'spinach', label: 'Spinach', description: 'Leafy green vegetable', group: 'Vegetables' },
+];
+
+export const Default: Story = {
+  render: () => {
+    const setup = () => {
+      const el = document.querySelector('#default-dl') as any;
+      if (el) {
+        el.items = fruits;
+        el.addEventListener('elx-datalist-select', (e: CustomEvent) => {
+          console.log('Selected:', e.detail);
+        });
+      }
+    };
+    setTimeout(setup, 0);
+    return html`
+      <div style="max-width: 400px;">
+        <elx-datalist id="default-dl" label="Select a food"></elx-datalist>
+      </div>
+    `;
+  },
+};
+
+export const WithCustomPlaceholder: Story = {
+  render: () => {
+    const setup = () => {
+      const el = document.querySelector('#placeholder-dl') as any;
+      if (el) el.items = fruits;
+    };
+    setTimeout(setup, 0);
+    return html`
+      <div style="max-width: 400px;">
+        <elx-datalist id="placeholder-dl" placeholder="Search foods..." label="Select a food"></elx-datalist>
+      </div>
+    `;
+  },
+};
+
+export const SimpleList: Story = {
+  render: () => {
+    const countries = [
+      { id: 'us', label: 'United States' },
+      { id: 'uk', label: 'United Kingdom' },
+      { id: 'ca', label: 'Canada' },
+      { id: 'au', label: 'Australia' },
+      { id: 'de', label: 'Germany' },
+      { id: 'fr', label: 'France' },
+      { id: 'jp', label: 'Japan' },
+    ];
+    const setup = () => {
+      const el = document.querySelector('#simple-dl') as any;
+      if (el) el.items = countries;
+    };
+    setTimeout(setup, 0);
+    return html`
+      <div style="max-width: 400px;">
+        <elx-datalist id="simple-dl" label="Select a country" placeholder="Search countries..."></elx-datalist>
+      </div>
+    `;
+  },
+};

--- a/src/components/datalist/datalist.test.ts
+++ b/src/components/datalist/datalist.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import './datalist';
+import type { DataListItem } from './datalist';
+
+const sampleItems: DataListItem[] = [
+  { id: 'apple', label: 'Apple', description: 'Red fruit', group: 'Fruits' },
+  { id: 'banana', label: 'Banana', description: 'Yellow fruit', group: 'Fruits' },
+  { id: 'cherry', label: 'Cherry', description: 'Small red fruit', group: 'Fruits' },
+  { id: 'carrot', label: 'Carrot', description: 'Orange vegetable', group: 'Vegetables' },
+  { id: 'broccoli', label: 'Broccoli', description: 'Green vegetable', group: 'Vegetables' },
+  { id: 'spinach', label: 'Spinach', group: 'Vegetables' },
+  { id: 'disabled-item', label: 'Disabled', disabled: true, group: 'Other' },
+];
+
+function createDataList(items: DataListItem[] = sampleItems): HTMLElement {
+  const el = document.createElement('elx-datalist') as any;
+  el.items = items;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('elx-datalist', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('registration', () => {
+    it('should be defined as a custom element', () => {
+      expect(customElements.get('elx-datalist')).toBeDefined();
+    });
+
+    it('should create an instance', () => {
+      const el = createDataList();
+      expect(el).toBeInstanceOf(HTMLElement);
+    });
+  });
+
+  describe('items', () => {
+    it('should render all non-disabled items', () => {
+      const el = createDataList() as any;
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items.length).toBe(6);
+    });
+
+    it('should render group labels', () => {
+      const el = createDataList() as any;
+      const groups = el.shadowRoot.querySelectorAll('.group-label');
+      expect(groups.length).toBe(2);
+      expect(groups[0].textContent).toBe('Fruits');
+      expect(groups[1].textContent).toBe('Vegetables');
+    });
+
+    it('should render descriptions', () => {
+      const el = createDataList() as any;
+      const descs = el.shadowRoot.querySelectorAll('.list-item-description');
+      expect(descs.length).toBe(5);
+    });
+
+    it('should update items dynamically', () => {
+      const el = createDataList([]) as any;
+      expect(el.shadowRoot.querySelector('.empty-state')).not.toBeNull();
+      el.items = sampleItems;
+      expect(el.shadowRoot.querySelectorAll('.list-item').length).toBe(6);
+    });
+  });
+
+  describe('filtering', () => {
+    it('should filter items by label', () => {
+      const el = createDataList() as any;
+      const input = el.shadowRoot.querySelector('.search-input') as HTMLInputElement;
+      input.value = 'apple';
+      input.dispatchEvent(new Event('input'));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items.length).toBe(1);
+    });
+
+    it('should filter items by description', () => {
+      const el = createDataList() as any;
+      const input = el.shadowRoot.querySelector('.search-input') as HTMLInputElement;
+      input.value = 'orange';
+      input.dispatchEvent(new Event('input'));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items.length).toBe(1);
+      expect(items[0].querySelector('.list-item-label').textContent).toBe('Carrot');
+    });
+
+    it('should filter items by group', () => {
+      const el = createDataList() as any;
+      const input = el.shadowRoot.querySelector('.search-input') as HTMLInputElement;
+      input.value = 'fruit';
+      input.dispatchEvent(new Event('input'));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items.length).toBe(3);
+    });
+
+    it('should be case insensitive', () => {
+      const el = createDataList() as any;
+      const input = el.shadowRoot.querySelector('.search-input') as HTMLInputElement;
+      input.value = 'BANANA';
+      input.dispatchEvent(new Event('input'));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items.length).toBe(1);
+    });
+
+    it('should show empty state when no matches', () => {
+      const el = createDataList() as any;
+      const input = el.shadowRoot.querySelector('.search-input') as HTMLInputElement;
+      input.value = 'xyznonexistent';
+      input.dispatchEvent(new Event('input'));
+      expect(el.shadowRoot.querySelector('.empty-state')).not.toBeNull();
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('should have no selection by default', () => {
+      const el = createDataList() as any;
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[0].classList.contains('active')).toBe(false);
+    });
+
+    it('should select first item on ArrowDown', () => {
+      const el = createDataList() as any;
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[0].classList.contains('active')).toBe(true);
+    });
+
+    it('should move down with ArrowDown', () => {
+      const el = createDataList() as any;
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[1].classList.contains('active')).toBe(true);
+    });
+
+    it('should move up with ArrowUp', () => {
+      const el = createDataList() as any;
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[0].classList.contains('active')).toBe(true);
+    });
+
+    it('should not go above first item', () => {
+      const el = createDataList() as any;
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[0].classList.contains('active')).toBe(false);
+    });
+
+    it('should not go below last item', () => {
+      const el = createDataList() as any;
+      el.focus();
+      for (let i = 0; i < 20; i++) {
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      }
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[items.length - 1].classList.contains('active')).toBe(true);
+    });
+
+    it('should dispatch change event on arrow', () => {
+      const el = createDataList() as any;
+      const spy = vi.fn();
+      el.addEventListener('elx-datalist-change', spy);
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0].detail.id).toBe('apple');
+    });
+
+    it('should dispatch select event on Enter', () => {
+      const el = createDataList() as any;
+      const spy = vi.fn();
+      el.addEventListener('elx-datalist-select', spy);
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0].detail.id).toBe('apple');
+    });
+  });
+
+  describe('mouse interaction', () => {
+    it('should select item on click', () => {
+      const el = createDataList() as any;
+      const spy = vi.fn();
+      el.addEventListener('elx-datalist-select', spy);
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      items[2].click();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0].detail.id).toBe('cherry');
+    });
+  });
+
+  describe('selectedItem and value', () => {
+    it('should return null when nothing selected', () => {
+      const el = createDataList() as any;
+      expect(el.selectedItem).toBeNull();
+      expect(el.value).toBe('');
+    });
+
+    it('should return selected item after keyboard navigation', () => {
+      const el = createDataList() as any;
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      expect(el.selectedItem).not.toBeNull();
+      expect(el.selectedItem.id).toBe('apple');
+      expect(el.value).toBe('apple');
+    });
+  });
+
+  describe('placeholder', () => {
+    it('should use default placeholder', () => {
+      const el = createDataList() as any;
+      const input = el.shadowRoot.querySelector('.search-input') as HTMLInputElement;
+      expect(input.placeholder).toBe('Filter...');
+    });
+
+    it('should use custom placeholder', () => {
+      const el = document.createElement('elx-datalist') as any;
+      el.setAttribute('placeholder', 'Search items...');
+      el.items = sampleItems;
+      document.body.appendChild(el);
+      const input = el.shadowRoot.querySelector('.search-input') as HTMLInputElement;
+      expect(input.placeholder).toBe('Search items...');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have listbox role', () => {
+      const el = createDataList() as any;
+      const container = el.shadowRoot.querySelector('.container');
+      expect(container.getAttribute('role')).toBe('listbox');
+    });
+
+    it('should have aria-label when label attribute set', () => {
+      const el = document.createElement('elx-datalist') as any;
+      el.setAttribute('label', 'Select a fruit');
+      el.items = sampleItems;
+      document.body.appendChild(el);
+      const container = el.shadowRoot.querySelector('.container');
+      expect(container.getAttribute('aria-label')).toBe('Select a fruit');
+    });
+
+    it('should have option role on items', () => {
+      const el = createDataList() as any;
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[0].getAttribute('role')).toBe('option');
+    });
+
+    it('should have aria-selected on active item', () => {
+      const el = createDataList() as any;
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[0].getAttribute('aria-selected')).toBe('true');
+      expect(items[1].getAttribute('aria-selected')).toBe('false');
+    });
+  });
+
+  describe('part attributes', () => {
+    it('should have part on container', () => {
+      const el = createDataList() as any;
+      const container = el.shadowRoot.querySelector('.container');
+      expect(container.getAttribute('part')).toBe('container');
+    });
+
+    it('should have part on list', () => {
+      const el = createDataList() as any;
+      const list = el.shadowRoot.querySelector('.list');
+      expect(list.getAttribute('part')).toBe('list');
+    });
+  });
+
+  describe('reconnection', () => {
+    it('should not duplicate DOM on reconnect', () => {
+      const el = createDataList() as any;
+      el.remove();
+      document.body.appendChild(el);
+      const containers = el.shadowRoot.querySelectorAll('.container');
+      expect(containers.length).toBe(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty items', () => {
+      const el = createDataList([]) as any;
+      expect(el.shadowRoot.querySelector('.empty-state')).not.toBeNull();
+    });
+
+    it('should handle Enter with no selection', () => {
+      const el = createDataList() as any;
+      const spy = vi.fn();
+      el.addEventListener('elx-datalist-select', spy);
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/datalist/datalist.test.ts
+++ b/src/components/datalist/datalist.test.ts
@@ -36,18 +36,19 @@ describe('elx-datalist', () => {
   });
 
   describe('items', () => {
-    it('should render all non-disabled items', () => {
+    it('should render all items including disabled', () => {
       const el = createDataList() as any;
       const items = el.shadowRoot.querySelectorAll('.list-item');
-      expect(items.length).toBe(6);
+      expect(items.length).toBe(7);
     });
 
     it('should render group labels', () => {
       const el = createDataList() as any;
       const groups = el.shadowRoot.querySelectorAll('.group-label');
-      expect(groups.length).toBe(2);
+      expect(groups.length).toBe(3);
       expect(groups[0].textContent).toBe('Fruits');
       expect(groups[1].textContent).toBe('Vegetables');
+      expect(groups[2].textContent).toBe('Other');
     });
 
     it('should render descriptions', () => {
@@ -60,7 +61,7 @@ describe('elx-datalist', () => {
       const el = createDataList([]) as any;
       expect(el.shadowRoot.querySelector('.empty-state')).not.toBeNull();
       el.items = sampleItems;
-      expect(el.shadowRoot.querySelectorAll('.list-item').length).toBe(6);
+      expect(el.shadowRoot.querySelectorAll('.list-item').length).toBe(7);
     });
   });
 
@@ -183,6 +184,33 @@ describe('elx-datalist', () => {
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy.mock.calls[0][0].detail.id).toBe('apple');
     });
+
+    it('should clear selection on Escape', () => {
+      const el = createDataList() as any;
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[0].classList.contains('active')).toBe(false);
+    });
+
+    it('should jump to first item on Home', () => {
+      const el = createDataList() as any;
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[0].classList.contains('active')).toBe(true);
+    });
+
+    it('should jump to last item on End', () => {
+      const el = createDataList() as any;
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(items[items.length - 1].classList.contains('active')).toBe(true);
+    });
   });
 
   describe('mouse interaction', () => {
@@ -260,6 +288,37 @@ describe('elx-datalist', () => {
       const items = el.shadowRoot.querySelectorAll('.list-item');
       expect(items[0].getAttribute('aria-selected')).toBe('true');
       expect(items[1].getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('should have aria-disabled on disabled items', () => {
+      const el = createDataList() as any;
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      let disabledItem: any = null;
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].textContent.indexOf('Disabled') !== -1) {
+          disabledItem = items[i];
+          break;
+        }
+      }
+      expect(disabledItem?.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('should update aria-activedescendant on keyboard nav', () => {
+      const el = createDataList() as any;
+      const container = el.shadowRoot.querySelector('.container');
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      const items = el.shadowRoot.querySelectorAll('.list-item');
+      expect(container.getAttribute('aria-activedescendant')).toBe(items[0].id);
+    });
+
+    it('should remove aria-activedescendant on Escape', () => {
+      const el = createDataList() as any;
+      const container = el.shadowRoot.querySelector('.container');
+      el.focus();
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(container.getAttribute('aria-activedescendant')).toBeNull();
     });
   });
 

--- a/src/components/datalist/datalist.ts
+++ b/src/components/datalist/datalist.ts
@@ -195,6 +195,7 @@ export class ElxDataList extends HTMLElement {
     container.setAttribute('part', 'container');
     container.className = 'container';
     container.setAttribute('role', 'listbox');
+    container.setAttribute('tabindex', '0');
     const lbl = this.getAttribute('label');
     if (lbl) {
       container.setAttribute('aria-label', lbl);
@@ -241,22 +242,22 @@ export class ElxDataList extends HTMLElement {
   }
 
   private _filterItems() {
-    const base: DataListItem[] = [];
-    for (let i = 0; i < this._items.length; i++) {
-      if (!this._items[i].disabled) {
-        base.push(this._items[i]);
-      }
-    }
     if (!this._searchValue) {
-      this._filteredItems = base;
+      this._filteredItems = this._items.slice();
     } else {
       const query = this._searchValue.toLowerCase();
-      this._filteredItems = base.filter(
-        (item) =>
+      const result: DataListItem[] = [];
+      for (let i = 0; i < this._items.length; i++) {
+        const item = this._items[i];
+        if (
           item.label.toLowerCase().indexOf(query) !== -1 ||
           (item.description && item.description.toLowerCase().indexOf(query) !== -1) ||
           (item.group && item.group.toLowerCase().indexOf(query) !== -1)
-      );
+        ) {
+          result.push(item);
+        }
+      }
+      this._filteredItems = result;
     }
   }
 
@@ -296,7 +297,13 @@ export class ElxDataList extends HTMLElement {
       }
       li.setAttribute('role', 'option');
       li.setAttribute('aria-selected', String(isActive));
-      li.addEventListener('click', () => this._selectItem(i));
+      if (item.disabled) {
+        li.classList.add('disabled');
+        li.setAttribute('aria-disabled', 'true');
+      }
+      if (!item.disabled) {
+        li.addEventListener('click', () => this._selectItem(i));
+      }
 
       const label = document.createElement('span');
       label.className = 'list-item-label';
@@ -318,6 +325,14 @@ export class ElxDataList extends HTMLElement {
     if (activeLi && activeLi.scrollIntoView) {
       activeLi.scrollIntoView({ block: 'nearest' });
     }
+
+    // Update aria-activedescendant
+    const container = this.shadowRoot?.querySelector('.container');
+    if (activeLi) {
+      container?.setAttribute('aria-activedescendant', activeLi.id);
+    } else {
+      container?.removeAttribute('aria-activedescendant');
+    }
   }
 
   private _handleKeydown(e: KeyboardEvent) {
@@ -337,6 +352,24 @@ export class ElxDataList extends HTMLElement {
       e.preventDefault();
       if (this._selectedIndex >= 0) {
         this._selectItem(this._selectedIndex);
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      this._selectedIndex = -1;
+      this._updateList();
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      if (this._filteredItems.length > 0) {
+        this._selectedIndex = 0;
+        this._updateList();
+        this._emitChange();
+      }
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      if (this._filteredItems.length > 0) {
+        this._selectedIndex = this._filteredItems.length - 1;
+        this._updateList();
+        this._emitChange();
       }
     }
   }

--- a/src/components/datalist/datalist.ts
+++ b/src/components/datalist/datalist.ts
@@ -1,0 +1,376 @@
+const dataListStyles = `
+  :host {
+    --elx-datalist-bg: var(--elx-color-surface, #ffffff);
+    --elx-datalist-border: var(--elx-color-border, #e2e8f0);
+    --elx-datalist-radius: var(--elx-radius-md, 0.375rem);
+    --elx-datalist-text: var(--elx-color-text, #1e293b);
+    --elx-datalist-text-muted: var(--elx-color-text-muted, #64748b);
+    --elx-datalist-hover-bg: var(--elx-color-neutral-100, #f1f5f9);
+    --elx-datalist-active-bg: var(--elx-color-primary, #3b82f6);
+    --elx-datalist-active-text: #ffffff;
+    display: block;
+  }
+
+  .container {
+    background: var(--elx-datalist-bg);
+    border: 1px solid var(--elx-datalist-border);
+    border-radius: var(--elx-datalist-radius);
+    overflow: hidden;
+    font-family: var(--elx-font-family-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  }
+
+  .search-box {
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--elx-datalist-border);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .search-icon {
+    color: var(--elx-datalist-text-muted);
+    font-size: 14px;
+  }
+
+  .search-input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: 14px;
+    color: var(--elx-datalist-text);
+    font-family: inherit;
+    padding: 4px 0;
+  }
+
+  .search-input::placeholder {
+    color: var(--elx-datalist-text-muted);
+  }
+
+  .list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 300px;
+    overflow-y: auto;
+  }
+
+  .list-item {
+    padding: 8px 12px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--elx-datalist-text);
+    font-size: 14px;
+    transition: background-color 0.15s ease;
+  }
+
+  .list-item:hover {
+    background-color: var(--elx-datalist-hover-bg);
+  }
+
+  .list-item.active {
+    background-color: var(--elx-datalist-active-bg);
+    color: var(--elx-datalist-active-text);
+  }
+
+  .list-item.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .list-item-label {
+    flex: 1;
+  }
+
+  .list-item-description {
+    font-size: 12px;
+    color: var(--elx-datalist-text-muted);
+  }
+
+  .list-item.active .list-item-description {
+    color: inherit;
+    opacity: 0.8;
+  }
+
+  .empty-state {
+    padding: 24px 12px;
+    text-align: center;
+    color: var(--elx-datalist-text-muted);
+    font-size: 14px;
+  }
+
+  .group-label {
+    padding: 8px 12px 4px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--elx-datalist-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+`;
+
+export interface DataListItem {
+  id: string;
+  label: string;
+  description?: string;
+  group?: string;
+  disabled?: boolean;
+}
+
+export class ElxDataList extends HTMLElement {
+  static observedAttributes = ['placeholder', 'label'];
+
+  private _items: DataListItem[] = [];
+  private _filteredItems: DataListItem[] = [];
+  private _selectedIndex = -1;
+  private _searchValue = '';
+  private _searchInput: HTMLInputElement | null = null;
+  private _listElement: HTMLUListElement | null = null;
+  private _onKeydown: (e: KeyboardEvent) => void;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this._onKeydown = this._handleKeydown.bind(this);
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot!.firstChild) {
+      this._buildDom();
+    }
+    this._filterItems();
+    this._updateList();
+    this.addEventListener('keydown', this._onKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('keydown', this._onKeydown);
+  }
+
+  attributeChangedCallback() {
+    if (this._searchInput) {
+      this._searchInput.placeholder = this.getAttribute('placeholder') || 'Filter...';
+    }
+    const container = this.shadowRoot?.querySelector('.container');
+    if (container) {
+      const lbl = this.getAttribute('label');
+      if (lbl) {
+        container.setAttribute('aria-label', lbl);
+      } else {
+        container.removeAttribute('aria-label');
+      }
+    }
+  }
+
+  get items(): DataListItem[] {
+    return this._items;
+  }
+
+  set items(val: DataListItem[]) {
+    this._items = val;
+    this._selectedIndex = -1;
+    this._filterItems();
+    this._updateList();
+  }
+
+  get selectedItem(): DataListItem | null {
+    if (this._selectedIndex >= 0 && this._selectedIndex < this._filteredItems.length) {
+      return this._filteredItems[this._selectedIndex];
+    }
+    return null;
+  }
+
+  get value(): string {
+    const item = this.selectedItem;
+    return item ? item.id : '';
+  }
+
+  private _buildDom() {
+    const style = document.createElement('style');
+    style.textContent = dataListStyles;
+
+    const container = document.createElement('div');
+    container.setAttribute('part', 'container');
+    container.className = 'container';
+    container.setAttribute('role', 'listbox');
+    const lbl = this.getAttribute('label');
+    if (lbl) {
+      container.setAttribute('aria-label', lbl);
+    }
+
+    const searchBox = document.createElement('div');
+    searchBox.setAttribute('part', 'search');
+    searchBox.className = 'search-box';
+
+    const searchIcon = document.createElement('span');
+    searchIcon.className = 'search-icon';
+    searchIcon.textContent = '🔍';
+    searchIcon.setAttribute('aria-hidden', 'true');
+
+    const searchInput = document.createElement('input');
+    searchInput.className = 'search-input';
+    searchInput.type = 'text';
+    searchInput.placeholder = this.getAttribute('placeholder') || 'Filter...';
+    searchInput.setAttribute('aria-label', 'Filter list');
+    searchInput.addEventListener('input', (e) => {
+      this._searchValue = (e.target as HTMLInputElement).value;
+      this._selectedIndex = -1;
+      this._filterItems();
+      this._updateList();
+    });
+
+    this._searchInput = searchInput;
+
+    searchBox.appendChild(searchIcon);
+    searchBox.appendChild(searchInput);
+
+    const list = document.createElement('ul');
+    list.setAttribute('part', 'list');
+    list.className = 'list';
+    list.setAttribute('role', 'presentation');
+
+    this._listElement = list;
+
+    container.appendChild(searchBox);
+    container.appendChild(list);
+
+    this.shadowRoot!.appendChild(style);
+    this.shadowRoot!.appendChild(container);
+  }
+
+  private _filterItems() {
+    const base: DataListItem[] = [];
+    for (let i = 0; i < this._items.length; i++) {
+      if (!this._items[i].disabled) {
+        base.push(this._items[i]);
+      }
+    }
+    if (!this._searchValue) {
+      this._filteredItems = base;
+    } else {
+      const query = this._searchValue.toLowerCase();
+      this._filteredItems = base.filter(
+        (item) =>
+          item.label.toLowerCase().indexOf(query) !== -1 ||
+          (item.description && item.description.toLowerCase().indexOf(query) !== -1) ||
+          (item.group && item.group.toLowerCase().indexOf(query) !== -1)
+      );
+    }
+  }
+
+  private _updateList() {
+    if (!this._listElement) return;
+
+    this._listElement.innerHTML = '';
+
+    if (this._filteredItems.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No items found';
+      this._listElement.appendChild(empty);
+      return;
+    }
+
+    let currentGroup = '';
+
+    for (let i = 0; i < this._filteredItems.length; i++) {
+      const item = this._filteredItems[i];
+
+      if (item.group && item.group !== currentGroup) {
+        currentGroup = item.group;
+        const groupLabel = document.createElement('div');
+        groupLabel.className = 'group-label';
+        groupLabel.setAttribute('aria-hidden', 'true');
+        groupLabel.textContent = currentGroup;
+        this._listElement.appendChild(groupLabel);
+      }
+
+      const li = document.createElement('li');
+      li.id = 'elx-dl-item-' + item.id;
+      li.className = 'list-item';
+      const isActive = i === this._selectedIndex;
+      if (isActive) {
+        li.classList.add('active');
+      }
+      li.setAttribute('role', 'option');
+      li.setAttribute('aria-selected', String(isActive));
+      li.addEventListener('click', () => this._selectItem(i));
+
+      const label = document.createElement('span');
+      label.className = 'list-item-label';
+      label.textContent = item.label;
+      li.appendChild(label);
+
+      if (item.description) {
+        const desc = document.createElement('span');
+        desc.className = 'list-item-description';
+        desc.textContent = item.description;
+        li.appendChild(desc);
+      }
+
+      this._listElement.appendChild(li);
+    }
+
+    // Scroll active item into view
+    const activeLi = this._listElement.querySelector('.list-item.active') as HTMLElement | null;
+    if (activeLi && activeLi.scrollIntoView) {
+      activeLi.scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  private _handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      this._selectedIndex = Math.min(this._selectedIndex + 1, this._filteredItems.length - 1);
+      this._updateList();
+      this._emitChange();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (this._selectedIndex > 0) {
+        this._selectedIndex = this._selectedIndex - 1;
+        this._updateList();
+        this._emitChange();
+      }
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (this._selectedIndex >= 0) {
+        this._selectItem(this._selectedIndex);
+      }
+    }
+  }
+
+  private _selectItem(index: number) {
+    const item = this._filteredItems[index];
+    if (!item || item.disabled) return;
+
+    this._selectedIndex = index;
+    this._updateList();
+
+    this.dispatchEvent(
+      new CustomEvent('elx-datalist-select', {
+        detail: { id: item.id, label: item.label },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _emitChange() {
+    const item = this.selectedItem;
+    if (item) {
+      this.dispatchEvent(
+        new CustomEvent('elx-datalist-change', {
+          detail: { id: item.id, label: item.label },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
+  }
+}
+
+if (!customElements.get('elx-datalist')) {
+  customElements.define('elx-datalist', ElxDataList);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,4 +43,5 @@ export * from './components/hover-card/hover-card';
 export * from './components/navigation-menu/navigation-menu';
 export * from './components/context-menu/context-menu';
 export * from './components/menubar/menubar';
+export * from './components/datalist/datalist';
 export * from './components/command-palette/command-palette';


### PR DESCRIPTION
Closes #58

## Changes
- **elx-datalist** — filterable list with search input, keyboard navigation, grouping, and empty state
- Supports items with label, description, group, and disabled state
- Arrow key navigation with roving selection, Enter to select
- Filters by label, description, and group (case-insensitive)
- Part attributes: `container`, `search`, `list`
- ARIA: `listbox` role, `option` role on items, `aria-selected`, `aria-label`
- 33 tests covering registration, filtering, keyboard nav, mouse interaction, accessibility, parts, reconnection

## Test Results
924/924 tests passing